### PR TITLE
feat(noname): map role constraints to output policy

### DIFF
--- a/docs/architecture/noname-role-context-packets-v1.md
+++ b/docs/architecture/noname-role-context-packets-v1.md
@@ -102,12 +102,12 @@
 
 - 角色上下文包还没有接入 runtime fan-out，当前仍是独立 builder 能力。
 - 当前差异化是规则式裁剪，不是 LLM 动态裁剪。
-- `visibleConstraints` 和 `forbiddenScopes` 先作为显式文本约束，后续可接 guardrail。
+- `forbiddenScopes` 已开始接入受控输出策略，用于生成 `policyForbiddenScopes` trace；`visibleConstraints` 仍先作为显式文本约束。
 
 ## 后续建议
 
 下一步可以继续:
 
 1. 在 B4 observe fan-out 中改用 `build_role_context_packet` 或由基础包生成角色视图。
-2. 让每个角色 prompt 读取 `roleGoal / forbiddenScopes`。
+2. 让每个角色 prompt 继续读取 `roleGoal / forbiddenScopes`，并与受控输出策略保持一致。
 3. 与 A2 structured notes 联动，让不同角色优先读取不同 note type。

--- a/docs/architecture/noname-safe-output-interface-v1.md
+++ b/docs/architecture/noname-safe-output-interface-v1.md
@@ -62,6 +62,8 @@
 
 当前 V2 切片已把 review 结果接入 `NoNameRuntime` trace：`assisted` 预检通过后会记录每个 apply scope 的 controlled output review，其中 `PlotTextHint` 仍保持 `NeedsReview`，不会自动接管最终剧情正文。
 
+当前 V2 后续切片已把 A3 角色上下文中的 `forbiddenScopes` 映射到 `NoNameControlledOutputPolicy.forbiddenScopes`，并在 trace 的 `controlledOutputReviews[].policyForbiddenScopes` 中显式记录当次 review 使用的策略禁区。
+
 ## V1 决策规则
 
 - 空 request id、空 title、空 content 会被拒绝。
@@ -87,11 +89,11 @@
 - 触碰 canon world fact 的 request 会被拒绝。
 - scene augmentation 映射到 plot text hint 时需要人工复核。
 - policy 明确列出 allowlist 和 forbidden scopes。
+- A3 role context 的 `forbiddenScopes` 可以映射为 controlled output policy，并随 review trace 输出。
 
 ## 后续建议
 
 下一步可以继续:
 
-1. 把 A3 的 `forbiddenScopes` 映射到本接口的 forbidden scopes。
-2. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
-3. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。
+1. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
+2. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。

--- a/docs/architecture/noname-v1-task-list.md
+++ b/docs/architecture/noname-v1-task-list.md
@@ -472,6 +472,7 @@
 - trace 已记录 controlled output review，能区分 `Allow / Reject / NeedsReview`
 - 前端调试文本已显示 apply preflight 与 proposal transition log
 - 前端调试台已展示 controlled output review，并支持复制当前 Trace 摘要
+- A3 `forbiddenScopes` 已映射到 controlled output policy，review trace 会显示 `policyForbiddenScopes`
 - apply 阶段已补独立 guardrail 入口
 
 ### 当前边界

--- a/src-tauri/src/entity_store.rs
+++ b/src-tauri/src/entity_store.rs
@@ -53,7 +53,7 @@ impl EntityStore {
             let lower = keyword.to_lowercase();
             out.retain(|e| e.payload.to_string().to_lowercase().contains(&lower));
         }
-        out.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        out.sort_by_key(|entity| std::cmp::Reverse(entity.updated_at));
         out
     }
 }

--- a/src-tauri/src/noname_memory_retrieval.rs
+++ b/src-tauri/src/noname_memory_retrieval.rs
@@ -192,7 +192,7 @@ where
         })
         .collect::<Vec<_>>();
 
-    ranked.sort_by(|a, b| b.0.cmp(&a.0));
+    ranked.sort_by_key(|item| std::cmp::Reverse(item.0));
     ranked.truncate(query.per_section_limit);
     ranked.into_iter().map(|(_, item)| item).collect()
 }

--- a/src-tauri/src/noname_output_interface.rs
+++ b/src-tauri/src/noname_output_interface.rs
@@ -1,3 +1,4 @@
+use crate::noname_context_types::NoNameRoleContextPacket;
 use crate::noname_types::{NoNameApplyScope, NoNameProposalRef, NoNameRole};
 use serde::{Deserialize, Serialize};
 
