### PR TITLE
Add NoName controlled output review trace

### DIFF
--- a/docs/architecture/noname-safe-output-interface-v1.md
+++ b/docs/architecture/noname-safe-output-interface-v1.md
@@ -60,6 +60,8 @@
 3. 返回 `Allow / Reject / NeedsReview`。
 4. V1 不直接执行 apply，只作为后续接入前的安全门面。
 
+当前 V2 切片已把 review 结果接入 `NoNameRuntime` trace：`assisted` 预检通过后会记录每个 apply scope 的 controlled output review，其中 `PlotTextHint` 仍保持 `NeedsReview`，不会自动接管最终剧情正文。
+
 ## V1 决策规则
 
 - 空 request id、空 title、空 content 会被拒绝。
@@ -90,6 +92,6 @@
 
 下一步可以继续:
 
-1. 在 `NoNameRuntime` trace 中记录 controlled output review，但仍不自动 apply。
-2. 把 A3 的 `forbiddenScopes` 映射到本接口的 forbidden scopes。
-3. 为 `NeedsReview` 设计前端调试台入口，让开发者手动确认是否进入更高层 apply。
+1. 把 A3 的 `forbiddenScopes` 映射到本接口的 forbidden scopes。
+2. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
+3. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。

--- a/docs/architecture/noname-v1-task-list.md
+++ b/docs/architecture/noname-v1-task-list.md
@@ -469,13 +469,15 @@
 - runtime 已按 guardrail 结果标记 proposal 为 `observed / ready / blocked`
 - 诊断文本已输出 `proposal_status=...`
 - trace 已记录 apply preflight 结果
+- trace 已记录 controlled output review，能区分 `Allow / Reject / NeedsReview`
 - 前端调试文本已显示 apply preflight 与 proposal transition log
+- 前端调试台已展示 controlled output review，并支持复制当前 Trace 摘要
 - apply 阶段已补独立 guardrail 入口
 
 ### 当前边界
 
 - proposal 目前不会改写剧情正文与状态机，但已可写入章节摘要提示这类低风险输出
-- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出，但还不是最终剧情应用分支
+- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出；`plotTextHint` 会先进入 controlled output review，仍不直接接管最终剧情应用分支
 - 仍然保持“经典主链路优先，NoName 仅辅助”
 
 ### 下一步子任务

--- a/src-tauri/src/noname_runtime.rs
+++ b/src-tauri/src/noname_runtime.rs
@@ -7,6 +7,9 @@ use crate::noname_guardrails::{
     validate_director_observation, validate_director_proposal_for_apply,
     NoNameDirectorGuardrailInput, NoNameGuardrailResult,
 };
+use crate::noname_output_interface::{
+    NoNameControlledOutputDecision, NoNameControlledOutputInterface, NoNameControlledOutputKind,
+};
 use crate::noname_protocol_agent::{NoNameAgentMessage, NoNameAgentMessageKind};
 use crate::noname_protocol_runtime::NoNameProtocolRuntime;
 use crate::noname_protocol_types::{NoNameAgentAddress, NoNameProtocolHeader, NoNameTraceWritable};
@@ -312,7 +315,9 @@ impl NoNameRuntime {
                             proposal.labels.push("apply_preflight_ready".to_string());
                         }
                         if proposal.apply_scopes.is_empty()
-                            || proposal.apply_scopes.contains(&NoNameApplyScope::Diagnostics)
+                            || proposal
+                                .apply_scopes
+                                .contains(&NoNameApplyScope::Diagnostics)
                         {
                             if !proposal
                                 .labels
@@ -330,6 +335,28 @@ impl NoNameRuntime {
                                 "{}:preflight_ready:no_diagnostics_scope",
                                 proposal.proposal_id
                             ));