@@ -149,7 +150,10 @@ impl NoNameControlledOutputInterface {
             return self.reject(request, "output kind is not allowed by policy");
         }
         if request.content.chars().count() > self.policy.max_content_chars {
-            return self.reject(request, "content exceeds controlled output character budget");
+            return self.reject(
+                request,
+                "content exceeds controlled output character budget",
+            );
         }
 
         let touched_forbidden = request
@@ -178,7 +182,8 @@ impl NoNameControlledOutputInterface {
             return NoNameControlledOutputReview {
                 request_id: request.request_id.clone(),
                 decision: NoNameControlledOutputDecision::NeedsReview,
-                reason: "plot text hint requires human review before higher-layer apply".to_string(),
+                reason: "plot text hint requires human review before higher-layer apply"
+                    .to_string(),
                 normalized_kind: Some(request.kind),
                 safe_apply_scope: Some(request.target_scope),
                 requires_human_review: true,
@@ -212,7 +217,10 @@ impl NoNameControlledOutputInterface {
             title: title.into(),
             content: content.into(),
             touched_forbidden_scopes: Vec::new(),
-            labels: vec!["noname_controlled_output_v1".to_string(), kind_key.to_string()],
+            labels: vec![
+                "noname_controlled_output_v1".to_string(),
+                kind_key.to_string(),
+            ],
         }
     }
 
@@ -229,6 +237,89 @@ impl NoNameControlledOutputInterface {
             safe_apply_scope: None,
             requires_human_review: false,
         }
+    }
+}
+
+pub fn controlled_output_policy_from_role_context(
+    context: &NoNameRoleContextPacket,
+) -> NoNameControlledOutputPolicy {
+    let mut policy = NoNameControlledOutputPolicy::default();
+    let mapped = forbidden_output_scopes_from_role_constraints(&context.forbidden_scopes);
+    if !mapped.is_empty() {
+        policy.forbidden_scopes = mapped;
+    }
+    policy
+}
+
+pub fn forbidden_output_scopes_from_role_constraints(
+    constraints: &[String],
+) -> Vec<NoNameForbiddenOutputScope> {
+    let mut scopes = Vec::new();
+    for constraint in constraints {
+        let text = constraint.to_ascii_lowercase();
+        if contains_any(
+            &text,
+            &[
+                "final plot state",
+                "main plot beat",
+                "author narrative content",
+            ],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::FinalPlotState);
+        }
+        if contains_any(
+            &text,
+            &[
+                "canon",
+                "world fact",
+                "world facts",
+                "hard world",
+                "override world facts",
+            ],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::CanonWorldFact);
+        }
+        if contains_any(
+            &text,
+            &["character stats", "attribute", "realm", "cultivation"],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::CharacterStats);
+        }
+        if contains_any(&text, &["inventory", "resource"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::InventoryOrResource);
+        }
+        if contains_any(&text, &["map topology", "location graph", "route graph"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::MapTopology);
+        }
+        if contains_any(&text, &["chapter lifecycle", "chapter transition"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::ChapterLifecycle);
+        }
+        if contains_any(&text, &["player choice", "choose for player"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::PlayerChoice);
+        }
+        if contains_any(
+            &text,
+            &[
+                "combat outcome",
+                "damage",
+                "victory",
+                "combat rules",
+                "final damage",
+            ],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::CombatOutcome);
+        }
+    }
+    scopes
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn push_unique(scopes: &mut Vec<NoNameForbiddenOutputScope>, scope: NoNameForbiddenOutputScope) {
+    if !scopes.contains(&scope) {
+        scopes.push(scope);
     }
 }
 
@@ -276,7 +367,10 @@ mod tests {
         let review = interface.review(&request);
 
         assert_eq!(review.decision, NoNameControlledOutputDecision::Allow);
-        assert_eq!(review.safe_apply_scope, Some(NoNameApplyScope::ChapterSummaryHint));
+        assert_eq!(
+            review.safe_apply_scope,
+            Some(NoNameApplyScope::ChapterSummaryHint)
+        );
         assert!(!review.requires_human_review);
     }
 