+                        }
+                        let (review_count, needs_review_count) =
+                            self.record_controlled_output_reviews(trace, &proposal);
+                        if review_count > 0 {
+                            trace.record_apply_execution(
+                                "runtime.controlled_output_review",
+                                "recorded",
+                                Some(format!(
+                                    "已记录{}条受控输出 review，其中{}条需要人工复核",
+                                    review_count, needs_review_count
+                                )),
+                            );
+                        }
+                        if needs_review_count > 0
+                            && !proposal
+                                .labels
+                                .iter()
+                                .any(|item| item == "controlled_output_needs_review")
+                        {
+                            proposal
+                                .labels
+                                .push("controlled_output_needs_review".to_string());
                         }
                         trace.record_apply_execution(
                             "runtime.apply_preflight",
@@ -410,6 +437,56 @@ impl NoNameRuntime {
         proposal
     }
 
+    fn record_controlled_output_reviews(
+        &self,
+        trace: &mut NoNameTrace,
+        proposal: &NoNameProposal,
+    ) -> (usize, usize) {
+        let interface = NoNameControlledOutputInterface::default();
+        let scopes = if proposal.apply_scopes.is_empty() {
+            vec![NoNameApplyScope::Diagnostics]
+        } else {
+            proposal.apply_scopes.clone()
+        };
+        let mut review_count = 0;
+        let mut needs_review_count = 0;
+
+        for scope in scopes {
+            let kind = controlled_output_kind_for_scope(scope);
+            let mut request = interface.draft_stub(
+                kind,
+                proposal.producer_role,
+                proposal.title.clone(),
+                proposal.summary.clone(),
+            );
+            request.request_id = format!(
+                "controlled-output-{}-{}",
+                proposal.proposal_id,
+                scope.as_str()
+            );
+            request.proposal_ref = Some(proposal.to_ref());
+            request.target_scope = scope;
+            request
+                .labels
+                .push("runtime_assisted_preflight".to_string());
+
+            let review = interface.review(&request);
+            if review.decision == NoNameControlledOutputDecision::NeedsReview {
+                needs_review_count += 1;
+            }
+            trace.record_proposal_transition(format!(
+                "{}:controlled_output:{}:{}",
+                proposal.proposal_id,
+                scope.as_str(),
+                controlled_output_decision_key(review.decision)
+            ));
+            trace.record_controlled_output_review(kind, review);
+            review_count += 1;
+        }
+
+        (review_count, needs_review_count)
+    }
+
     fn run_protocol_observe_fan_out(
         &mut self,
         input: &NoNameTurnInput,
@@ -463,7 +540,9 @@ impl NoNameRuntime {
                     "targetRole": role.as_str(),
                 }),
             );
-            let queued = self.protocol_runtime.submit_agent_message(task_request.clone())?;
+            let queued = self
+                .protocol_runtime
+                .submit_agent_message(task_request.clone())?;
             task_request.record_on_trace(trace, queued.status.as_str());
 
             let delegation = NoNameAgentMessage::new(
@@ -544,16 +623,30 @@ impl NoNameRuntime {
                         "{}:fanout:{}:error:{}",
                         input.turn_id,
                         role.as_str(),
-                        error_message
-                            .payload["code"]
-                            .as_str()
-                            .unwrap_or("unknown")
+                        error_message.payload["code"].as_str().unwrap_or("unknown")
                     ));
                 }
             }
         }
 
         Ok(observations)
+    }
+}
+
+fn controlled_output_kind_for_scope(scope: NoNameApplyScope) -> NoNameControlledOutputKind {
+    match scope {
+        NoNameApplyScope::Diagnostics => NoNameControlledOutputKind::NarrativeNote,
+        NoNameApplyScope::ChapterSummaryHint => NoNameControlledOutputKind::RecapNote,
+        NoNameApplyScope::OptionBiasHint => NoNameControlledOutputKind::IntermediateNarrativeHint,
+        NoNameApplyScope::PlotTextHint => NoNameControlledOutputKind::SceneAugmentation,
+    }
+}
+
+fn controlled_output_decision_key(decision: NoNameControlledOutputDecision) -> &'static str {
+    match decision {
+        NoNameControlledOutputDecision::Allow => "allow",
+        NoNameControlledOutputDecision::Reject => "reject",
+        NoNameControlledOutputDecision::NeedsReview => "needs_review",
     }
 }
 
@@ -716,6 +809,7 @@ mod tests {
                 .map(|item| item.outcome.as_str()),
             Some("skipped_observe_only")
         );