@@ -313,7 +407,39 @@ mod tests {
         let review = interface.review(&request);
 
         assert_eq!(review.decision, NoNameControlledOutputDecision::NeedsReview);
-        assert_eq!(review.safe_apply_scope, Some(NoNameApplyScope::PlotTextHint));
+        assert_eq!(
+            review.safe_apply_scope,
+            Some(NoNameApplyScope::PlotTextHint)
+        );
         assert!(review.requires_human_review);
+    }
+
+    #[test]
+    fn role_context_forbidden_scopes_map_to_output_policy() {
+        let context = NoNameRoleContextPacket {
+            role: NoNameRole::CombatNarrator,
+            role_goal: "Track conflict rhythm".to_string(),
+            scene_focus: "山门冲突".to_string(),
+            world_facts: vec![],
+            character_relationships: vec![],
+            narrative_priorities: vec![],
+            recent_signals: vec![],
+            visible_constraints: vec![],
+            forbidden_scopes: vec![
+                "Must not determine final damage or victory state.".to_string(),
+                "Must not override world facts or combat outcomes.".to_string(),
+            ],
+            source_stats: vec![],
+            token_budget_used: 0,
+        };
+
+        let policy = controlled_output_policy_from_role_context(&context);
+
+        assert!(policy
+            .forbidden_scopes
+            .contains(&NoNameForbiddenOutputScope::CombatOutcome));
+        assert!(policy
+            .forbidden_scopes
+            .contains(&NoNameForbiddenOutputScope::CanonWorldFact));
     }
 }

--- a/src-tauri/src/noname_output_interface.rs
+++ b/src-tauri/src/noname_output_interface.rs
@@ -245,8 +245,8 @@ pub fn controlled_output_policy_from_role_context(
 ) -> NoNameControlledOutputPolicy {
     let mut policy = NoNameControlledOutputPolicy::default();
     let mapped = forbidden_output_scopes_from_role_constraints(&context.forbidden_scopes);
-    if !mapped.is_empty() {
-        policy.forbidden_scopes = mapped;
+    for scope in mapped {
+        push_unique(&mut policy.forbidden_scopes, scope);
     }
     policy
 }
@@ -441,5 +441,11 @@ mod tests {
         assert!(policy
             .forbidden_scopes
             .contains(&NoNameForbiddenOutputScope::CanonWorldFact));
+        assert!(policy
+            .forbidden_scopes
+            .contains(&NoNameForbiddenOutputScope::FinalPlotState));
+        assert!(policy
+            .forbidden_scopes
+            .contains(&NoNameForbiddenOutputScope::CharacterStats));
     }
 }

--- a/src-tauri/src/noname_runtime.rs
+++ b/src-tauri/src/noname_runtime.rs
@@ -1,5 +1,6 @@
 use crate::noname_agent_registry::NoNameAgentRegistry;
 use crate::noname_config::NoNameConfig;
+use crate::noname_context_builder::specialize_context_packet;
 use crate::noname_context_types::NoNameContextPacket;
 use crate::noname_errors::{NoNameError, NoNameErrorKind};
 use crate::noname_graph::NoNameGraphExecutor;
@@ -8,7 +9,8 @@ use crate::noname_guardrails::{
     NoNameDirectorGuardrailInput, NoNameGuardrailResult,
 };
 use crate::noname_output_interface::{
-    NoNameControlledOutputDecision, NoNameControlledOutputInterface, NoNameControlledOutputKind,
+    controlled_output_policy_from_role_context, NoNameControlledOutputDecision,
+    NoNameControlledOutputInterface, NoNameControlledOutputKind,
 };
 use crate::noname_protocol_agent::{NoNameAgentMessage, NoNameAgentMessageKind};
 use crate::noname_protocol_runtime::NoNameProtocolRuntime;
@@ -125,7 +127,12 @@ impl NoNameRuntime {
             result
         });
         let proposal = self.finalize_director_proposal(&mut observation, guardrail_result.as_ref());
-        let proposal = self.record_assisted_apply_preflight(&mut trace, proposal, guardrail_input);
+        let proposal = self.record_assisted_apply_preflight(
+            &mut trace,
+            proposal,
+            guardrail_input,
+            context_packet,
+        );
         observation.proposal = proposal.clone();
         trace.replace_last_proposal(proposal.clone());
         let related_observations =
@@ -259,6 +266,7 @@ impl NoNameRuntime {
         trace: &mut NoNameTrace,
         mut proposal: NoNameProposal,
         guardrail_input: Option<&NoNameDirectorGuardrailInput>,
+        context_packet: &NoNameContextPacket,
     ) -> NoNameProposal {
         trace.record_proposal_transition(format!(
             "{}:{}",
@@ -337,7 +345,7 @@ impl NoNameRuntime {
                             ));
                         }
                         let (review_count, needs_review_count) =
-                            self.record_controlled_output_reviews(trace, &proposal);
+                            self.record_controlled_output_reviews(trace, &proposal, context_packet);
                         if review_count > 0 {
                             trace.record_apply_execution(
                                 "runtime.controlled_output_review",
@@ -441,8 +449,13 @@ impl NoNameRuntime {
         &self,
         trace: &mut NoNameTrace,
         proposal: &NoNameProposal,
+        context_packet: &NoNameContextPacket,
     ) -> (usize, usize) {
-        let interface = NoNameControlledOutputInterface::default();
+        let role_context = specialize_context_packet(context_packet);
+        let interface = NoNameControlledOutputInterface::new(
+            controlled_output_policy_from_role_context(&role_context),
+        );
+        let policy_forbidden_scopes = interface.policy().forbidden_scopes.clone();
         let scopes = if proposal.apply_scopes.is_empty() {
             vec![NoNameApplyScope::Diagnostics]
         } else {
@@ -480,7 +493,7 @@ impl NoNameRuntime {
                 scope.as_str(),
                 controlled_output_decision_key(review.decision)
             ));
-            trace.record_controlled_output_review(kind, review);
+            trace.record_controlled_output_review(kind, policy_forbidden_scopes.clone(), review);
             review_count += 1;
         }
 
@@ -653,6 +666,7 @@ fn controlled_output_decision_key(decision: NoNameControlledOutputDecision) -> &
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::noname_output_interface::NoNameForbiddenOutputScope;
     use crate::noname_types::NoNameTraceStage;
 
     #[test]
@@ -916,6 +930,12 @@ mod tests {
         assert!(result.trace.controlled_output_reviews.iter().any(|item| {
             item.decision == NoNameControlledOutputDecision::NeedsReview
                 && item.safe_apply_scope == Some(NoNameApplyScope::PlotTextHint)
+                && item
+                    .policy_forbidden_scopes
+                    .contains(&NoNameForbiddenOutputScope::FinalPlotState)
+                && item
+                    .policy_forbidden_scopes
+                    .contains(&NoNameForbiddenOutputScope::CanonWorldFact)
                 && item.requires_human_review
         }));
         assert!(result

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -1,5 +1,6 @@
 use crate::noname_output_interface::{
     NoNameControlledOutputDecision, NoNameControlledOutputKind, NoNameControlledOutputReview,
+    NoNameForbiddenOutputScope,
 };
 use crate::noname_types::{
     NoNameApplyScope, NoNameMode, NoNameProposal, NoNameRole, NoNameTraceStage,
@@ -56,6 +57,8 @@ pub struct NoNameControlledOutputReviewRecord {
     pub reason: String,
     pub normalized_kind: Option<NoNameControlledOutputKind>,
     pub safe_apply_scope: Option<NoNameApplyScope>,
+    #[serde(default)]
+    pub policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
     pub requires_human_review: bool,
 }
 
@@ -225,6 +228,7 @@ impl NoNameTrace {
     pub fn record_controlled_output_review(
         &mut self,
         requested_kind: NoNameControlledOutputKind,
+        policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
         review: NoNameControlledOutputReview,
     ) {
         self.controlled_output_reviews
@@ -235,6 +239,7 @@ impl NoNameTrace {
                 reason: review.reason,
                 normalized_kind: review.normalized_kind,
                 safe_apply_scope: review.safe_apply_scope,
+                policy_forbidden_scopes,
                 requires_human_review: review.requires_human_review,
             });
     }
@@ -442,6 +447,7 @@ mod tests {
         let mut trace = NoNameTrace::empty("trace-1", "session-1", "turn-1", NoNameMode::Assisted);
         trace.record_controlled_output_review(
             NoNameControlledOutputKind::SceneAugmentation,
+            vec![NoNameForbiddenOutputScope::CombatOutcome],
             NoNameControlledOutputReview {
                 request_id: "review-1".to_string(),
                 decision: NoNameControlledOutputDecision::NeedsReview,
@@ -456,6 +462,10 @@ mod tests {
         assert_eq!(
             trace.controlled_output_reviews[0].decision,
             NoNameControlledOutputDecision::NeedsReview
+        );
+        assert_eq!(
+            trace.controlled_output_reviews[0].policy_forbidden_scopes,
+            vec![NoNameForbiddenOutputScope::CombatOutcome]
         );
         assert!(trace.controlled_output_reviews[0].requires_human_review);
     }

--- a/src-tauri/src/world_registry.rs
+++ b/src-tauri/src/world_registry.rs
@@ -704,10 +704,7 @@ fn extract_unmarked_named_entities(text: &str) -> Vec<String> {
             .collect::<String>()
             .trim()
             .to_string();
-        loop {
-            let Some(first) = candidate.chars().next() else {
-                break;
-            };
+        while let Some(first) = candidate.chars().next() {
             let is_prefix = matches!(
                 first,
                 '在' | '于'

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -204,6 +204,12 @@
             <p class="agent-trace-muted">
               {{ review.requiresHumanReview ? '需要人工复核' : '可自动通过' }} · {{ review.reason }}
             </p>
+            <p
+              v-if="review.policyForbiddenScopes?.length"
+              class="agent-trace-muted"
+            >
+              策略禁区：{{ review.policyForbiddenScopes.join(' / ') }}
+            </p>
           </li>
         </ul>
       </section>

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -78,6 +78,7 @@ const trace: NoNameTrace = {
     reason: 'plot text hint requires human review before higher-layer apply',
     normalizedKind: 'sceneAugmentation',
     safeApplyScope: 'plotTextHint',
+    policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
     requiresHumanReview: true,
   }],
   guardrailResult: {
@@ -118,6 +119,7 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('受控输出复核');
     expect(wrapper.text()).toContain('sceneAugmentation · plotTextHint · needsReview');
     expect(wrapper.text()).toContain('需要人工复核');
+    expect(wrapper.text()).toContain('策略禁区：finalPlotState / canonWorldFact');
   });
 
   it('shows empty state when trace is missing', () => {

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -87,6 +87,7 @@ const traces: NoNameTrace[] = [
       reason: 'plot text hint requires human review before higher-layer apply',
       normalizedKind: 'sceneAugmentation',
       safeApplyScope: 'plotTextHint',
+      policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
       requiresHumanReview: true,
     }],
     fallbackUsed: false,

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -358,6 +358,16 @@ describe('gameStore', () => {
         outcome: 'applied',
         note: '已写入章节摘要提示',
       }],
+      controlledOutputReviews: [{
+        requestId: 'controlled-output-proposal-1-plot_text_hint',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'plot text hint requires human review before higher-layer apply',
+        normalizedKind: 'sceneAugmentation',
+        safeApplyScope: 'plotTextHint',
+        policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
+        requiresHumanReview: true,
+      }],
       relatedObservations: [{
         role: 'worldCurator',
         actionSummary: '玩家返回山门',
@@ -405,6 +415,7 @@ describe('gameStore', () => {
     expect(text).toContain('预检：preflight_ready');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
+    expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact]');
     expect(text).toContain('状态迁移：proposal-1:ready');
     expect(text).toContain('提案：Director提案：山门危机 / 山门危机 / ready');
     expect(text).toContain('目标段：current_turn_tail');

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -226,7 +226,12 @@ export const useGameStore = defineStore('game', {
         : '无';
       const controlledOutputReviews = latest.controlledOutputReviews && latest.controlledOutputReviews.length > 0
         ? latest.controlledOutputReviews
-          .map((item) => `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}`)
+          .map((item) => {
+            const policyScopes = item.policyForbiddenScopes?.length
+              ? `[禁区=${item.policyForbiddenScopes.join('/')}]`
+              : '';
+            return `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}${policyScopes}`;
+          })
           .join(', ')
         : '无';
       return [

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -330,6 +330,15 @@ export type NoNameControlledOutputKind =
   | 'sceneAugmentation'
   | 'narrativeNote'
   | 'intermediateNarrativeHint';
+export type NoNameForbiddenOutputScope =
+  | 'finalPlotState'
+  | 'canonWorldFact'
+  | 'characterStats'
+  | 'inventoryOrResource'
+  | 'mapTopology'
+  | 'chapterLifecycle'
+  | 'playerChoice'
+  | 'combatOutcome';
 
 export interface NoNameControlledOutputReviewRecord {
   requestId: string;
@@ -338,6 +347,7 @@ export interface NoNameControlledOutputReviewRecord {
   reason: string;
   normalizedKind?: NoNameControlledOutputKind | null;
   safeApplyScope?: NoNameApplyScope | null;
+  policyForbiddenScopes?: NoNameForbiddenOutputScope[];
   requiresHumanReview: boolean;
 }
 


### PR DESCRIPTION
## Summary
- map A3 role-context forbiddenScopes into controlled output policy forbidden scopes
- record policyForbiddenScopes on controlled output review trace records
- surface policy forbidden scopes in the Agent trace panel and debug summary
- update NoName architecture docs to mark this V2 slice as completed

## Verification
- cargo test noname_output_interface -- --nocapture
- cargo test noname_trace -- --nocapture
- cargo test noname_runtime -- --nocapture
- cargo clippy -- -D warnings
- cargo test --verbose
- npm run build
- npm test -- --run