+        assert!(result.trace.controlled_output_reviews.is_empty());
         assert!(matches!(
             result.guardrail_result.as_ref().map(|item| item.outcome),
             Some(NoNameGuardrailOutcome::Accept | NoNameGuardrailOutcome::Repair)
@@ -818,6 +912,17 @@ mod tests {
                 .map(|item| item.outcome.as_str()),
             Some("applied_diagnostics_note")
         );
+        assert_eq!(result.trace.controlled_output_reviews.len(), 4);
+        assert!(result.trace.controlled_output_reviews.iter().any(|item| {
+            item.decision == NoNameControlledOutputDecision::NeedsReview
+                && item.safe_apply_scope == Some(NoNameApplyScope::PlotTextHint)
+                && item.requires_human_review
+        }));
+        assert!(result
+            .trace
+            .proposal_transition_log
+            .iter()
+            .any(|item| item.contains("controlled_output:plot_text_hint:needs_review")));
         assert!(result
             .trace
             .graph_path
@@ -909,6 +1014,7 @@ mod tests {
                 .map(|item| item.outcome.as_str()),
             Some("preflight_blocked")
         );
+        assert!(result.trace.controlled_output_reviews.is_empty());
         assert!(result
             .trace
             .graph_path
@@ -959,6 +1065,7 @@ mod tests {
                 .map(|item| item.outcome.as_str()),
             Some("preflight_fallback_required")
         );
+        assert!(result.trace.controlled_output_reviews.is_empty());
         assert!(result
             .trace
             .graph_path

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -1,4 +1,9 @@
-use crate::noname_types::{NoNameMode, NoNameProposal, NoNameRole, NoNameTraceStage};
+use crate::noname_output_interface::{
+    NoNameControlledOutputDecision, NoNameControlledOutputKind, NoNameControlledOutputReview,
+};
+use crate::noname_types::{
+    NoNameApplyScope, NoNameMode, NoNameProposal, NoNameRole, NoNameTraceStage,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -44,6 +49,18 @@ pub struct NoNameApplyPlanRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct NoNameControlledOutputReviewRecord {
+    pub request_id: String,
+    pub requested_kind: NoNameControlledOutputKind,
+    pub decision: NoNameControlledOutputDecision,
+    pub reason: String,
+    pub normalized_kind: Option<NoNameControlledOutputKind>,
+    pub safe_apply_scope: Option<NoNameApplyScope>,
+    pub requires_human_review: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NoNameRelatedObservationRecord {
     pub role: NoNameRole,
     pub action_summary: String,
@@ -83,6 +100,8 @@ pub struct NoNameTrace {
     #[serde(default)]
     pub apply_execution_log: Vec<NoNameApplyExecutionRecord>,
     #[serde(default)]
+    pub controlled_output_reviews: Vec<NoNameControlledOutputReviewRecord>,
+    #[serde(default)]
     pub related_observations: Vec<NoNameRelatedObservationRecord>,
     #[serde(default)]
     pub protocol_events: Vec<NoNameProtocolEventRecord>,
@@ -110,6 +129,7 @@ impl NoNameTrace {
             proposal_transition_log: Vec::new(),
             apply_plan_log: Vec::new(),
             apply_execution_log: Vec::new(),
+            controlled_output_reviews: Vec::new(),
             related_observations: Vec::new(),
             protocol_events: Vec::new(),
             guardrail_result: None,
@@ -200,6 +220,23 @@ impl NoNameTrace {
             outcome: outcome.into(),
             note,
         });
+    }
+
+    pub fn record_controlled_output_review(
+        &mut self,
+        requested_kind: NoNameControlledOutputKind,
+        review: NoNameControlledOutputReview,
+    ) {
+        self.controlled_output_reviews
+            .push(NoNameControlledOutputReviewRecord {
+                request_id: review.request_id,
+                requested_kind,
+                decision: review.decision,
+                reason: review.reason,
+                normalized_kind: review.normalized_kind,
+                safe_apply_scope: review.safe_apply_scope,
+                requires_human_review: review.requires_human_review,
+            });
     }
 
     pub fn replace_related_observations(
@@ -398,5 +435,28 @@ mod tests {
             trace.apply_result.as_ref().map(|item| item.attempted),
             Some(true)
         );
+    }
+
+    #[test]
+    fn controlled_output_review_can_be_recorded() {
+        let mut trace = NoNameTrace::empty("trace-1", "session-1", "turn-1", NoNameMode::Assisted);
+        trace.record_controlled_output_review(
+            NoNameControlledOutputKind::SceneAugmentation,
+            NoNameControlledOutputReview {
+                request_id: "review-1".to_string(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "plot text hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::SceneAugmentation),
+                safe_apply_scope: Some(crate::noname_types::NoNameApplyScope::PlotTextHint),
+                requires_human_review: true,
+            },
+        );
+
+        assert_eq!(trace.controlled_output_reviews.len(), 1);
+        assert_eq!(
+            trace.controlled_output_reviews[0].decision,
+            NoNameControlledOutputDecision::NeedsReview
+        );
+        assert!(trace.controlled_output_reviews[0].requires_human_review);
     }
 }

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -192,10 +192,7 @@ fn target_segment_supports_apply_scope(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum NoNameApplyTargetDecision {
     Apply,
-    Skip {
-        outcome: &'static str,
-        note: String,
-    },
+    Skip { outcome: &'static str, note: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -320,7 +317,10 @@ fn plan_noname_apply_target(
                 };
             }
             let option_hint = build_noname_option_bias_hint(proposal);
-            let diagnostics = state.last_generation_diagnostics.as_deref().unwrap_or_default();
+            let diagnostics = state
+                .last_generation_diagnostics
+                .as_deref()
+                .unwrap_or_default();
             if diagnostics.contains(option_hint.as_str()) {
                 return NoNameApplyTargetPlan {
                     target,
@@ -353,8 +353,18 @@ fn build_noname_apply_plan_set(
     plot_text: Option<&str>,
 ) -> Vec<NoNameApplyTargetPlan> {
     let mut plans = vec![
-        plan_noname_apply_target(proposal, NoNameApplyScope::PlotTextHint, plot_state, plot_text),
-        plan_noname_apply_target(proposal, NoNameApplyScope::ChapterSummaryHint, plot_state, None),
+        plan_noname_apply_target(
+            proposal,
+            NoNameApplyScope::PlotTextHint,
+            plot_state,
+            plot_text,
+        ),
+        plan_noname_apply_target(
+            proposal,
+            NoNameApplyScope::ChapterSummaryHint,
+            plot_state,
+            None,
+        ),
         plan_noname_apply_target(proposal, NoNameApplyScope::OptionBiasHint, plot_state, None),
     ];
     plans.sort_by(|left, right| {
@@ -369,10 +379,7 @@ fn build_noname_apply_plan_set(
     plans
 }
 
-fn record_noname_apply_plan(
-    trace: &mut NoNameTrace,
-    plan: &NoNameApplyTargetPlan,
-) {
+fn record_noname_apply_plan(trace: &mut NoNameTrace, plan: &NoNameApplyTargetPlan) {
     let (decision, note) = match &plan.decision {
         NoNameApplyTargetDecision::Apply => (
             "apply",
@@ -6588,6 +6595,7 @@ mod tests {
                 proposal_transition_log: vec!["proposal-1:observed".to_string()],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -6646,6 +6654,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -6760,6 +6769,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -6841,6 +6851,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -6933,6 +6944,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -7044,6 +7056,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -7116,6 +7129,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -7175,8 +7189,9 @@ mod tests {
             .trace
             .apply_execution_log
             .iter()
-            .any(|item| item.target == "plot_text_hint"
-                && item.outcome == "skipped_target_mismatch"));
+            .any(
+                |item| item.target == "plot_text_hint" && item.outcome == "skipped_target_mismatch"
+            ));
     }
 
     #[test]
@@ -7216,6 +7231,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -7276,8 +7292,9 @@ mod tests {
             .trace
             .apply_execution_log
             .iter()
-            .any(|item| item.target == "chapter_summary_hint"
-                && item.outcome == "skipped_duplicate"));
+            .any(
+                |item| item.target == "chapter_summary_hint" && item.outcome == "skipped_duplicate"
+            ));
     }
 
     #[test]
@@ -7315,6 +7332,7 @@ mod tests {
                 proposal_transition_log: vec![],
                 apply_plan_log: vec![],
                 apply_execution_log: vec![],
+                controlled_output_reviews: vec![],
                 related_observations: vec![],
                 protocol_events: vec![],
                 guardrail_result: None,
@@ -7378,7 +7396,6 @@ mod tests {
             .trace
             .apply_execution_log
             .iter()
-            .any(|item| item.target == "option_bias_hint"
-                && item.outcome == "skipped_duplicate"));
+            .any(|item| item.target == "option_bias_hint" && item.outcome == "skipped_duplicate"));
     }
 }

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -179,6 +179,35 @@
         </ul>
       </section>
 
+      <section class="agent-trace-card">
+        <p class="agent-trace-card-title">
+          受控输出复核
+        </p>
+        <p
+          v-if="controlledOutputReviews.length === 0"
+          class="agent-trace-muted"
+        >
+          暂无受控输出复核记录
+        </p>
+        <ul
+          v-else
+          class="agent-trace-rows"
+        >
+          <li
+            v-for="review in controlledOutputReviews"
+            :key="review.requestId"
+            class="agent-trace-row"
+          >
+            <p class="agent-trace-main-line">
+              {{ review.requestedKind }} · {{ review.safeApplyScope || '无作用域' }} · {{ review.decision }}
+            </p>
+            <p class="agent-trace-muted">
+              {{ review.requiresHumanReview ? '需要人工复核' : '可自动通过' }} · {{ review.reason }}
+            </p>
+          </li>
+        </ul>
+      </section>
+
       <div class="agent-trace-grid">
         <section class="agent-trace-card">
           <p class="agent-trace-card-title">
@@ -298,6 +327,7 @@ const latestProposal = computed(() => {
 
 const relatedObservations = computed(() => props.trace?.relatedObservations ?? []);
 const protocolEvents = computed(() => props.trace?.protocolEvents ?? []);
+const controlledOutputReviews = computed(() => props.trace?.controlledOutputReviews ?? []);
 
 const guardrailLabel = computed(() => {
   const result = props.trace?.guardrailResult;

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -19,6 +19,14 @@
         </div>
         <div class="noname-debug-console-actions">
           <button
+            type="button"
+            class="noname-debug-console-btn"
+            :disabled="!selectedTraceReport"
+            @click="copySelectedTraceReport"
+          >
+            复制摘要
+          </button>
+          <button
             v-if="isDevMode"
             type="button"
             class="noname-debug-console-btn"
@@ -78,6 +86,24 @@
               </span>
             </button>
           </div>
+
+          <section
+            v-if="selectedTraceReport"
+            class="noname-debug-console-report"
+          >
+            <div class="noname-debug-console-report-head">
+              <p class="noname-debug-console-section-title">
+                诊断摘要
+              </p>
+              <span
+                v-if="copyStatus"
+                class="noname-debug-console-copy-status"
+              >
+                {{ copyStatus }}
+              </span>
+            </div>
+            <pre class="noname-debug-console-report-body">{{ selectedTraceReport }}</pre>
+          </section>
         </aside>
 
         <main class="noname-debug-console-main">
@@ -155,6 +181,59 @@ const selectedTrace = computed(() => {
   const index = selectedIndex.value;
   return props.traces[index] ?? props.traces[props.traces.length - 1];
 });
+
+const copyStatus = ref('');
+
+const selectedTraceReport = computed(() => buildTraceReport(selectedTrace.value));
+
+async function copySelectedTraceReport() {
+  const report = selectedTraceReport.value;
+  if (!report) {
+    return;
+  }
+  try {
+    await navigator.clipboard?.writeText(report);
+    copyStatus.value = '摘要已复制';
+  } catch {
+    copyStatus.value = '复制失败，请手动选择摘要';
+  }
+}
+
+function buildTraceReport(trace: NoNameTrace | null) {
+  if (!trace) {
+    return '';
+  }
+  const latestProposal = trace.proposals.length > 0
+    ? trace.proposals[trace.proposals.length - 1]
+    : null;
+  const readyCount = trace.proposals.filter((proposal) => proposal.applyable || proposal.status === 'ready').length;
+  const graphPath = trace.graphPath.length > 0 ? trace.graphPath.join(' -> ') : '无';
+  const protocolEvents = trace.protocolEvents ?? [];
+  const controlledReviews = trace.controlledOutputReviews ?? [];
+  const humanReviewCount = controlledReviews.filter((review) => review.requiresHumanReview).length;
+  const relatedObservations = trace.relatedObservations ?? [];
+  const guardrail = trace.guardrailResult
+    ? `${trace.guardrailResult.outcome}${trace.guardrailResult.reason ? ` (${trace.guardrailResult.reason})` : ''}`
+    : '无';
+  const applyResult = trace.applyResult
+    ? `${trace.applyResult.outcome}${trace.applyResult.reason ? ` (${trace.applyResult.reason})` : ''}`
+    : '无';
+  return [
+    `Trace: ${trace.traceId}`,
+    `Mode: ${trace.mode}`,
+    `Turn: ${trace.turnId}`,
+    `Graph: ${graphPath}`,
+    `Proposals: ${readyCount}/${trace.proposals.length} applyable`,
+    `Latest Proposal: ${latestProposal ? `${latestProposal.producerRole}:${latestProposal.kind}:${latestProposal.focus}` : '无'}`,
+    `Related Observations: ${relatedObservations.length}`,
+    `Protocol Events: ${protocolEvents.length}`,
+    `Controlled Reviews: ${controlledReviews.length} (${humanReviewCount} needs human review)`,
+    `Guardrail: ${guardrail}`,
+    `Apply Result: ${applyResult}`,
+    `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,
+    `Elapsed: ${trace.elapsedMs} ms`,
+  ].join('\n');
+}
 </script>
 
 <style scoped>
@@ -305,6 +384,43 @@ const selectedTrace = computed(() => {
 .noname-debug-console-trace-meta {
   font-size: 12px;
   color: var(--ink-text-muted);
+}
+
+.noname-debug-console-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.54;
+}
+
+.noname-debug-console-report {
+  margin-top: 16px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 76%, transparent);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--ink-card-bg-soft) 88%, transparent);
+  padding: 12px;
+}
+
+.noname-debug-console-report-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+
+.noname-debug-console-copy-status {
+  color: var(--ink-text-muted);
+  font-size: 12px;
+}
+
+.noname-debug-console-report-body {
+  margin: 10px 0 0;
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--ink-text-primary);
+  font-size: 12px;
+  line-height: 1.55;
+  font-family: "LXGW WenKai", "Noto Serif SC", serif;
 }
 
 @media (max-width: 1024px) {

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -71,6 +71,15 @@ const trace: NoNameTrace = {
     status: 'running',
     detail: 'turn-8-director-observe',
   }],
+  controlledOutputReviews: [{
+    requestId: 'controlled-output-proposal-2-plot_text_hint',
+    requestedKind: 'sceneAugmentation',
+    decision: 'needsReview',
+    reason: 'plot text hint requires human review before higher-layer apply',
+    normalizedKind: 'sceneAugmentation',
+    safeApplyScope: 'plotTextHint',
+    requiresHumanReview: true,
+  }],
   guardrailResult: {
     outcome: 'accept',
     reason: null,
@@ -106,6 +115,9 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('协议事件');
     expect(wrapper.text()).toContain('agent · delegation · running');
+    expect(wrapper.text()).toContain('受控输出复核');
+    expect(wrapper.text()).toContain('sceneAugmentation · plotTextHint · needsReview');
+    expect(wrapper.text()).toContain('需要人工复核');
   });
 
   it('shows empty state when trace is missing', () => {

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import NoNameDebugConsole from '../NoNameDebugConsole.vue';
 import type { NoNameTrace } from '../../types/game';
 
@@ -71,6 +71,24 @@ const traces: NoNameTrace[] = [
     }],
     guardrailResult: { outcome: 'accept', reason: null },
     applyResult: { attempted: true, outcome: 'preflight_ready', reason: '允许应用' },
+    protocolEvents: [{
+      channel: 'agent',
+      from: 'runtime',
+      to: 'worldCurator',
+      kind: 'taskRequest',
+      taskId: 'task-1',
+      status: 'queued',
+      detail: 'fan-out',
+    }],
+    controlledOutputReviews: [{
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      requestedKind: 'sceneAugmentation',
+      decision: 'needsReview',
+      reason: 'plot text hint requires human review before higher-layer apply',
+      normalizedKind: 'sceneAugmentation',
+      safeApplyScope: 'plotTextHint',
+      requiresHumanReview: true,
+    }],
     fallbackUsed: false,
     elapsedMs: 28,
   },
@@ -89,6 +107,9 @@ describe('NoNameDebugConsole', () => {
 
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('当前模式：assisted');
+    expect(wrapper.text()).toContain('Protocol Events: 1');
+    expect(wrapper.text()).toContain('Controlled Reviews: 1 (1 needs human review)');
+    expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
     const traceButtons = wrapper.findAll('.noname-debug-console-trace-btn');
     expect(traceButtons).toHaveLength(2);
@@ -107,12 +128,36 @@ describe('NoNameDebugConsole', () => {
       },
     });
 
-    await wrapper.find('.noname-debug-console-btn').trigger('click');
+    await wrapper.findAll('.noname-debug-console-btn')[1].trigger('click');
     await wrapper.findAll('.noname-debug-console-mode-btn')[2].trigger('click');
     await wrapper.find('.noname-debug-console-btn-primary').trigger('click');
 
     expect(wrapper.emitted('clear-traces')).toBeTruthy();
     expect(wrapper.emitted('set-no-name-mode')?.[0]).toEqual(['assisted']);
     expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('copies the selected trace report', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const wrapper = mount(NoNameDebugConsole, {
+      props: {
+        isOpen: true,
+        traces,
+        noNameMode: 'assisted',
+        isDevMode: true,
+      },
+    });
+
+    await wrapper.findAll('.noname-debug-console-btn')[0].trigger('click');
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace: trace-2'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Protocol Events: 1'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Controlled Reviews: 1'));
+    expect(wrapper.text()).toContain('摘要已复制');
   });
 });

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -224,6 +224,11 @@ export const useGameStore = defineStore('game', {
           .map((item) => `${item.channel}:${item.kind}:${item.status}`)
           .join(', ')
         : '无';
+      const controlledOutputReviews = latest.controlledOutputReviews && latest.controlledOutputReviews.length > 0
+        ? latest.controlledOutputReviews
+          .map((item) => `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}`)
+          .join(', ')
+        : '无';
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -232,6 +237,7 @@ export const useGameStore = defineStore('game', {
         `提案：${proposal ? `${proposal.title} / ${proposal.focus} / ${proposalStatus}` : '无'}`,
         `协作观察：${relatedObservations}`,
         `协议事件：${protocolEvents}`,
+        `受控输出复核：${controlledOutputReviews}`,
         `目标段：${proposal?.targetSegment || '无'}`,
         `预期效果：${proposal?.intendedEffect || '无'}`,
         `作用域：${proposalScopes}`,

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -324,6 +324,23 @@ export interface NoNameApplyPlanRecord {
   note?: string | null;
 }
 
+export type NoNameControlledOutputDecision = 'allow' | 'reject' | 'needsReview';
+export type NoNameControlledOutputKind =
+  | 'recapNote'
+  | 'sceneAugmentation'
+  | 'narrativeNote'
+  | 'intermediateNarrativeHint';
+
+export interface NoNameControlledOutputReviewRecord {
+  requestId: string;
+  requestedKind: NoNameControlledOutputKind;
+  decision: NoNameControlledOutputDecision;
+  reason: string;
+  normalizedKind?: NoNameControlledOutputKind | null;
+  safeApplyScope?: NoNameApplyScope | null;
+  requiresHumanReview: boolean;
+}
+
 export type NoNameProposalStatus = 'observed' | 'ready' | 'blocked' | 'applied' | 'fallback';
 export type NoNameApplyScope =
   | 'diagnostics'
@@ -382,6 +399,7 @@ export interface NoNameTrace {
   proposalTransitionLog?: string[];
   applyPlanLog?: NoNameApplyPlanRecord[];
   applyExecutionLog?: NoNameApplyExecutionRecord[];
+  controlledOutputReviews?: NoNameControlledOutputReviewRecord[];
   relatedObservations?: NoNameRelatedObservation[];
   protocolEvents?: NoNameProtocolEvent[];
   guardrailResult?: NoNameGuardrailTraceResult | null;


### PR DESCRIPTION
## Summary
- record controlled output review results in NoName trace during assisted preflight
- surface controlled output reviews in AgentTracePanel, NoNameDebugConsole, and store debug text
- update NoName T7/safe output docs for the V2 slice

## Validation
- cargo test noname_runtime -- --nocapture
- cargo test noname_trace -- --nocapture
- cargo clippy -- -D warnings
- npm test -- --run src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts
- npm run build
- npm test -- --run
- cargo test --verbose