### PR TITLE
feat(noname): add reviewed apply runtime scopes

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,10 +4,14 @@
 
 ## 当前状态
 
-截至 `2026-04-09`：
+截至 `2026-04-18`：
 
 - `NoName Agent V1` 基础闭环已完成
-- 当前代码进度已经超过原始 `T6` 计划，进入 `assisted skeleton`
+- 当前代码进度已经超过原始 `T6` 计划，进入 `T7 assisted skeleton / 受控应用 proposal` 阶段
+- `T7-0.6` 已完成：`PlotTextHint` 只有在人工批准、二次护栏 allow、显式命令与段落快照一致时才会写入正文
+- `T7-0.7` 已完成：前端调试台已补显式人工 apply 的差异预览、重复写入禁用与 stale snapshot 友好提示
+- `T7-3` 已完成最小可视化基线：apply lifecycle 已统一展示到调试面板、复制摘要与 Info 调试文本
+- `T7-1` 已完成第三切片：后端 reviewed apply runtime 与通用命令入口 `apply_noname_reviewed_output` 已复用到 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，三者都要求人工批准、二次护栏 allow 与快照一致
 - 如果要继续推进实现，优先阅读 `noname-v1-blueprint.md`、`noname-v1-task-list.md` 与 `noname-t7-file-checklist.md`
 
 ## 推荐阅读顺序
@@ -51,7 +55,7 @@
   - 面向实现的 V1 蓝图、阶段目标、当前状态与下一阶段方向。
 
 - `noname-v1-task-list.md`
-  - 可执行的开发任务清单，现已补充 `T0-T6` 完成状态与 `T7 assisted skeleton` 说明。
+  - 可执行的开发任务清单，现已补充 `T0-T6` 完成状态与 `T7 assisted skeleton` / 显式人工 apply 说明。
 
 - `noname-t1-file-checklist.md`
   - `T1 Core 类型与配置骨架` 的文件级实现清单，明确每个文件该放什么、先做什么、做到什么算完成。

--- a/docs/architecture/noname-safe-output-interface-v1.md
+++ b/docs/architecture/noname-safe-output-interface-v1.md
@@ -64,6 +64,18 @@
 
 当前 V2 后续切片已把 A3 角色上下文中的 `forbiddenScopes` 映射到 `NoNameControlledOutputPolicy.forbiddenScopes`，并在 trace 的 `controlledOutputReviews[].policyForbiddenScopes` 中显式记录当次 review 使用的策略禁区。
 
+当前前端调试台已为 `NeedsReview` 增加人工复核入口：开发者可以把单条 review 标记为“可进入高层 apply 设计”或“暂不应用”。该标记会通过 `mark_noname_controlled_output_review` 写回最近 trace，形成可追踪的 review intent；当人工批准 `PlotTextHint` 时，后端会记录 `review_intent_ready / awaiting_second_guardrail` 计划与执行日志，但不会直接触发剧情正文写入。
+
+当前后续切片已新增 `resolve_noname_second_guardrail`：只处理已人工批准且处于 `awaiting_second_guardrail` 的 review，输出 `allow / reject / fallback` 决策，并写入 trace 的 apply plan、execution 与 transition log。`allow` 也只是进入“等待显式人工 apply 命令”的下一站，不会自动写最终剧情正文。
+
+当前 T7-0.6 已新增 `apply_noname_manual_plot_text_hint`：只有在 `PlotTextHint` 已人工批准、二次护栏 `allow`、并且调用方再次提交 `chapterIndex / segmentIndex / expectedSegmentText` 快照一致时，才会把正文提示写入当前剧情段落；写入后 trace 会记录 `manual_apply / manual_plot_text_applied / manual_apply:plot_text_hint`，用于区分“人工显式写入”和普通低风险自动 apply。
+
+当前 T7-0.7 已补前端显式人工 apply 预览：调试台会展示当前段落的“写入前 / 写入后”，在段落已经包含 NoName 标记或 trace 已记录 `manual_plot_text_applied` 时禁用按钮；后端返回 stale snapshot / 重复写入 / 章节变化等错误时，前端会转成更明确的中文提示。
+
+当前 T7-3 已补 apply lifecycle 可视化基线：前端会从 trace 的 plan、execution、review、transition 与 fallback 字段推导“提案阶段 / Apply 预检 / 低风险输出 / 人工复核 / 二次护栏 / 人工写入 / 回退”进度，并统一展示到调试台、复制摘要和 Info 调试文本。
+
+当前 T7-1 第三切片已新增 `noname_apply.rs` reviewed apply runtime：人工批准、二次护栏、scope 匹配、快照校验、剧情写入和 trace 留痕已从 `tauri_commands.rs` 抽出；前端显式写入改走通用命令 `apply_noname_reviewed_output(scope=plotTextHint)`，旧命令保留兼容；`ChapterSummaryHint` 和 `OptionBiasHint` 也已接入同一 runtime，分别要求提交章节摘要快照、诊断提示快照一致后才写入对应低风险提示层。
+
 ## V1 决策规则
 
 - 空 request id、空 title、空 content 会被拒绝。
@@ -90,10 +102,18 @@
 - scene augmentation 映射到 plot text hint 时需要人工复核。
 - policy 明确列出 allowlist 和 forbidden scopes。
 - A3 role context 的 `forbiddenScopes` 可以映射为 controlled output policy，并随 review trace 输出。
+- 前端调试台可以对 `NeedsReview` review 做人工标记，并在复制摘要里体现待复核/通过/拒绝数量。
+- 后端可记录 `humanReviewDecision / humanReviewedAt / humanReviewNote`，并把人工复核 intent 写入 trace 状态迁移日志。
+- 人工批准后的 `PlotTextHint` 会进入二次 guardrail / apply planner 等待队列，trace 会记录 `review_intent_ready` 与 `awaiting_second_guardrail`，但不会直接 apply 到正文。
+- `resolve_noname_second_guardrail` 可记录 `second_guardrail_allow / second_guardrail_reject / second_guardrail_fallback`，用于完整表达二次护栏决策。
+- `apply_noname_manual_plot_text_hint` 可在人工批准 + 二次护栏 allow + 正文快照一致时显式写入 `PlotTextHint`，并拒绝陈旧段落、重复 NoName 标记和不匹配的章节。
+- 前端调试台可在写入前展示差异预览，并对重复应用 / stale snapshot 给出明确提示。
+- apply lifecycle 可视化可以稳定表达 apply / review / guardrail / manual apply / fallback 当前状态。
+- reviewed apply runtime 已提供统一入口，当前覆盖 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，后续可继续评估 `plot_engine` 低风险输出层入口。
 
 ## 后续建议
 
 下一步可以继续:
 
-1. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
-2. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。
+1. 继续扩展 `noname_apply.rs` 的落地边界，让 `plot_engine` 低风险输出层复用 reviewed apply runtime，但仍要求快照校验和 trace 留痕。
+2. 将更多输出类型接入现有 lifecycle 可视化与测试基线，继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。

--- a/docs/architecture/noname-t7-file-checklist.md
+++ b/docs/architecture/noname-t7-file-checklist.md
@@ -1,6 +1,6 @@
 # NoName Agent T7 文件级实现清单
 
-更新时间: 2026-04-09
+更新时间: 2026-04-17
 状态: 文件级执行清单
 目标: 将 `T7 Assisted Skeleton 与受控应用预备` 拆到可直接实施的文件粒度
 关联文档:
@@ -27,7 +27,7 @@
 
 ## 1.1 当前进度
 
-截至 `2026-04-09`，`T7` 第一批已经完成：
+截至 `2026-04-17`，`T7` 第一批已经完成：
 
 - `NoNameProposal` 已补 `status`
   - `observed / ready / blocked / applied / fallback`
@@ -37,12 +37,22 @@
 - apply 阶段已补独立 guardrail 入口
 - 调试诊断已输出 `proposal_status` 与 `apply=...`
 - 前端调试文本已优先展示显式 `status`、apply preflight 与状态迁移
+- 已补 `disabled / observe_only / assisted` 模式矩阵测试，并在命令层确保 disabled 跳过 NoName turn
+- 前端调试台已为 `NeedsReview` 受控输出增加本地人工复核标记入口，用于记录“可进入高层 apply 设计 / 暂不应用”
+- 后端已提供 `mark_noname_controlled_output_review`，可把人工复核 intent 写回最近 trace
+- 人工批准后的 `PlotTextHint` intent 已进入二次 guardrail / apply planner 等待队列，trace 会记录 `review_intent_ready / awaiting_second_guardrail`
+- 后端已提供 `resolve_noname_second_guardrail`，可记录 `allow / reject / fallback` 二次护栏决策
+- `T7-0.6` 已接入 `apply_noname_manual_plot_text_hint`，要求人工批准、二次护栏 allow、章节/段落快照一致后才显式写入正文提示，并记录 `manual_plot_text_applied`
+- `T7-0.7` 已补前端差异预览、重复写入禁用与 stale snapshot 友好错误提示，显式人工写入前能看到“写入前 / 写入后”
+- `T7-3` 已补 `noNameApplyLifecycle` 前端收敛层，统一从 plan / execution / review / transition / fallback 推导 apply 生命周期，并展示到调试台、复制摘要和 Info 文本
+- `T7-1` 第三切片已新增 `src-tauri/src/noname_apply.rs`，把 reviewed apply 校验、快照校验、剧情写入和 trace 记录从命令层抽成可复用 runtime；前端已改走 `apply_noname_reviewed_output(scope=plotTextHint)`，后端与 Web mock 已扩展支持 `ChapterSummaryHint` 和 `OptionBiasHint`
 
 当前仍未完成的部分：
 
 - proposal 已可进入“诊断层 + 章节摘要提示 + 选项偏置提示”低风险 apply，但还没有进入更高权重的剧情输出层
-- trace 已有 apply transition log，并已记录诊断层 / 章节摘要提示 / 选项偏置提示 apply；但还没有更高权重输出层的 apply/reject/fallback 执行明细
+- trace 已有 apply transition log、执行明细和 lifecycle 可视化；`PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint` 已补人工显式 apply 执行明细，但还没有通用化到所有高权重输出层
 - `plot_engine` 侧还没有低风险输出层应用入口
+- reviewed apply runtime 目前支持 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，下一步重点是评估 `plot_engine` 低风险输出层入口
 
 ## 2. 建议文件范围
 
@@ -53,6 +63,7 @@
 - `src-tauri/src/tauri_commands.rs`
 - `src-tauri/src/noname_trace.rs`
 - `src-tauri/src/noname_types.rs`
+- `src-tauri/src/noname_apply.rs`
 
 ### 高概率配套修改文件
 
@@ -170,6 +181,7 @@
 
 - 增加显式的 apply 分支，例如：
   - `maybe_apply_assisted_proposal()`
+  - `apply_noname_manual_plot_text_hint()`
 - 明确三种模式行为：
   - `disabled`: 完全跳过 NoName
   - `observe_only`: 记录 proposal，但不尝试应用
@@ -340,12 +352,11 @@
 
 如果下一步开始写代码，建议按这个顺序推进：
 
-1. `noname_types.rs`
+1. `tauri_commands.rs`
 2. `noname_trace.rs`
-3. `noname_guardrails.rs`
-4. `noname_runtime.rs`
-5. `tauri_commands.rs`
-6. `game.ts`
-7. `gameStore.ts`
-8. `webRuntime.ts`
-这个顺序的好处是：先把状态机和边界讲清楚，再碰真正容易引发回归的应用分支。
+3. `game.ts`
+4. `gameStore.ts`
+5. `AgentTracePanel.vue`
+6. `webRuntime.ts`
+7. 对应前后端测试
+这个顺序的好处是：在已有 lifecycle 可视化基线下，先把当前显式 apply 命令抽象成可复用 runtime，再补更多输出类型的回归测试。

--- a/docs/architecture/noname-v1-blueprint.md
+++ b/docs/architecture/noname-v1-blueprint.md
@@ -1,7 +1,7 @@
 # NoName Agent V1 实施蓝图
 
-更新时间: 2026-04-09
-状态: V1 已完成，`assisted skeleton` 进行中
+更新时间: 2026-04-17
+状态: V1 已完成，`T7 assisted skeleton / 受控应用 proposal` 进行中
 目标: 将 `NoName Agent` 从设计文档推进到可运行的 V1 骨架，并为后续受控应用阶段建立基线
 关联文档:
 - `noname-agent-v1.md`
@@ -23,15 +23,16 @@ V1 的核心目标：
 
 ## 1.1 当前状态快照
 
-截至 `2026-04-09`，当前代码状态为：
+截至 `2026-04-17`，当前代码状态为：
 
 - `V1` 基础闭环已经完成
 - `DirectorAgent` 已接入 `execute_player_action`
 - 结构化 `NoNameProposal` 已落地
 - Guardrail 已接入并可产出 `accept / repair / reject`
 - 前端已经能查看 trace、proposal、guardrail、fallback 调试摘要
-- 当前正在推进 `assisted skeleton`
-- 当前尚未进入“真正应用 proposal 到主剧情结果”的阶段
+- 当前正在推进 `T7 assisted skeleton / 受控应用 proposal`
+- `assisted` 已可自动应用诊断层、章节摘要提示、选项偏置提示这三类低风险输出
+- `PlotTextHint` 已进入人工批准、二次护栏、显式命令、段落快照校验后的人工写入链路，不会自动接管最终剧情生成
 
 ## 2. V1 范围边界
 
@@ -244,12 +245,20 @@ V1 的核心目标：
 - runtime 可将 proposal 标记为 `applyable`
 - trace 可记录 proposal、guardrail、fallback、阶段跳转
 - 前端调试信息可显示 proposal 是否 `ready`
+- 已补 `disabled / observe_only / assisted` 模式矩阵测试，确保 disabled 不影响主链路、observe-only 仅记录、assisted 才进入受控低风险 apply
+- 前端调试台已为 `NeedsReview` 受控输出补本地人工复核入口，支持标记“可进入高层 apply 设计 / 暂不应用”
+- `mark_noname_controlled_output_review` 已可把人工复核 intent 写回最近 trace，记录 `humanReviewDecision / humanReviewedAt / humanReviewNote`
+- 人工批准后的 `PlotTextHint` intent 已可进入二次 guardrail / apply planner 等待队列，trace 记录 `review_intent_ready / awaiting_second_guardrail`
+- `resolve_noname_second_guardrail` 已可输出 `allow / reject / fallback` 决策，并记录 `second_guardrail_*` apply plan / execution / transition
+- `apply_noname_manual_plot_text_hint` 已提供显式人工 apply 命令，要求人工批准、二次护栏 allow、章节/段落快照一致后才写入 `PlotTextHint`，并记录 `manual_plot_text_applied`
+- 前端调试台已补应用前差异预览、重复写入禁用与 stale snapshot 友好错误提示
+- `T7-3` 已补 apply lifecycle 可视化基线，能从提案、预检、低风险输出、人工复核、二次护栏、人工写入、fallback 等阶段阅读当前 trace
+- `T7-1` 第三切片已抽出 reviewed apply runtime，并新增 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 人工写入已改走该入口，旧命令保留兼容，`ChapterSummaryHint` 与 `OptionBiasHint` 已复用同一入口和快照校验
 
 当前未完成：
 
-- proposal 还没有真正影响最终剧情文本或状态落地
-- 还没有“应用 proposal 后的二次 guardrail + 回退”链路
-- 还没有完整的 `disabled / observe_only / assisted` 集成测试矩阵
+- proposal 仍不会自动影响最终剧情文本或核心状态；`PlotTextHint` 只允许在人工批准 + 二次护栏 + 显式命令下写入
+- reviewed apply runtime 已接入 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，尚未扩展到 `plot_engine` 低风险输出层入口
 
 阶段完成标准：
 

--- a/docs/architecture/noname-v1-task-list.md
+++ b/docs/architecture/noname-v1-task-list.md
@@ -1,7 +1,7 @@
 # NoName Agent V1 开发任务清单
 
-更新时间: 2026-04-09
-状态: V1 基础闭环已完成，已进入 `assisted skeleton` 阶段
+更新时间: 2026-04-17
+状态: V1 基础闭环已完成，已进入 `T7 assisted skeleton / 受控应用 proposal` 阶段
 目标: 将 `NoName Agent` V1 设计拆解为可按顺序实施的开发任务
 关联文档:
 - `noname-agent-v1.md`
@@ -24,12 +24,12 @@
 
 ## 1.1 当前实现状态
 
-截至 `2026-04-09`，当前仓库中的 `NoName Agent` 实现状态如下：
+截至 `2026-04-17`，当前仓库中的 `NoName Agent` 实现状态如下：
 
 - `T0` 到 `T6` 已完成
 - `V1 Done` 条件已满足
 - 代码已超出原始 V1 任务清单，进入 `T7 assisted skeleton`
-- 当前 `assisted` 仅完成“可判定 / 可标记 / 可调试”，尚未进入真正的受控应用分支
+- 当前 `assisted` 已进入受控应用分支：低风险输出可自动 apply，`PlotTextHint` 仅允许人工批准 + 二次护栏 + 显式命令 + 快照校验后写入
 - 当前验证基线：
   - `cargo test -q` 通过
   - 前端定向测试通过
@@ -474,18 +474,26 @@
 - 前端调试台已展示 controlled output review，并支持复制当前 Trace 摘要
 - A3 `forbiddenScopes` 已映射到 controlled output policy，review trace 会显示 `policyForbiddenScopes`
 - apply 阶段已补独立 guardrail 入口
+- `T7-4` 已补 `disabled / observe_only / assisted` 模式矩阵测试，覆盖 disabled 跳过、observe-only 只记录、assisted 受控低风险 apply
+- `NeedsReview` 已补前端本地人工复核入口，可标记“可进入高层 apply 设计 / 暂不应用 / 重置待复核”，但不直接写入剧情正文
+- `mark_noname_controlled_output_review` 已接入，人工复核 intent 会写回最近 trace 并记录状态迁移
+- 人工批准后的 `PlotTextHint` intent 已进入二次 guardrail / apply planner 等待队列，trace 会记录 `review_intent_ready / awaiting_second_guardrail`
+- `resolve_noname_second_guardrail` 已接入，能记录 `allow / reject / fallback` 二次护栏决策，但仍不直接写入剧情正文
+- `T7-0.6` 已接入 `apply_noname_manual_plot_text_hint`，只有人工批准 + 二次护栏 allow + 当前章节/段落快照一致时，才允许显式写入 `PlotTextHint`
+- `T7-0.7` 已补显式人工 apply 的前端差异预览、重复写入禁用与 stale snapshot 友好提示
+- `T7-3` 已补 apply lifecycle 展示与测试基线，调试面板、复制摘要、Info 调试文本可以统一展示 apply / review / guardrail / manual apply / fallback 进度
+- `T7-1` 第三切片已新增 `noname_apply.rs` reviewed apply runtime，提供 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 显式写入已改走该入口，`ChapterSummaryHint` 与 `OptionBiasHint` 也已接入人工批准 + 二次护栏 + 快照一致的显式 reviewed apply
 
 ### 当前边界
 
-- proposal 目前不会改写剧情正文与状态机，但已可写入章节摘要提示这类低风险输出
-- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出；`plotTextHint` 会先进入 controlled output review，仍不直接接管最终剧情应用分支
+- proposal 目前不会自动改写剧情正文与状态机，但已可写入章节摘要提示这类低风险输出
+- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出；`plotTextHint` 会先进入 controlled output review、人工复核 intent、二次护栏，再由显式人工命令写入当前剧情段落
+- reviewed apply runtime 已形成统一通道，目前支持 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`；`plot_engine` 低风险输出层入口还需要继续评估
 - 仍然保持“经典主链路优先，NoName 仅辅助”
 
 ### 下一步子任务
 
-- `T7-1` 将受控应用边界从选项偏置提示继续扩展到下一层低风险输出
-- `T7-3` 明确 apply / reject / fallback 的 trace 记录
-- `T7-4` 增加 `disabled / observe_only / assisted` 的集成测试矩阵
+- `T7-1.2` 已完成两个扩展 scope：`ChapterSummaryHint` 与 `OptionBiasHint` 可复用 reviewed apply runtime；下一步可继续评估 `plot_engine` 低风险输出层入口
 
 ### 验收标准
 
@@ -577,6 +585,6 @@
 
 如果继续推进实现，当前最推荐的是：
 
-1. 推进 `T7`，把 `assisted skeleton` 变成真正的“受控应用 proposal”
-2. 为 `disabled / observe_only / assisted` 补完整集成测试矩阵
+1. 继续推进 `T7-1.2` 的后续落地层，让 `plot_engine` 低风险输出层复用 `noname_apply.rs` reviewed apply runtime
+2. 把新增 scope 持续接入现有 apply lifecycle，让后续更多输出类型复用同一套可视化与测试基线
 这会比继续扩文档或继续堆更多角色更有价值，因为它决定 `NoName Agent` 是否能从“可观察”走向“可辅助落地”。

--- a/src-tauri/src/game_engine.rs
+++ b/src-tauri/src/game_engine.rs
@@ -1,12 +1,14 @@
 use crate::event_log::{EventImportance, EventLog};
 use crate::game_state::{Character, GameState, GameTime, WorldState};
 use crate::models::{CharacterStats, Element, Grade, Lifespan, SpiritualRoot};
+use crate::noname_types::NoNameMode;
 use crate::npc::{CoreValue, Goal, NPCMemory, Personality, PersonalityTrait, NPC};
 use crate::npc_engine::{NPCDecision, NPCEngine, NPCEvent};
 use crate::numerical_system::NumericalSystem;
-use crate::noname_types::NoNameMode;
 use crate::plot_engine::{PlotEngine, PlotState, Scene};
-use crate::save_load::{MigrationBatchReport, NoNameSaveSettings, SaveData, SaveInfo, SaveLoadSystem};
+use crate::save_load::{
+    MigrationBatchReport, NoNameSaveSettings, SaveData, SaveInfo, SaveLoadSystem,
+};
 use crate::script::{Script, ScriptType};
 use crate::script_manager::ScriptManager;
 use crate::world_registry::WorldRegistry;
@@ -390,12 +392,11 @@ impl GameEngine {
             let registry_lock = self.world_registry.lock().unwrap();
             registry_lock.clone()
         };
-        let save_data = SaveData::from_game_state_with_plot(
-            save_state,
-            plot_snapshot,
-            registry_snapshot,
-        )
-        .with_noname_settings(NoNameSaveSettings { mode: self.noname_mode() });
+        let save_data =
+            SaveData::from_game_state_with_plot(save_state, plot_snapshot, registry_snapshot)
+                .with_noname_settings(NoNameSaveSettings {
+                    mode: self.noname_mode(),
+                });
         self.save_load_system.save_game(slot_id, &save_data)?;
 
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,9 +13,10 @@ pub mod llm_service;
 pub mod memory_layers;
 pub mod memory_manager;
 pub mod models;
+pub mod noname_agent_registry;
+pub mod noname_apply;
 pub mod noname_capability_base;
 pub mod noname_capability_registry;
-pub mod noname_agent_registry;
 pub mod noname_config;
 pub mod noname_context_builder;
 pub mod noname_context_types;
@@ -24,8 +25,8 @@ pub mod noname_graph;
 pub mod noname_guardrails;
 pub mod noname_knowledge_retrieval;
 pub mod noname_knowledge_store;
-pub mod noname_memory_manager;
 pub mod noname_memory_compaction;
+pub mod noname_memory_manager;
 pub mod noname_memory_retrieval;
 pub mod noname_memory_store;
 pub mod noname_memory_types;
@@ -80,6 +81,10 @@ pub fn run() {
             tauri_commands::execute_player_action,
             tauri_commands::get_noname_recent_traces,
             tauri_commands::clear_noname_recent_traces,
+            tauri_commands::mark_noname_controlled_output_review,
+            tauri_commands::resolve_noname_second_guardrail,
+            tauri_commands::apply_noname_manual_plot_text_hint,
+            tauri_commands::apply_noname_reviewed_output,
             tauri_commands::get_noname_mode,
             tauri_commands::set_noname_mode,
             tauri_commands::travel_to_location,

--- a/src-tauri/src/noname_agent_registry.rs
+++ b/src-tauri/src/noname_agent_registry.rs
@@ -40,28 +40,32 @@ impl NoNameAgentRegistry {
                     responsibility: "统筹当前回合的剧情观察焦点与低风险推进方向",
                     primary_inputs: &["narrative_notes", "episodic_memory", "chapter_summaries"],
                     output_kind: NoNameProposalKind::PlotCandidate,
-                    boundary_with_director: "Director 负责统筹，不负责直接补全世界事实或 NPC/战斗细节。",
+                    boundary_with_director:
+                        "Director 负责统筹，不负责直接补全世界事实或 NPC/战斗细节。",
                 },
                 NoNameRoleProfile {
                     role: NoNameRole::WorldCurator,
                     responsibility: "补全世界事实、场景约束和设定锚点，维持世界一致性",
                     primary_inputs: &["hard_facts", "chapter_summaries", "referenced_entities"],
                     output_kind: NoNameProposalKind::WorldPatchProposal,
-                    boundary_with_director: "WorldCurator 不负责决定剧情主冲突，只负责提供世界层约束与补丁候选。",
+                    boundary_with_director:
+                        "WorldCurator 不负责决定剧情主冲突，只负责提供世界层约束与补丁候选。",
                 },
                 NoNameRoleProfile {
                     role: NoNameRole::NpcIntent,
                     responsibility: "推断 NPC 动机、立场变化和关系反应",
                     primary_inputs: &["referenced_entities", "recent_context", "episodic_memory"],
                     output_kind: NoNameProposalKind::NpcIntentProposal,
-                    boundary_with_director: "NpcIntent 不负责编排整段剧情，只补足角色行为动机与反应。",
+                    boundary_with_director:
+                        "NpcIntent 不负责编排整段剧情，只补足角色行为动机与反应。",
                 },
                 NoNameRoleProfile {
                     role: NoNameRole::CombatNarrator,
                     responsibility: "观察冲突节奏、动作反馈与战斗描写锚点",
                     primary_inputs: &["recent_context", "episodic_memory", "action_summary"],
                     output_kind: NoNameProposalKind::CombatNarration,
-                    boundary_with_director: "CombatNarrator 不负责世界规则或人物动机，只服务于冲突表现层。",
+                    boundary_with_director:
+                        "CombatNarrator 不负责世界规则或人物动机，只服务于冲突表现层。",
                 },
             ],
         }
@@ -192,7 +196,10 @@ mod tests {
                 .expect("npc intent dispatch should work"),
         ];
 
-        assert_eq!(observations[0].proposal.kind, NoNameProposalKind::PlotCandidate);
+        assert_eq!(
+            observations[0].proposal.kind,
+            NoNameProposalKind::PlotCandidate
+        );
         assert_eq!(
             observations[1].proposal.kind,
             NoNameProposalKind::WorldPatchProposal

--- a/src-tauri/src/noname_apply.rs
+++ b/src-tauri/src/noname_apply.rs
@@ -1,0 +1,672 @@
+use crate::noname_trace::{NoNameHumanReviewDecision, NoNameTrace};
+use crate::noname_types::{NoNameApplyScope, NoNameProposal, NoNameTargetSegment};
+use crate::plot_engine::PlotState;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplySegmentSnapshot {
+    pub chapter_index: u32,
+    pub segment_index: usize,
+    pub expected_segment_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplySummarySnapshot {
+    pub chapter_index: u32,
+    pub expected_summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplyDiagnosticsSnapshot {
+    pub chapter_index: u32,
+    pub expected_generation_diagnostics: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameReviewedApplyRequest {
+    pub request_id: String,
+    pub scope: NoNameApplyScope,
+    pub segment_snapshot: Option<NoNameApplySegmentSnapshot>,
+    pub summary_snapshot: Option<NoNameApplySummarySnapshot>,
+    pub diagnostics_snapshot: Option<NoNameApplyDiagnosticsSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoNameReviewedApplyOutcome {
+    pub trace: NoNameTrace,
+    pub plot_state: PlotState,
+}
+
+fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
+    match scope {
+        NoNameApplyScope::PlotTextHint => 300,
+        NoNameApplyScope::ChapterSummaryHint => 200,
+        NoNameApplyScope::OptionBiasHint => 100,
+        NoNameApplyScope::Diagnostics => 50,
+    }
+}
+
+fn next_apply_plan_order(trace: &NoNameTrace) -> u32 {
+    trace
+        .apply_plan_log
+        .iter()
+        .map(|item| item.order)
+        .max()
+        .unwrap_or_default()
+        + 1
+}
+
+fn find_review_proposal<'a>(
+    trace: &'a NoNameTrace,
+    request_id: &str,
+) -> Option<&'a NoNameProposal> {
+    trace
+        .proposals
+        .iter()
+        .rev()
+        .find(|proposal| request_id.contains(&proposal.proposal_id))
+        .or_else(|| trace.proposals.last())
+}
+
+fn target_segment_supports_apply_scope(
+    target_segment: NoNameTargetSegment,
+    scope: NoNameApplyScope,
+) -> bool {
+    match scope {
+        NoNameApplyScope::PlotTextHint => matches!(
+            target_segment,
+            NoNameTargetSegment::CurrentTurnHead | NoNameTargetSegment::CurrentTurnTail
+        ),
+        _ => true,
+    }
+}
+
+fn trace_has_second_guardrail_allow(
+    trace: &NoNameTrace,
+    request_id: &str,
+    scope: NoNameApplyScope,
+) -> bool {
+    let transition = format!("{}:second_guardrail:allow", request_id);
+    trace
+        .proposal_transition_log
+        .iter()
+        .any(|entry| entry == &transition)
+        || trace.apply_execution_log.iter().any(|entry| {
+            entry.target == scope.as_str() && entry.outcome == "second_guardrail_allowed"
+        })
+}
+
+fn build_plot_text_hint(proposal: &NoNameProposal) -> String {
+    format!("【NoName】重点关注：{}", proposal.focus.trim())
+}
+
+fn build_chapter_summary_hint(proposal: &NoNameProposal) -> String {
+    format!("NoName summary hint: {}", proposal.focus.trim())
+}
+
+fn build_option_bias_hint(proposal: &NoNameProposal) -> String {
+    format!(
+        "NoName option bias: next turn should prioritize actions around {}",
+        proposal.focus.trim()
+    )
+}
+
+fn manual_apply_outcome_for_scope(scope: NoNameApplyScope) -> &'static str {
+    match scope {
+        NoNameApplyScope::PlotTextHint => "manual_plot_text_applied",
+        NoNameApplyScope::ChapterSummaryHint => "manual_chapter_summary_hint_applied",
+        NoNameApplyScope::OptionBiasHint => "manual_option_bias_hint_applied",
+        NoNameApplyScope::Diagnostics => "manual_diagnostics_applied",
+    }
+}
+
+fn validate_reviewed_apply_request<'a>(
+    trace: &'a NoNameTrace,
+    request: &'a NoNameReviewedApplyRequest,
+) -> Result<&'a NoNameProposal, String> {
+    let review = trace
+        .controlled_output_reviews
+        .iter()
+        .find(|review| review.request_id == request.request_id)
+        .ok_or_else(|| {
+            format!(
+                "NoName controlled output review not found: {}",
+                request.request_id
+            )
+        })?;
+
+    if review.human_review_decision != Some(NoNameHumanReviewDecision::ApprovedForHigherApply) {
+        return Err(format!(
+            "NoName controlled output review is not approved for manual apply: {}",
+            request.request_id
+        ));
+    }
+    if review.safe_apply_scope != Some(request.scope) {
+        return Err(format!(
+            "manual apply scope mismatch: expected {}, review scope {:?}",
+            request.scope.as_str(),
+            review.safe_apply_scope
+        ));
+    }
+    if !trace_has_second_guardrail_allow(trace, &request.request_id, request.scope) {
+        return Err("second guardrail has not allowed this review".to_string());
+    }
+    if trace.apply_execution_log.iter().any(|entry| {
+        entry.target == request.scope.as_str()
+            && entry.outcome == manual_apply_outcome_for_scope(request.scope)
+    }) {
+        return Err(format!(
+            "manual {} has already been applied for this trace",
+            request.scope.as_str()
+        ));
+    }
+
+    let proposal = find_review_proposal(trace, &request.request_id)
+        .ok_or_else(|| "NoName proposal not found for manual apply".to_string())?;
+    if !target_segment_supports_apply_scope(proposal.target_segment, request.scope) {
+        return Err(format!(
+            "target_segment={} does not support manual {}",
+            proposal.target_segment.as_str(),
+            request.scope.as_str()
+        ));
+    }
+
+    Ok(proposal)
+}
+
+fn apply_plot_text_hint_to_segment(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.segment_snapshot else {
+        return Err("plot_text_hint manual apply requires a segment snapshot".to_string());
+    };
+    if plot_state.current_chapter.index != snapshot.chapter_index {
+        return Err(format!(
+            "chapter mismatch: expected {}, current {}",
+            snapshot.chapter_index, plot_state.current_chapter.index
+        ));
+    }
+    let Some(current_segment) = plot_state
+        .current_chapter
+        .content
+        .get(snapshot.segment_index)
+    else {
+        return Err(format!(
+            "segment index out of range: {}",
+            snapshot.segment_index
+        ));
+    };
+    if current_segment != &snapshot.expected_segment_text {
+        return Err("segment snapshot mismatch; refusing stale manual apply".to_string());
+    }
+    if snapshot.expected_segment_text.contains("【NoName】")
+        || snapshot.expected_segment_text.contains("NoName提示")
+    {
+        return Err("segment already contains a NoName marker".to_string());
+    }
+
+    let hint = build_plot_text_hint(proposal);
+    let updated_segment = match proposal.target_segment {
+        NoNameTargetSegment::CurrentTurnHead => {
+            format!("{}\n\n{}", hint, snapshot.expected_segment_text.trim())
+        }
+        _ => format!("{}\n\n{}", snapshot.expected_segment_text.trim(), hint),
+    };
+
+    plot_state.current_chapter.content[snapshot.segment_index] = updated_segment.clone();
+    if let Some(history_segment) = plot_state
+        .plot_history
+        .iter_mut()
+        .rev()
+        .find(|item| item.as_str() == snapshot.expected_segment_text)
+    {
+        *history_segment = updated_segment.clone();
+    } else {
+        return Err("plot history snapshot mismatch; refusing partial manual apply".to_string());
+    }
+    plot_state.current_scene.description = plot_state.current_chapter.content.join("\n\n");
+    if let Some(result) = plot_state.last_action_result.as_mut() {
+        if result.description == snapshot.expected_segment_text {
+            result.description = updated_segment;
+        }
+    }
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "显式人工 apply 已确认 chapter={} segment={}，准备写入 {}",
+            snapshot.chapter_index,
+            snapshot.segment_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        "manual_plot_text_applied",
+        Some(format!(
+            "已由显式人工命令写入正文提示，聚焦“{}”",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:plot_text_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        "manual_plot_text_applied",
+        Some("显式人工 apply 已写入正文提示".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
+fn apply_chapter_summary_hint(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.summary_snapshot else {
+        return Err("chapter_summary_hint manual apply requires a summary snapshot".to_string());
+    };
+    if plot_state.current_chapter.index != snapshot.chapter_index {
+        return Err(format!(
+            "chapter mismatch: expected {}, current {}",
+            snapshot.chapter_index, plot_state.current_chapter.index
+        ));
+    }
+    if plot_state.current_chapter.summary != snapshot.expected_summary {
+        return Err("summary snapshot mismatch; refusing stale manual apply".to_string());
+    }
+
+    let focus = proposal.focus.trim();
+    let hint = build_chapter_summary_hint(proposal);
+    if !focus.is_empty()
+        && (snapshot.expected_summary.contains(focus) || snapshot.expected_summary.contains(&hint))
+    {
+        return Err("chapter summary already contains this NoName hint".to_string());
+    }
+
+    let summary = snapshot.expected_summary.trim();
+    let updated_summary = if summary.is_empty() {
+        hint.clone()
+    } else {
+        match proposal.target_segment {
+            NoNameTargetSegment::ChapterSummaryHead => format!("{}; {}", hint, summary),
+            _ => format!("{}; {}", summary, hint),
+        }
+    };
+
+    plot_state.current_chapter.summary = updated_summary.clone();
+    if let Some(history_chapter) = plot_state
+        .chapters
+        .iter_mut()
+        .find(|chapter| chapter.index == snapshot.chapter_index)
+    {
+        history_chapter.summary = updated_summary;
+    }
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "manual apply confirmed for chapter={} scope={}",
+            snapshot.chapter_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        manual_apply_outcome_for_scope(request.scope),
+        Some(format!(
+            "manual chapter summary hint applied for focus={}",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:chapter_summary_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        manual_apply_outcome_for_scope(request.scope),
+        Some("manual chapter summary hint applied".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
+fn apply_option_bias_hint(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.diagnostics_snapshot else {
+        return Err("option_bias_hint manual apply requires a diagnostics snapshot".to_string());
+    };
+    if plot_state.current_chapter.index != snapshot.chapter_index {
+        return Err(format!(
+            "chapter mismatch: expected {}, current {}",
+            snapshot.chapter_index, plot_state.current_chapter.index
+        ));
+    }
+    if !plot_state.is_waiting_for_input {
+        return Err("option_bias_hint manual apply requires waiting-for-input state".to_string());
+    }
+
+    let current_diagnostics = plot_state
+        .last_generation_diagnostics
+        .clone()
+        .unwrap_or_default();
+    if current_diagnostics != snapshot.expected_generation_diagnostics {
+        return Err("diagnostics snapshot mismatch; refusing stale manual apply".to_string());
+    }
+
+    let hint = build_option_bias_hint(proposal);
+    if current_diagnostics.contains(&hint) {
+        return Err("diagnostics already contains this NoName option bias hint".to_string());
+    }
+
+    plot_state.last_generation_diagnostics = Some(if current_diagnostics.trim().is_empty() {
+        hint.clone()
+    } else {
+        format!("{}; {}", current_diagnostics, hint)
+    });
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "manual apply confirmed for chapter={} scope={}",
+            snapshot.chapter_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        manual_apply_outcome_for_scope(request.scope),
+        Some(format!(
+            "manual option bias hint applied for focus={}",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:option_bias_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        manual_apply_outcome_for_scope(request.scope),
+        Some("manual option bias hint applied".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
+pub fn apply_reviewed_output_to_plot_state(
+    trace: NoNameTrace,
+    request: NoNameReviewedApplyRequest,
+    plot_state: PlotState,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let proposal = validate_reviewed_apply_request(&trace, &request)?.clone();
+    match request.scope {
+        NoNameApplyScope::PlotTextHint => {
+            apply_plot_text_hint_to_segment(trace, plot_state, &request, &proposal)
+        }
+        NoNameApplyScope::ChapterSummaryHint => {
+            apply_chapter_summary_hint(trace, plot_state, &request, &proposal)
+        }
+        NoNameApplyScope::OptionBiasHint => {
+            apply_option_bias_hint(trace, plot_state, &request, &proposal)
+        }
+        scope => Err(format!(
+            "manual reviewed apply currently does not support {}",
+            scope.as_str()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::noname_output_interface::{
+        NoNameControlledOutputDecision, NoNameControlledOutputKind, NoNameControlledOutputReview,
+    };
+    use crate::noname_types::{NoNameMode, NoNameProposalKind, NoNameProposalStatus, NoNameRole};
+    use crate::plot_engine::Scene;
+
+    fn make_plot_state(summary: &str) -> PlotState {
+        let scene = Scene {
+            id: "scene-1".to_string(),
+            name: "test scene".to_string(),
+            description: "test description".to_string(),
+            location: "test".to_string(),
+            available_options: Vec::new(),
+        };
+        let mut state = PlotState::new(scene);
+        state.current_chapter.summary = summary.to_string();
+        state
+    }
+
+    fn make_trace_for_summary_apply() -> (NoNameTrace, String) {
+        let proposal_id = "proposal-summary".to_string();
+        let request_id = "controlled-output-proposal-summary-chapter_summary_hint".to_string();
+        let mut trace = NoNameTrace::empty("trace-1", "session-1", "turn-1", NoNameMode::Assisted);
+        trace.record_proposal(NoNameProposal {
+            proposal_id,
+            kind: NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "summary hint".to_string(),
+            summary: "suggest summary hint".to_string(),
+            focus: "sect crisis".to_string(),
+            target_segment: NoNameTargetSegment::ChapterSummaryHead,
+            intended_effect: "prepend chapter summary hint".to_string(),
+            rationale: "keep recap focused".to_string(),
+            suggested_action: Some("manual apply".to_string()),
+            labels: vec!["test".to_string()],
+            apply_scopes: vec![NoNameApplyScope::ChapterSummaryHint],
+            status: NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            NoNameControlledOutputKind::RecapNote,
+            Vec::new(),
+            NoNameControlledOutputReview {
+                request_id: request_id.clone(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "summary hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::RecapNote),
+                safe_apply_scope: Some(NoNameApplyScope::ChapterSummaryHint),
+                requires_human_review: true,
+            },
+        );
+        trace.controlled_output_reviews[0].human_review_decision =
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply);
+        trace.record_apply_execution(
+            NoNameApplyScope::ChapterSummaryHint.as_str(),
+            "second_guardrail_allowed",
+            None,
+        );
+        (trace, request_id)
+    }
+
+    fn make_trace_for_option_bias_apply() -> (NoNameTrace, String) {
+        let proposal_id = "proposal-option-bias".to_string();
+        let request_id = "controlled-output-proposal-option-bias-option_bias_hint".to_string();
+        let mut trace = NoNameTrace::empty("trace-2", "session-1", "turn-2", NoNameMode::Assisted);
+        trace.record_proposal(NoNameProposal {
+            proposal_id,
+            kind: NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "option bias hint".to_string(),
+            summary: "suggest option bias hint".to_string(),
+            focus: "hidden cave".to_string(),
+            target_segment: NoNameTargetSegment::CurrentTurnTail,
+            intended_effect: "bias next player options".to_string(),
+            rationale: "keep choices focused".to_string(),
+            suggested_action: Some("manual apply".to_string()),
+            labels: vec!["test".to_string()],
+            apply_scopes: vec![NoNameApplyScope::OptionBiasHint],
+            status: NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            NoNameControlledOutputKind::IntermediateNarrativeHint,
+            Vec::new(),
+            NoNameControlledOutputReview {
+                request_id: request_id.clone(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "option bias hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::IntermediateNarrativeHint),
+                safe_apply_scope: Some(NoNameApplyScope::OptionBiasHint),
+                requires_human_review: true,
+            },
+        );
+        trace.controlled_output_reviews[0].human_review_decision =
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply);
+        trace.record_apply_execution(
+            NoNameApplyScope::OptionBiasHint.as_str(),
+            "second_guardrail_allowed",
+            None,
+        );
+        (trace, request_id)
+    }
+
+    #[test]
+    fn reviewed_apply_can_write_chapter_summary_hint() {
+        let (trace, request_id) = make_trace_for_summary_apply();
+        let plot_state = make_plot_state("existing summary");
+
+        let outcome = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::ChapterSummaryHint,
+                segment_snapshot: None,
+                summary_snapshot: Some(NoNameApplySummarySnapshot {
+                    chapter_index: 1,
+                    expected_summary: "existing summary".to_string(),
+                }),
+                diagnostics_snapshot: None,
+            },
+            plot_state,
+        )
+        .expect("summary hint should be manually applied");
+
+        assert!(outcome
+            .plot_state
+            .current_chapter
+            .summary
+            .starts_with("NoName summary hint: sect crisis; existing summary"));
+        assert!(outcome.trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "chapter_summary_hint"
+                && entry.outcome == "manual_chapter_summary_hint_applied"
+        }));
+        assert!(outcome
+            .trace
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry.ends_with(":manual_apply:chapter_summary_hint")));
+    }
+
+    #[test]
+    fn reviewed_apply_rejects_stale_chapter_summary_snapshot() {
+        let (trace, request_id) = make_trace_for_summary_apply();
+        let plot_state = make_plot_state("newer summary");
+
+        let error = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::ChapterSummaryHint,
+                segment_snapshot: None,
+                summary_snapshot: Some(NoNameApplySummarySnapshot {
+                    chapter_index: 1,
+                    expected_summary: "older summary".to_string(),
+                }),
+                diagnostics_snapshot: None,
+            },
+            plot_state,
+        )
+        .expect_err("stale summary should be rejected");
+
+        assert!(error.contains("summary snapshot mismatch"));
+    }
+
+    #[test]
+    fn reviewed_apply_can_write_option_bias_hint() {
+        let (trace, request_id) = make_trace_for_option_bias_apply();
+        let mut plot_state = make_plot_state("");
+        plot_state.last_generation_diagnostics = Some("base diagnostics".to_string());
+
+        let outcome = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::OptionBiasHint,
+                segment_snapshot: None,
+                summary_snapshot: None,
+                diagnostics_snapshot: Some(NoNameApplyDiagnosticsSnapshot {
+                    chapter_index: 1,
+                    expected_generation_diagnostics: "base diagnostics".to_string(),
+                }),
+            },
+            plot_state,
+        )
+        .expect("option bias hint should be manually applied");
+
+        assert_eq!(
+            outcome.plot_state.last_generation_diagnostics.as_deref(),
+            Some(
+                "base diagnostics; NoName option bias: next turn should prioritize actions around hidden cave"
+            )
+        );
+        assert!(outcome.trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "option_bias_hint" && entry.outcome == "manual_option_bias_hint_applied"
+        }));
+        assert!(outcome
+            .trace
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry.ends_with(":manual_apply:option_bias_hint")));
+    }
+
+    #[test]
+    fn reviewed_apply_rejects_stale_option_bias_snapshot() {
+        let (trace, request_id) = make_trace_for_option_bias_apply();
+        let mut plot_state = make_plot_state("");
+        plot_state.last_generation_diagnostics = Some("newer diagnostics".to_string());
+
+        let error = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::OptionBiasHint,
+                segment_snapshot: None,
+                summary_snapshot: None,
+                diagnostics_snapshot: Some(NoNameApplyDiagnosticsSnapshot {
+                    chapter_index: 1,
+                    expected_generation_diagnostics: "older diagnostics".to_string(),
+                }),
+            },
+            plot_state,
+        )
+        .expect_err("stale diagnostics should be rejected");
+
+        assert!(error.contains("diagnostics snapshot mismatch"));
+    }
+}

--- a/src-tauri/src/noname_apply.rs
+++ b/src-tauri/src/noname_apply.rs
@@ -59,12 +59,17 @@ fn find_review_proposal<'a>(
     trace: &'a NoNameTrace,
     request_id: &str,
 ) -> Option<&'a NoNameProposal> {
+    let proposal_id = trace
+        .controlled_output_reviews
+        .iter()
+        .find(|review| review.request_id == request_id)
+        .and_then(|review| review.proposal_id.as_deref())?;
+
     trace
         .proposals
         .iter()
         .rev()
-        .find(|proposal| request_id.contains(&proposal.proposal_id))
-        .or_else(|| trace.proposals.last())
+        .find(|proposal| proposal.proposal_id == proposal_id)
 }
 
 fn target_segment_supports_apply_scope(
@@ -483,6 +488,7 @@ mod tests {
             applyable: true,
         });
         trace.record_controlled_output_review(
+            Some("proposal-summary".to_string()),
             NoNameControlledOutputKind::RecapNote,
             Vec::new(),
             NoNameControlledOutputReview {
@@ -525,6 +531,7 @@ mod tests {
             applyable: true,
         });
         trace.record_controlled_output_review(
+            Some("proposal-option-bias".to_string()),
             NoNameControlledOutputKind::IntermediateNarrativeHint,
             Vec::new(),
             NoNameControlledOutputReview {
@@ -668,5 +675,30 @@ mod tests {
         .expect_err("stale diagnostics should be rejected");
 
         assert!(error.contains("diagnostics snapshot mismatch"));
+    }
+
+    #[test]
+    fn reviewed_apply_rejects_when_reviewed_proposal_binding_is_missing() {
+        let (mut trace, request_id) = make_trace_for_summary_apply();
+        trace.controlled_output_reviews[0].proposal_id = Some("proposal-missing".to_string());
+        let plot_state = make_plot_state("existing summary");
+
+        let error = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::ChapterSummaryHint,
+                segment_snapshot: None,
+                summary_snapshot: Some(NoNameApplySummarySnapshot {
+                    chapter_index: 1,
+                    expected_summary: "existing summary".to_string(),
+                }),
+                diagnostics_snapshot: None,
+            },
+            plot_state,
+        )
+        .expect_err("missing reviewed proposal binding should be rejected");
+
+        assert!(error.contains("NoName proposal not found"));
     }
 }

--- a/src-tauri/src/noname_context_builder.rs
+++ b/src-tauri/src/noname_context_builder.rs
@@ -1,8 +1,7 @@
 use crate::entity_store::{EntityQuery, EntityStore};
 use crate::entity_types::EntityType;
 use crate::noname_context_types::{
-    NoNameContextBuildInput, NoNameContextPacket, NoNameContextSourceStat,
-    NoNameRoleContextPacket,
+    NoNameContextBuildInput, NoNameContextPacket, NoNameContextSourceStat, NoNameRoleContextPacket,
 };
 use crate::noname_memory_manager::NoNameMemoryManager;
 use crate::noname_memory_retrieval::NoNameMemoryQuery;
@@ -277,7 +276,8 @@ fn npc_intent_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
 fn combat_narrator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
     NoNameRoleContextPacket {
         role: NoNameRole::CombatNarrator,
-        role_goal: "Track conflict rhythm, action feedback, and combat narration anchors.".to_string(),
+        role_goal: "Track conflict rhythm, action feedback, and combat narration anchors."
+            .to_string(),
         scene_focus: first_of(&[
             &packet.recent_context,
             &packet.episodic_memory,
@@ -607,7 +607,10 @@ mod tests {
 
         assert_eq!(world.scene_focus, "Gate has a ward");
         assert_eq!(npc.scene_focus, "Character:ElderQinghe");
-        assert!(world.forbidden_scopes.iter().any(|item| item.contains("NPC")));
+        assert!(world
+            .forbidden_scopes
+            .iter()
+            .any(|item| item.contains("NPC")));
         assert!(npc
             .forbidden_scopes
             .iter()

--- a/src-tauri/src/noname_guardrails.rs
+++ b/src-tauri/src/noname_guardrails.rs
@@ -622,7 +622,9 @@ mod tests {
         proposal.status = crate::noname_types::NoNameProposalStatus::Ready;
         proposal.applyable = true;
         proposal.target_segment = crate::noname_types::NoNameTargetSegment::ChapterSummaryHead;
-        proposal.apply_scopes.push(crate::noname_types::NoNameApplyScope::PlotTextHint);
+        proposal
+            .apply_scopes
+            .push(crate::noname_types::NoNameApplyScope::PlotTextHint);
 
         let result = validate_director_proposal_for_apply(
             NoNameMode::Assisted,

--- a/src-tauri/src/noname_knowledge_retrieval.rs
+++ b/src-tauri/src/noname_knowledge_retrieval.rs
@@ -134,18 +134,13 @@ fn min_score_matches(snippet: &NoNameKnowledgeSnippet, min_score: Option<u32>) -
         .unwrap_or(true)
 }
 
-fn dedupe_snippets(
-    snippets: Vec<NoNameKnowledgeSnippet>,
-) -> (Vec<NoNameKnowledgeSnippet>, usize) {
+fn dedupe_snippets(snippets: Vec<NoNameKnowledgeSnippet>) -> (Vec<NoNameKnowledgeSnippet>, usize) {
     let mut deduped: Vec<NoNameKnowledgeSnippet> = Vec::new();
     let mut duplicate_count = 0;
 
     for snippet in snippets {
         let key = snippet_key(&snippet);
-        if let Some(existing) = deduped
-            .iter_mut()
-            .find(|item| snippet_key(item) == key)
-        {
+        if let Some(existing) = deduped.iter_mut().find(|item| snippet_key(item) == key) {
             duplicate_count += 1;
             if compare_snippets(&snippet, existing).is_lt() {
                 *existing = snippet;

--- a/src-tauri/src/noname_knowledge_store.rs
+++ b/src-tauri/src/noname_knowledge_store.rs
@@ -102,7 +102,11 @@ impl NoNameKnowledgeProvider for InMemoryKnowledgeProvider {
             })
             .collect::<Vec<_>>();
 
-        snippets.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.document_id.cmp(&b.document_id)));
+        snippets.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| a.document_id.cmp(&b.document_id))
+        });
         snippets.truncate(query.limit);
         snippets
     }
@@ -115,10 +119,7 @@ pub struct GraphKnowledgeProvider {
 }
 
 impl GraphKnowledgeProvider {
-    pub fn new(
-        nodes: Vec<NoNameKnowledgeGraphNode>,
-        edges: Vec<NoNameKnowledgeGraphEdge>,
-    ) -> Self {
+    pub fn new(nodes: Vec<NoNameKnowledgeGraphNode>, edges: Vec<NoNameKnowledgeGraphEdge>) -> Self {
         Self { nodes, edges }
     }
 }
@@ -141,7 +142,13 @@ impl NoNameKnowledgeProvider for GraphKnowledgeProvider {
             .iter()
             .filter_map(|node| {
                 let score = score_graph_node(node, keyword.as_deref(), &tag_terms)
-                    + score_graph_edges(node, &self.nodes, &self.edges, keyword.as_deref(), &tag_terms);
+                    + score_graph_edges(
+                        node,
+                        &self.nodes,
+                        &self.edges,
+                        keyword.as_deref(),
+                        &tag_terms,
+                    );
                 if score == 0 {
                     return None;
                 }
@@ -157,7 +164,11 @@ impl NoNameKnowledgeProvider for GraphKnowledgeProvider {
             })
             .collect::<Vec<_>>();
 
-        snippets.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.document_id.cmp(&b.document_id)));
+        snippets.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| a.document_id.cmp(&b.document_id))
+        });
         snippets.truncate(query.limit);
         snippets
     }
@@ -173,11 +184,7 @@ fn score_document(
     if let Some(keyword) = keyword {
         score += contains_text(&document.title, keyword) as u32 * 5;
         score += contains_text(&document.body, keyword) as u32 * 3;
-        score += document
-            .tags
-            .iter()
-            .any(|tag| contains_text(tag, keyword)) as u32
-            * 2;
+        score += document.tags.iter().any(|tag| contains_text(tag, keyword)) as u32 * 2;
     }
 
     for tag in tags {
@@ -203,11 +210,7 @@ fn score_graph_node(
     if let Some(keyword) = keyword {
         score += contains_text(&node.label, keyword) as u32 * 5;
         score += contains_text(&node.body, keyword) as u32 * 3;
-        score += node
-            .tags
-            .iter()
-            .any(|tag| contains_text(tag, keyword)) as u32
-            * 2;
+        score += node.tags.iter().any(|tag| contains_text(tag, keyword)) as u32 * 2;
     }
 
     for tag in tags {
@@ -234,7 +237,11 @@ fn score_graph_edges(
         .iter()
         .filter(|edge| edge.from == node.node_id || edge.to == node.node_id)
         .map(|edge| {
-            let neighbor_id = if edge.from == node.node_id { &edge.to } else { &edge.from };
+            let neighbor_id = if edge.from == node.node_id {
+                &edge.to
+            } else {
+                &edge.from
+            };
             let neighbor = nodes.iter().find(|item| &item.node_id == neighbor_id);
             let relation_score = keyword
                 .map(|term| contains_text(&edge.relation, term) as u32 * 3)
@@ -276,7 +283,11 @@ fn build_graph_excerpt(
         .filter(|edge| edge.from == node.node_id || edge.to == node.node_id)
         .take(3)
         .filter_map(|edge| {
-            let neighbor_id = if edge.from == node.node_id { &edge.to } else { &edge.from };
+            let neighbor_id = if edge.from == node.node_id {
+                &edge.to
+            } else {
+                &edge.from
+            };
             let neighbor = nodes.iter().find(|item| &item.node_id == neighbor_id)?;
             Some(format!("{}:{}", edge.relation, neighbor.label))
         })

--- a/src-tauri/src/noname_memory_compaction.rs
+++ b/src-tauri/src/noname_memory_compaction.rs
@@ -165,10 +165,7 @@ impl NoNameMemoryCompactionService {
         }
     }
 
-    pub fn compact_chapter(
-        &self,
-        input: NoNameChapterCompactionInput,
-    ) -> NoNameCompactionSummary {
+    pub fn compact_chapter(&self, input: NoNameChapterCompactionInput) -> NoNameCompactionSummary {
         let mut source_ids = Vec::new();
         let mut fragments = Vec::new();
         let mut key_entities = Vec::new();
@@ -447,7 +444,12 @@ mod tests {
                 importance: NoNameMemoryImportance::High,
             }],
             notes: vec![
-                note("note-goal", NoNameNarrativeNoteType::Goal, "Hold Gate", "Keep the gate standing"),
+                note(
+                    "note-goal",
+                    NoNameNarrativeNoteType::Goal,
+                    "Hold Gate",
+                    "Keep the gate standing",
+                ),
                 note(
                     "note-conflict",
                     NoNameNarrativeNoteType::Conflict,
@@ -513,7 +515,10 @@ mod tests {
         assert_eq!(summary.kind, NoNameCompactionKind::Trace);
         assert_eq!(summary.source_ids, vec!["trace-1"]);
         assert!(summary.goals.contains(&"gate crisis".to_string()));
-        assert!(summary.diagnostics.iter().any(|item| item.contains("guardrail=reject")));
+        assert!(summary
+            .diagnostics
+            .iter()
+            .any(|item| item.contains("guardrail=reject")));
         assert!(summary
             .diagnostics
             .iter()

--- a/src-tauri/src/noname_memory_manager.rs
+++ b/src-tauri/src/noname_memory_manager.rs
@@ -108,10 +108,7 @@ impl NoNameMemoryManager {
         self.store.retrieve(query)
     }
 
-    pub fn compact_turn_memory(
-        &self,
-        input: NoNameTurnCompactionInput,
-    ) -> NoNameCompactionSummary {
+    pub fn compact_turn_memory(&self, input: NoNameTurnCompactionInput) -> NoNameCompactionSummary {
         NoNameMemoryCompactionService::new().compact_turn(input)
     }
 

--- a/src-tauri/src/noname_memory_retrieval.rs
+++ b/src-tauri/src/noname_memory_retrieval.rs
@@ -198,7 +198,11 @@ where
 }
 
 fn working_match_score(query: &NoNameMemoryQuery, item: &NoNameWorkingMemoryItem) -> u32 {
-    let content = [item.summary.as_str(), item.category.as_str(), item.source.as_str()];
+    let content = [
+        item.summary.as_str(),
+        item.category.as_str(),
+        item.source.as_str(),
+    ];
     score_text_fields(query, &content)
 }
 
@@ -211,11 +215,21 @@ fn episodic_match_score(query: &NoNameMemoryQuery, item: &NoNameEpisodicMemoryIt
     let location_score = query
         .location
         .as_deref()
-        .map(|location| item.location_id.as_deref().map(|value| contains_text(value, location)).unwrap_or(false) as u32 * 5)
+        .map(|location| {
+            item.location_id
+                .as_deref()
+                .map(|value| contains_text(value, location))
+                .unwrap_or(false) as u32
+                * 5
+        })
         .unwrap_or_default();
     let text_score = score_text_fields(
         query,
-        &[item.summary.as_str(), item.event_type.as_str(), item.detail_ref.as_deref().unwrap_or("")],
+        &[
+            item.summary.as_str(),
+            item.event_type.as_str(),
+            item.detail_ref.as_deref().unwrap_or(""),
+        ],
     );
 
     actor_score + location_score + text_score
@@ -425,7 +439,14 @@ mod tests {
                 2,
                 NoNameMemoryImportance::High,
             )],
-            &[sample_semantic("fact-1", "青河长老", "山门", 85, 4, vec!["防守"])],
+            &[sample_semantic(
+                "fact-1",
+                "青河长老",
+                "山门",
+                85,
+                4,
+                vec!["防守"],
+            )],
             &[sample_narrative(
                 "note-1",
                 "守住山门",
@@ -446,7 +467,10 @@ mod tests {
     fn retrieval_ranks_by_relevance_then_recency_then_importance() {
         let result = retrieve_memories(
             &NoNameMemoryQuery::by_keyword(NoNameRole::CombatNarrator, "交锋", 200, 2),
-            &[sample_working("敌修与玩家激烈交锋", 3), sample_working("普通巡山记录", 9)],
+            &[
+                sample_working("敌修与玩家激烈交锋", 3),
+                sample_working("普通巡山记录", 9),
+            ],
             &[
                 sample_episodic(
                     "episode-old",
@@ -465,7 +489,14 @@ mod tests {
                     NoNameMemoryImportance::Medium,
                 ),
             ],
-            &[sample_semantic("fact-1", "玩家", "山门", 70, 1, vec!["战斗"])],
+            &[sample_semantic(
+                "fact-1",
+                "玩家",
+                "山门",
+                70,
+                1,
+                vec!["战斗"],
+            )],
             &[sample_narrative(
                 "note-1",
                 "山门交锋",
@@ -503,7 +534,14 @@ mod tests {
                 2,
                 NoNameMemoryImportance::Medium,
             )],
-            &[sample_semantic("fact-1", "玩家", "山门", 80, 3, vec!["地点"])],
+            &[sample_semantic(
+                "fact-1",
+                "玩家",
+                "山门",
+                80,
+                3,
+                vec!["地点"],
+            )],
             &[sample_narrative(
                 "note-1",
                 "山门危机",

--- a/src-tauri/src/noname_note_store.rs
+++ b/src-tauri/src/noname_note_store.rs
@@ -73,10 +73,7 @@ impl NoNameNoteStore {
             .collect()
     }
 
-    pub fn list_by_status(
-        &self,
-        status: NoNameNarrativeStatus,
-    ) -> Vec<NoNameNarrativeMemoryItem> {
+    pub fn list_by_status(&self, status: NoNameNarrativeStatus) -> Vec<NoNameNarrativeMemoryItem> {
         self.notes
             .iter()
             .filter(|item| item.status == status)
@@ -157,18 +154,18 @@ impl NoNameNoteStore {
         review
     }
 
-    pub fn review_chapter(
-        &self,
-        chapter_index: u32,
-        updated_at: u64,
-    ) -> NoNameChapterNoteReview {
+    pub fn review_chapter(&self, chapter_index: u32, updated_at: u64) -> NoNameChapterNoteReview {
         let mut review = NoNameChapterNoteReview {
             chapter_index,
             updated_at,
             ..NoNameChapterNoteReview::default()
         };
 
-        for note in self.notes.iter().filter(|item| item.chapter_index == chapter_index) {
+        for note in self
+            .notes
+            .iter()
+            .filter(|item| item.chapter_index == chapter_index)
+        {
             match note.status {
                 NoNameNarrativeStatus::Active => review.active_note_ids.push(note.note_id.clone()),
                 NoNameNarrativeStatus::Resolved | NoNameNarrativeStatus::Archived => {
@@ -275,7 +272,10 @@ mod tests {
 
         let archived = store.archive("note-1", 12).expect("note should archive");
         assert_eq!(archived.status, NoNameNarrativeStatus::Archived);
-        assert_eq!(store.list_by_status(NoNameNarrativeStatus::Archived).len(), 1);
+        assert_eq!(
+            store.list_by_status(NoNameNarrativeStatus::Archived).len(),
+            1
+        );
     }
 
     #[test]

--- a/src-tauri/src/noname_protocol_agent.rs
+++ b/src-tauri/src/noname_protocol_agent.rs
@@ -101,7 +101,9 @@ impl NoNameAgentMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::noname_protocol_types::{NoNameTaskLifecycle, NoNameTaskStatus, NoNameTraceWritable};
+    use crate::noname_protocol_types::{
+        NoNameTaskLifecycle, NoNameTaskStatus, NoNameTraceWritable,
+    };
     use crate::noname_types::{NoNameMode, NoNameRole};
     use serde_json::json;
 

--- a/src-tauri/src/noname_protocol_runtime.rs
+++ b/src-tauri/src/noname_protocol_runtime.rs
@@ -40,8 +40,7 @@ impl NoNameProtocolRuntime {
         message: NoNameAgentMessage,
     ) -> Result<NoNameTaskLifecycle, NoNameError> {
         let next = self.resolve_next_lifecycle(&message.lifecycle, message.kind)?;
-        self.task_states
-            .insert(next.task_id.clone(), next.clone());
+        self.task_states.insert(next.task_id.clone(), next.clone());
         self.agent_history.push(message);
         Ok(next)
     }
@@ -251,8 +250,14 @@ mod tests {
             )
             .expect("tool execution should succeed");
 
-        assert_eq!(envelope.kind, crate::noname_protocol_tool::NoNameToolEnvelopeKind::Result);
-        assert_eq!(envelope.result.as_ref().map(|value| value["echo"].as_str()), Some(Some("ok")));
+        assert_eq!(
+            envelope.kind,
+            crate::noname_protocol_tool::NoNameToolEnvelopeKind::Result
+        );
+        assert_eq!(
+            envelope.result.as_ref().map(|value| value["echo"].as_str()),
+            Some(Some("ok"))
+        );
         assert_eq!(
             runtime.task_state("tool-task-1").map(|state| state.status),
             Some(NoNameTaskStatus::Completed)

--- a/src-tauri/src/noname_protocol_types.rs
+++ b/src-tauri/src/noname_protocol_types.rs
@@ -241,7 +241,13 @@ mod tests {
             .cancelled("operator request")
             .expect("cancel");
 
-        assert_eq!(failed.last_error.as_ref().map(|err| err.code.as_str()), Some("noname.tool.failure"));
-        assert_eq!(cancelled.cancellation_reason.as_deref(), Some("operator request"));
+        assert_eq!(
+            failed.last_error.as_ref().map(|err| err.code.as_str()),
+            Some("noname.tool.failure")
+        );
+        assert_eq!(
+            cancelled.cancellation_reason.as_deref(),
+            Some("operator request")
+        );
     }
 }

--- a/src-tauri/src/noname_roles.rs
+++ b/src-tauri/src/noname_roles.rs
@@ -2,8 +2,8 @@ use crate::noname_capability_registry::NoNameCapabilityRegistry;
 use crate::noname_context_types::NoNameContextPacket;
 use crate::noname_errors::{NoNameError, NoNameErrorKind};
 use crate::noname_prompts::{
-    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID,
-    NPC_INTENT_OBSERVE_PROMPT_ID, WORLD_CURATOR_OBSERVE_PROMPT_ID,
+    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID, NPC_INTENT_OBSERVE_PROMPT_ID,
+    WORLD_CURATOR_OBSERVE_PROMPT_ID,
 };
 use crate::noname_protocol_tool::{NoNamePromptResolve, NoNameResourceRead, NoNameToolCall};
 use crate::noname_protocol_types::{NoNameProtocolHeader, NoNameTraceWritable};
@@ -95,7 +95,10 @@ impl DirectorAgent {
             intended_effect: "为下一轮低风险输出提供稳定导向".to_string(),
             rationale: rationale.clone(),
             suggested_action: Some("保持 observe-only，等待后续 assisted 落地".to_string()),
-            labels: vec![NoNameRole::Director.as_str().to_string(), "observe_only".to_string()],
+            labels: vec![
+                NoNameRole::Director.as_str().to_string(),
+                "observe_only".to_string(),
+            ],
             apply_scopes: vec![
                 NoNameApplyScope::Diagnostics,
                 NoNameApplyScope::ChapterSummaryHint,
@@ -355,7 +358,10 @@ impl CombatNarratorAgent {
                 "observe_only".to_string(),
                 "combat".to_string(),
             ],
-            apply_scopes: vec![NoNameApplyScope::Diagnostics, NoNameApplyScope::PlotTextHint],
+            apply_scopes: vec![
+                NoNameApplyScope::Diagnostics,
+                NoNameApplyScope::PlotTextHint,
+            ],
             status: NoNameProposalStatus::Observed,
             applyable: false,
         };
@@ -372,7 +378,11 @@ impl CombatNarratorAgent {
         })
     }
 
-    fn goal_from_context(&self, context_packet: &NoNameContextPacket, action_summary: &str) -> String {
+    fn goal_from_context(
+        &self,
+        context_packet: &NoNameContextPacket,
+        action_summary: &str,
+    ) -> String {
         self.pick_focus(context_packet, action_summary)
     }
 
@@ -466,13 +476,18 @@ fn first_non_player_character(referenced_entities: &[String]) -> Option<String> 
 }
 
 fn contains_combat_signal(text: &str) -> bool {
-    ["战", "斗", "交手", "冲突", "出招", "杀", "攻"].iter().any(|token| text.contains(token))
+    ["战", "斗", "交手", "冲突", "出招", "杀", "攻"]
+        .iter()
+        .any(|token| text.contains(token))
 }
 
 pub fn unsupported_role_error(role: NoNameRole) -> NoNameError {
     NoNameError::new(
         NoNameErrorKind::Config,
-        format!("role {} is not registered for observe dispatch", role.as_str()),
+        format!(
+            "role {} is not registered for observe dispatch",
+            role.as_str()
+        ),
         "noname.agent.unsupported_role",
         true,
     )
@@ -491,9 +506,15 @@ mod tests {
     fn sample_packet(role: NoNameRole) -> NoNameContextPacket {
         NoNameContextPacket {
             role,
-            hard_facts: vec!["玩家 位于 山门".to_string(), "山门受宗门法阵保护".to_string()],
+            hard_facts: vec![
+                "玩家 位于 山门".to_string(),
+                "山门受宗门法阵保护".to_string(),
+            ],
             working_memory: vec!["玩家刚刚选择回到山门".to_string()],
-            episodic_memory: vec!["玩家返回山门".to_string(), "执事长老抬手示意弟子退后".to_string()],
+            episodic_memory: vec![
+                "玩家返回山门".to_string(),
+                "执事长老抬手示意弟子退后".to_string(),
+            ],
             narrative_notes: vec!["山门危机: 强敌逼近".to_string()],
             chapter_summaries: vec!["第一章: 危机渐近".to_string()],
             recent_context: vec!["敌修拔剑逼近，山门弟子列阵应对".to_string()],

--- a/src-tauri/src/noname_runtime.rs
+++ b/src-tauri/src/noname_runtime.rs
@@ -493,7 +493,12 @@ impl NoNameRuntime {
                 scope.as_str(),
                 controlled_output_decision_key(review.decision)
             ));
-            trace.record_controlled_output_review(kind, policy_forbidden_scopes.clone(), review);
+            trace.record_controlled_output_review(
+                Some(proposal.proposal_id.clone()),
+                kind,
+                policy_forbidden_scopes.clone(),
+                review,
+            );
             review_count += 1;
         }
 

--- a/src-tauri/src/noname_tools.rs
+++ b/src-tauri/src/noname_tools.rs
@@ -4,13 +4,13 @@ use crate::noname_capability_base::{
 };
 use crate::noname_capability_registry::NoNameCapabilityRegistry;
 use crate::noname_context_types::NoNameContextPacket;
+use crate::noname_prompt_catalog::NoNamePromptTemplate;
 use crate::noname_prompts::{
     combat_narrator_observe_prompt_template, director_observe_prompt_template,
     npc_intent_observe_prompt_template, world_curator_observe_prompt_template,
-    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID,
-    NPC_INTENT_OBSERVE_PROMPT_ID, WORLD_CURATOR_OBSERVE_PROMPT_ID,
+    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID, NPC_INTENT_OBSERVE_PROMPT_ID,
+    WORLD_CURATOR_OBSERVE_PROMPT_ID,
 };
-use crate::noname_prompt_catalog::NoNamePromptTemplate;
 use crate::noname_resources::NoNameResourceDocument;
 use serde_json::json;
 

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -52,6 +52,8 @@ pub struct NoNameApplyPlanRecord {
 #[serde(rename_all = "camelCase")]
 pub struct NoNameControlledOutputReviewRecord {
     pub request_id: String,
+    #[serde(default)]
+    pub proposal_id: Option<String>,
     pub requested_kind: NoNameControlledOutputKind,
     pub decision: NoNameControlledOutputDecision,
     pub reason: String,
@@ -277,6 +279,7 @@ impl NoNameTrace {
 
     pub fn record_controlled_output_review(
         &mut self,
+        proposal_id: Option<String>,
         requested_kind: NoNameControlledOutputKind,
         policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
         review: NoNameControlledOutputReview,
@@ -284,6 +287,7 @@ impl NoNameTrace {
         self.controlled_output_reviews
             .push(NoNameControlledOutputReviewRecord {
                 request_id: review.request_id,
+                proposal_id,
                 requested_kind,
                 decision: review.decision,
                 reason: review.reason,
@@ -499,6 +503,7 @@ mod tests {
     fn controlled_output_review_can_be_recorded() {
         let mut trace = NoNameTrace::empty("trace-1", "session-1", "turn-1", NoNameMode::Assisted);
         trace.record_controlled_output_review(
+            Some("proposal-1".to_string()),
             NoNameControlledOutputKind::SceneAugmentation,
             vec![NoNameForbiddenOutputScope::CombatOutcome],
             NoNameControlledOutputReview {
@@ -512,6 +517,10 @@ mod tests {
         );
 
         assert_eq!(trace.controlled_output_reviews.len(), 1);
+        assert_eq!(
+            trace.controlled_output_reviews[0].proposal_id.as_deref(),
+            Some("proposal-1")
+        );
         assert_eq!(
             trace.controlled_output_reviews[0].decision,
             NoNameControlledOutputDecision::NeedsReview

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -60,6 +60,56 @@ pub struct NoNameControlledOutputReviewRecord {
     #[serde(default)]
     pub policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
     pub requires_human_review: bool,
+    #[serde(default)]
+    pub human_review_decision: Option<NoNameHumanReviewDecision>,
+    #[serde(default)]
+    pub human_reviewed_at: Option<u64>,
+    #[serde(default)]
+    pub human_review_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NoNameHumanReviewDecision {
+    Pending,
+    ApprovedForHigherApply,
+    RejectedForHigherApply,
+}
+
+impl NoNameHumanReviewDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::ApprovedForHigherApply => "approved_for_higher_apply",
+            Self::RejectedForHigherApply => "rejected_for_higher_apply",
+        }
+    }
+
+    pub fn note(self) -> &'static str {
+        match self {
+            Self::Pending => "人工复核已重置为待确认，未触发高层 apply",
+            Self::ApprovedForHigherApply => "人工确认可进入高层 apply 设计，仍需后端二次 guardrail",
+            Self::RejectedForHigherApply => "人工确认暂不应用，保持当前安全边界",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NoNameSecondGuardrailDecision {
+    Allow,
+    Reject,
+    Fallback,
+}
+
+impl NoNameSecondGuardrailDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Reject => "reject",
+            Self::Fallback => "fallback",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -241,6 +291,9 @@ impl NoNameTrace {
                 safe_apply_scope: review.safe_apply_scope,
                 policy_forbidden_scopes,
                 requires_human_review: review.requires_human_review,
+                human_review_decision: None,
+                human_reviewed_at: None,
+                human_review_note: None,
             });
     }
 

--- a/src-tauri/src/save_load.rs
+++ b/src-tauri/src/save_load.rs
@@ -611,8 +611,10 @@ mod tests {
         let system = SaveLoadSystem::with_directory(temp_dir.path().to_path_buf());
 
         let game_state = create_test_game_state();
-        let save_data = SaveData::from_game_state(game_state)
-            .with_noname_settings(NoNameSaveSettings { mode: NoNameMode::Assisted });
+        let save_data =
+            SaveData::from_game_state(game_state).with_noname_settings(NoNameSaveSettings {
+                mode: NoNameMode::Assisted,
+            });
         system.save_game(1, &save_data).unwrap();
 
         let saves = system.list_saves().unwrap();

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -7430,6 +7430,7 @@ mod tests {
             applyable: true,
         });
         trace.record_controlled_output_review(
+            Some("proposal-review".to_string()),
             crate::noname_output_interface::NoNameControlledOutputKind::SceneAugmentation,
             vec![crate::noname_output_interface::NoNameForbiddenOutputScope::FinalPlotState],
             crate::noname_output_interface::NoNameControlledOutputReview {

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -14,14 +14,19 @@ use crate::llm_runtime_config::{
 };
 use crate::llm_service::{LLMConfig, LLMRequest, LLMService};
 use crate::memory_layers::{ChapterSummary, MemoryEntry, WorldFact};
+use crate::noname_apply::{
+    apply_reviewed_output_to_plot_state, NoNameApplyDiagnosticsSnapshot,
+    NoNameApplySegmentSnapshot, NoNameApplySummarySnapshot, NoNameReviewedApplyRequest,
+};
 use crate::noname_config::NoNameConfig;
 use crate::noname_context_builder::build_context_packet;
 use crate::noname_context_types::NoNameContextBuildInput;
 use crate::noname_guardrails::{NoNameDirectorGuardrailInput, NoNameGuardrailResult};
 use crate::noname_memory_manager::NoNameMemoryManager;
+use crate::noname_output_interface::NoNameControlledOutputDecision;
 use crate::noname_roles::NoNameDirectorObservation;
 use crate::noname_runtime::{NoNameDirectorRunResult, NoNameRuntime, NoNameTurnInput};
-use crate::noname_trace::NoNameTrace;
+use crate::noname_trace::{NoNameHumanReviewDecision, NoNameSecondGuardrailDecision, NoNameTrace};
 use crate::noname_types::{NoNameApplyScope, NoNameMode, NoNameRole, NoNameTargetSegment};
 use crate::novel_generator::{Novel, NovelGenerator};
 use crate::numerical_system::{Action, Context, StatChange};
@@ -201,6 +206,13 @@ struct NoNameApplyTargetPlan {
     priority: u32,
     order: u32,
     decision: NoNameApplyTargetDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoNameManualPlotTextApplyResult {
+    pub trace: NoNameTrace,
+    pub plot_state: PlotState,
 }
 
 fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
@@ -401,6 +413,400 @@ fn record_noname_apply_plan_and_skip_execution(
     if let NoNameApplyTargetDecision::Skip { outcome, note } = &plan.decision {
         trace.record_apply_execution(plan.target, *outcome, Some(note.clone()));
     }
+}
+
+fn next_noname_apply_plan_order(trace: &NoNameTrace) -> u32 {
+    trace
+        .apply_plan_log
+        .iter()
+        .map(|item| item.order)
+        .max()
+        .unwrap_or_default()
+        + 1
+}
+
+fn find_review_proposal<'a>(
+    trace: &'a NoNameTrace,
+    request_id: &str,
+) -> Option<&'a crate::noname_types::NoNameProposal> {
+    trace
+        .proposals
+        .iter()
+        .rev()
+        .find(|proposal| request_id.contains(&proposal.proposal_id))
+        .or_else(|| trace.proposals.last())
+}
+
+fn record_noname_human_review_apply_intent(
+    trace: &mut NoNameTrace,
+    request_id: &str,
+    decision: NoNameHumanReviewDecision,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) {
+    let target = safe_apply_scope
+        .map(|scope| scope.as_str())
+        .unwrap_or("controlled_output");
+    let order = next_noname_apply_plan_order(trace);
+    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 25;
+
+    match decision {
+        NoNameHumanReviewDecision::Pending => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "review_intent_pending",
+                priority,
+                Some("人工复核已重置为待确认，未进入二次 guardrail".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "human_review_pending",
+                Some("等待人工确认，不触发高层 apply".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:apply_intent:pending", request_id));
+        }
+        NoNameHumanReviewDecision::RejectedForHigherApply => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "reject",
+                priority,
+                Some("人工复核拒绝进入高层 apply，保持安全边界".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "rejected_by_human_review",
+                Some("开发者选择暂不应用，未触发二次 guardrail".to_string()),
+            );
+            trace.record_proposal_transition(format!(
+                "{}:apply_intent:rejected_by_human_review",
+                request_id
+            ));
+        }
+        NoNameHumanReviewDecision::ApprovedForHigherApply => {
+            let rejection_reason = if trace.mode != NoNameMode::Assisted {
+                Some("当前 trace 不是 assisted 模式，拒绝进入高层 apply intent".to_string())
+            } else if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+                Some(format!(
+                    "当前仅允许 plot_text_hint 进入人工确认后的二次 guardrail，实际作用域为 {}",
+                    target
+                ))
+            } else {
+                match find_review_proposal(trace, request_id) {
+                    Some(proposal)
+                        if proposal.status
+                            == crate::noname_types::NoNameProposalStatus::Applied
+                            && proposal.applyable
+                            && target_segment_supports_apply_scope(
+                                proposal.target_segment,
+                                NoNameApplyScope::PlotTextHint,
+                            ) =>
+                    {
+                        None
+                    }
+                    Some(proposal)
+                        if proposal.status
+                            != crate::noname_types::NoNameProposalStatus::Applied
+                            || !proposal.applyable =>
+                    {
+                        Some(format!(
+                            "proposal 状态为 {} / applyable={}，拒绝进入高层 apply intent",
+                            proposal.status.as_str(),
+                            proposal.applyable
+                        ))
+                    }
+                    Some(proposal) => Some(format!(
+                        "target_segment={} 不支持 plot_text_hint 二次 apply",
+                        proposal.target_segment.as_str()
+                    )),
+                    None => {
+                        Some("未找到 review 对应 proposal，拒绝进入高层 apply intent".to_string())
+                    }
+                }
+            };
+
+            if let Some(reason) = rejection_reason {
+                trace.record_apply_plan(
+                    order,
+                    target,
+                    "second_guardrail_reject",
+                    priority,
+                    Some(reason.clone()),
+                );
+                trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason));
+                trace.record_proposal_transition(format!(
+                    "{}:apply_intent:second_guardrail_rejected",
+                    request_id
+                ));
+                return;
+            }
+
+            trace.record_apply_plan(
+                order,
+                target,
+                "review_intent_ready",
+                priority,
+                Some(
+                    "人工确认已通过，已排入二次 guardrail / apply planner，未写入正文".to_string(),
+                ),
+            );
+            trace.record_apply_execution(
+                target,
+                "awaiting_second_guardrail",
+                Some("高层 apply intent 已记录，等待后续二次 guardrail 决策".to_string()),
+            );
+            trace.record_proposal_transition(format!(
+                "{}:apply_intent:awaiting_second_guardrail",
+                request_id
+            ));
+        }
+    }
+}
+
+fn review_is_waiting_for_second_guardrail(trace: &NoNameTrace, request_id: &str) -> bool {
+    let transition = format!("{}:apply_intent:awaiting_second_guardrail", request_id);
+    trace
+        .proposal_transition_log
+        .iter()
+        .any(|entry| entry == &transition)
+        || trace.apply_execution_log.iter().any(|entry| {
+            entry.outcome == "awaiting_second_guardrail"
+                && entry.target == NoNameApplyScope::PlotTextHint.as_str()
+        })
+}
+
+fn second_guardrail_revalidation_reason(
+    trace: &NoNameTrace,
+    request_id: &str,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) -> Option<String> {
+    if trace.mode != NoNameMode::Assisted {
+        return Some("当前 trace 不是 assisted 模式，二次 guardrail 拒绝".to_string());
+    }
+    if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+        return Some("当前二次 guardrail 只允许处理 plot_text_hint".to_string());
+    }
+    if !review_is_waiting_for_second_guardrail(trace, request_id) {
+        return Some("review 尚未进入 awaiting_second_guardrail 队列".to_string());
+    }
+
+    match find_review_proposal(trace, request_id) {
+        Some(proposal)
+            if proposal.status == crate::noname_types::NoNameProposalStatus::Applied
+                && proposal.applyable
+                && target_segment_supports_apply_scope(
+                    proposal.target_segment,
+                    NoNameApplyScope::PlotTextHint,
+                ) =>
+        {
+            None
+        }
+        Some(proposal)
+            if proposal.status != crate::noname_types::NoNameProposalStatus::Applied
+                || !proposal.applyable =>
+        {
+            Some(format!(
+                "proposal 状态为 {} / applyable={}，二次 guardrail 拒绝",
+                proposal.status.as_str(),
+                proposal.applyable
+            ))
+        }
+        Some(proposal) => Some(format!(
+            "target_segment={} 不支持 plot_text_hint 二次 guardrail",
+            proposal.target_segment.as_str()
+        )),
+        None => Some("未找到 review 对应 proposal，二次 guardrail 拒绝".to_string()),
+    }
+}
+
+fn record_noname_second_guardrail_decision(
+    trace: &mut NoNameTrace,
+    request_id: &str,
+    decision: NoNameSecondGuardrailDecision,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) -> Result<(), String> {
+    let target = safe_apply_scope
+        .map(|scope| scope.as_str())
+        .unwrap_or("controlled_output");
+    let order = next_noname_apply_plan_order(trace);
+    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 50;
+    let revalidation_reason =
+        second_guardrail_revalidation_reason(trace, request_id, safe_apply_scope);
+
+    if let Some(reason) = revalidation_reason {
+        trace.record_apply_plan(
+            order,
+            target,
+            "second_guardrail_reject",
+            priority,
+            Some(reason.clone()),
+        );
+        trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason.clone()));
+        trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
+        trace.set_apply_result(true, "second_guardrail_reject", Some(reason));
+        return Ok(());
+    }
+
+    match decision {
+        NoNameSecondGuardrailDecision::Allow => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_allow",
+                priority,
+                Some("二次 guardrail 允许进入后续人工 apply 命令；当前不写正文".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_allowed",
+                Some("已允许进入下一步人工 apply，但未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:allow", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_allow",
+                Some("二次 guardrail 已允许；等待显式人工 apply 命令".to_string()),
+            );
+        }
+        NoNameSecondGuardrailDecision::Reject => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_reject",
+                priority,
+                Some("二次 guardrail 人工拒绝高层 apply".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_rejected",
+                Some("二次 guardrail 决策为拒绝，未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_reject",
+                Some("二次 guardrail 已拒绝高层 apply".to_string()),
+            );
+        }
+        NoNameSecondGuardrailDecision::Fallback => {
+            trace.push_stage(crate::noname_types::NoNameTraceStage::ApplyFallback);
+            trace.fallback_used = true;
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_fallback",
+                priority,
+                Some("二次 guardrail 要求回退经典链路".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_fallback",
+                Some("已记录回退决策，未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:fallback", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_fallback",
+                Some("二次 guardrail 决策为 fallback，继续依赖经典链路".to_string()),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_noname_manual_plot_text_hint_to_plot_state(
+    trace: NoNameTrace,
+    request_id: &str,
+    plot_state: PlotState,
+    chapter_index: u32,
+    segment_index: usize,
+    expected_segment_text: &str,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let outcome = apply_reviewed_output_to_plot_state(
+        trace,
+        NoNameReviewedApplyRequest {
+            request_id: request_id.to_string(),
+            scope: NoNameApplyScope::PlotTextHint,
+            segment_snapshot: Some(NoNameApplySegmentSnapshot {
+                chapter_index,
+                segment_index,
+                expected_segment_text: expected_segment_text.to_string(),
+            }),
+            summary_snapshot: None,
+            diagnostics_snapshot: None,
+        },
+        plot_state,
+    )?;
+    Ok(NoNameManualPlotTextApplyResult {
+        trace: outcome.trace,
+        plot_state: outcome.plot_state,
+    })
+}
+
+fn build_noname_reviewed_apply_request(
+    request_id: String,
+    scope: NoNameApplyScope,
+    chapter_index: Option<u32>,
+    segment_index: Option<usize>,
+    expected_segment_text: Option<String>,
+    expected_summary: Option<String>,
+    expected_generation_diagnostics: Option<String>,
+) -> Result<NoNameReviewedApplyRequest, String> {
+    let segment_snapshot = match scope {
+        NoNameApplyScope::PlotTextHint => Some(NoNameApplySegmentSnapshot {
+            chapter_index: chapter_index
+                .ok_or_else(|| "plot_text_hint manual apply requires chapter_index".to_string())?,
+            segment_index: segment_index
+                .ok_or_else(|| "plot_text_hint manual apply requires segment_index".to_string())?,
+            expected_segment_text: expected_segment_text.ok_or_else(|| {
+                "plot_text_hint manual apply requires expected_segment_text".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+    let summary_snapshot = match scope {
+        NoNameApplyScope::ChapterSummaryHint => Some(NoNameApplySummarySnapshot {
+            chapter_index: chapter_index.ok_or_else(|| {
+                "chapter_summary_hint manual apply requires chapter_index".to_string()
+            })?,
+            expected_summary: expected_summary.ok_or_else(|| {
+                "chapter_summary_hint manual apply requires expected_summary".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+    let diagnostics_snapshot = match scope {
+        NoNameApplyScope::OptionBiasHint => Some(NoNameApplyDiagnosticsSnapshot {
+            chapter_index: chapter_index.ok_or_else(|| {
+                "option_bias_hint manual apply requires chapter_index".to_string()
+            })?,
+            expected_generation_diagnostics: expected_generation_diagnostics.ok_or_else(|| {
+                "option_bias_hint manual apply requires expected_generation_diagnostics".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+
+    Ok(NoNameReviewedApplyRequest {
+        request_id,
+        scope,
+        segment_snapshot,
+        summary_snapshot,
+        diagnostics_snapshot,
+    })
+}
+
+fn apply_noname_reviewed_output_to_plot_state(
+    trace: NoNameTrace,
+    request: NoNameReviewedApplyRequest,
+    plot_state: PlotState,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let outcome = apply_reviewed_output_to_plot_state(trace, request, plot_state)?;
+    Ok(NoNameManualPlotTextApplyResult {
+        trace: outcome.trace,
+        plot_state: outcome.plot_state,
+    })
 }
 
 fn apply_noname_plot_text_hint(
@@ -648,6 +1054,23 @@ fn run_noname_observe_only_for_turn(
         .map_err(|e| e.to_string())?;
 
     Ok(result)
+}
+
+fn maybe_run_noname_for_turn(
+    action_summary: &str,
+    game_state: &GameState,
+    plot_state: &PlotState,
+    timestamp: u64,
+) -> Option<NoNameDirectorRunResult> {
+    let mode = noname_runtime()
+        .lock()
+        .map(|runtime| runtime.mode())
+        .unwrap_or(NoNameMode::Disabled);
+    if !mode.is_enabled() {
+        return None;
+    }
+
+    run_noname_observe_only_for_turn(action_summary, game_state, plot_state, timestamp).ok()
 }
 
 fn build_plot_context_for_generation(
@@ -3668,13 +4091,8 @@ pub async fn execute_player_action(
     plot_state.last_action_result = Some(action_result.clone());
     let plot_text_for_history = plot_update.plot_text.clone();
     let mut plot_text_for_player = plot_update.plot_text.clone();
-    let mut noname_result = run_noname_observe_only_for_turn(
-        &noname_action_summary,
-        &game_state,
-        &plot_state,
-        timestamp,
-    )
-    .ok();
+    let mut noname_result =
+        maybe_run_noname_for_turn(&noname_action_summary, &game_state, &plot_state, timestamp);
     let mut noname_plot_text_applied = false;
     if let Some(result) = noname_result.as_mut() {
         let plans = build_noname_apply_plan_set(
@@ -4006,6 +4424,215 @@ pub async fn clear_noname_recent_traces() -> Result<(), String> {
         .map_err(|_| "NoName runtime lock poisoned".to_string())?;
     runtime.clear_traces();
     Ok(())
+}
+
+#[tauri::command]
+pub async fn mark_noname_controlled_output_review(
+    trace_id: String,
+    request_id: String,
+    decision: NoNameHumanReviewDecision,
+) -> Result<NoNameTrace, String> {
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    let mut trace = runtime
+        .get_recent_traces()
+        .into_iter()
+        .rev()
+        .find(|trace| trace.trace_id == trace_id)
+        .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?;
+
+    let reviewed_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let safe_apply_scope = {
+        let review = trace
+            .controlled_output_reviews
+            .iter_mut()
+            .find(|review| review.request_id == request_id)
+            .ok_or_else(|| format!("NoName controlled output review not found: {}", request_id))?;
+
+        if review.decision != NoNameControlledOutputDecision::NeedsReview
+            || !review.requires_human_review
+        {
+            return Err(format!(
+                "NoName controlled output review does not require human review: {}",
+                request_id
+            ));
+        }
+
+        review.human_review_decision = Some(decision);
+        review.human_reviewed_at = Some(reviewed_at);
+        review.human_review_note = Some(decision.note().to_string());
+        review.safe_apply_scope
+    };
+
+    if safe_apply_scope.is_none() {
+        return Err(format!(
+            "NoName controlled output review has no safe apply scope: {}",
+            request_id
+        ));
+    }
+
+    trace.record_proposal_transition(format!("{}:human_review:{}", request_id, decision.as_str()));
+    record_noname_human_review_apply_intent(&mut trace, &request_id, decision, safe_apply_scope);
+
+    if !runtime.replace_trace(trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(trace)
+}
+
+#[tauri::command]
+pub async fn resolve_noname_second_guardrail(
+    trace_id: String,
+    request_id: String,
+    decision: NoNameSecondGuardrailDecision,
+) -> Result<NoNameTrace, String> {
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    let mut trace = runtime
+        .get_recent_traces()
+        .into_iter()
+        .rev()
+        .find(|trace| trace.trace_id == trace_id)
+        .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?;
+
+    let safe_apply_scope = {
+        let review = trace
+            .controlled_output_reviews
+            .iter()
+            .find(|review| review.request_id == request_id)
+            .ok_or_else(|| format!("NoName controlled output review not found: {}", request_id))?;
+
+        if review.human_review_decision != Some(NoNameHumanReviewDecision::ApprovedForHigherApply) {
+            return Err(format!(
+                "NoName controlled output review is not approved for second guardrail: {}",
+                request_id
+            ));
+        }
+
+        review.safe_apply_scope
+    };
+
+    record_noname_second_guardrail_decision(&mut trace, &request_id, decision, safe_apply_scope)?;
+
+    if !runtime.replace_trace(trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(trace)
+}
+
+#[tauri::command]
+pub async fn apply_noname_manual_plot_text_hint(
+    trace_id: String,
+    request_id: String,
+    chapter_index: u32,
+    segment_index: usize,
+    expected_segment_text: String,
+    engine: State<'_, Mutex<GameEngine>>,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let trace = {
+        let runtime = noname_runtime()
+            .lock()
+            .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+        runtime
+            .get_recent_traces()
+            .into_iter()
+            .rev()
+            .find(|trace| trace.trace_id == trace_id)
+            .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?
+    };
+
+    let result = {
+        let engine = match engine.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
+        let result = apply_noname_manual_plot_text_hint_to_plot_state(
+            trace,
+            &request_id,
+            plot_state,
+            chapter_index,
+            segment_index,
+            &expected_segment_text,
+        )?;
+        engine
+            .update_plot_state(result.plot_state.clone())
+            .map_err(|e| e.to_string())?;
+        result
+    };
+
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    if !runtime.replace_trace(result.trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(result)
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn apply_noname_reviewed_output(
+    trace_id: String,
+    request_id: String,
+    scope: NoNameApplyScope,
+    chapter_index: Option<u32>,
+    segment_index: Option<usize>,
+    expected_segment_text: Option<String>,
+    expected_summary: Option<String>,
+    expected_generation_diagnostics: Option<String>,
+    engine: State<'_, Mutex<GameEngine>>,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let request = build_noname_reviewed_apply_request(
+        request_id,
+        scope,
+        chapter_index,
+        segment_index,
+        expected_segment_text,
+        expected_summary,
+        expected_generation_diagnostics,
+    )?;
+    let trace = {
+        let runtime = noname_runtime()
+            .lock()
+            .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+        runtime
+            .get_recent_traces()
+            .into_iter()
+            .rev()
+            .find(|trace| trace.trace_id == trace_id)
+            .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?
+    };
+
+    let result = {
+        let engine = match engine.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
+        let result = apply_noname_reviewed_output_to_plot_state(trace, request, plot_state)?;
+        engine
+            .update_plot_state(result.plot_state.clone())
+            .map_err(|e| e.to_string())?;
+        result
+    };
+
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    if !runtime.replace_trace(result.trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(result)
 }
 
 #[tauri::command]
@@ -4710,6 +5337,7 @@ mod tests {
     use crate::event_log::{EventImportance, GameEvent};
     use crate::models::{CultivationRealm, Element, Grade, SpiritualRoot};
     use crate::script::{InitialState, Location, ScriptType, WorldSetting};
+    use std::sync::{Mutex as TestMutex, OnceLock as TestOnceLock};
     use tempfile::tempdir;
 
     fn create_test_script() -> Script {
@@ -4744,6 +5372,35 @@ mod tests {
             world_setting,
             initial_state,
         )
+    }
+
+    fn noname_mode_matrix_lock() -> &'static TestMutex<()> {
+        static LOCK: TestOnceLock<TestMutex<()>> = TestOnceLock::new();
+        LOCK.get_or_init(|| TestMutex::new(()))
+    }
+
+    fn reset_noname_runtime_for_mode_test(mode: NoNameMode) {
+        let mut runtime = noname_runtime()
+            .lock()
+            .expect("noname runtime lock should be available");
+        runtime.set_mode(mode);
+        runtime.clear_traces();
+    }
+
+    fn create_noname_mode_fixture() -> (GameState, PlotState) {
+        let mut engine = GameEngine::new();
+        let script = create_test_script();
+        let game_state = engine
+            .initialize_game(script)
+            .expect("test game should initialize");
+        let plot_state = engine
+            .initialize_plot_with_opening(
+                "山门风声渐紧，灵气沿石阶回荡。".to_string(),
+                Some(vec![make_option(0, "返回山门广场")]),
+            )
+            .expect("test plot should initialize");
+
+        (game_state, plot_state)
     }
 
     #[test]
@@ -6618,6 +7275,301 @@ mod tests {
         assert!(text.contains("applyable=no"));
         assert!(text.contains("guardrail=accept"));
         assert!(text.contains("apply=skipped_observe_only"));
+    }
+
+    #[test]
+    fn test_t7_mode_matrix_disabled_skips_noname_turn() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::Disabled);
+        let (game_state, plot_state) = create_noname_mode_fixture();
+
+        let result =
+            maybe_run_noname_for_turn("自由输入: 观察山门灵气", &game_state, &plot_state, 10);
+
+        assert!(result.is_none());
+        assert!(noname_runtime()
+            .lock()
+            .expect("noname runtime lock should be available")
+            .get_recent_traces()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_t7_mode_matrix_observe_only_records_without_apply() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::ObserveOnly);
+        let (game_state, plot_state) = create_noname_mode_fixture();
+        let mut plot_state_after = plot_state.clone();
+
+        let mut result =
+            maybe_run_noname_for_turn("自由输入: 观察山门灵气", &game_state, &plot_state, 11)
+                .expect("observe-only should produce a NoName observation");
+        apply_noname_low_risk_outputs(&mut plot_state_after, &mut result, false);
+        append_noname_observation_diagnostics(
+            &mut plot_state_after.last_generation_diagnostics,
+            result.trace.mode,
+            &result.observation,
+            result.guardrail_result.as_ref(),
+            &result.trace,
+        );
+
+        assert_eq!(
+            result.proposal.status,
+            crate::noname_types::NoNameProposalStatus::Observed
+        );
+        assert!(!result.proposal.applyable);
+        assert!(result.trace.controlled_output_reviews.is_empty());
+        assert_eq!(
+            result
+                .trace
+                .apply_result
+                .as_ref()
+                .map(|item| item.outcome.as_str()),
+            Some("skipped_observe_only")
+        );
+        assert!(!plot_state_after
+            .current_chapter
+            .summary
+            .contains("NoName提示"));
+        let diagnostics = plot_state_after
+            .last_generation_diagnostics
+            .as_deref()
+            .unwrap_or_default();
+        assert!(diagnostics.contains("NoName.observe_only"));
+        assert!(diagnostics.contains("proposal_status=observed"));
+        assert!(diagnostics.contains("apply=skipped_observe_only"));
+    }
+
+    #[test]
+    fn test_t7_mode_matrix_assisted_records_review_and_low_risk_apply() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::Assisted);
+        let (game_state, plot_state) = create_noname_mode_fixture();
+        let mut plot_state_after = plot_state.clone();
+
+        let mut result =
+            maybe_run_noname_for_turn("自由输入: 观察山门灵气", &game_state, &plot_state, 12)
+                .expect("assisted should produce a NoName observation");
+        apply_noname_low_risk_outputs(&mut plot_state_after, &mut result, false);
+        append_noname_observation_diagnostics(
+            &mut plot_state_after.last_generation_diagnostics,
+            result.trace.mode,
+            &result.observation,
+            result.guardrail_result.as_ref(),
+            &result.trace,
+        );
+
+        assert_eq!(
+            result.proposal.status,
+            crate::noname_types::NoNameProposalStatus::Applied
+        );
+        assert!(result.proposal.applyable);
+        assert_eq!(result.trace.controlled_output_reviews.len(), 4);
+        assert!(result
+            .trace
+            .controlled_output_reviews
+            .iter()
+            .any(|review| review.requires_human_review));
+        assert!(plot_state_after
+            .current_chapter
+            .summary
+            .contains("NoName提示"));
+        let diagnostics = plot_state_after
+            .last_generation_diagnostics
+            .as_deref()
+            .unwrap_or_default();
+        assert!(diagnostics.contains("NoName选项偏置"));
+        assert!(diagnostics.contains("NoName.assisted"));
+        assert!(diagnostics.contains("proposal_status=applied"));
+        assert!(diagnostics.contains("apply=applied_scoped_outputs"));
+        assert!(result
+            .trace
+            .apply_execution_log
+            .iter()
+            .any(|item| item.target == "chapter_summary_hint" && item.outcome == "applied"));
+        assert!(result
+            .trace
+            .apply_execution_log
+            .iter()
+            .any(|item| item.target == "option_bias_hint" && item.outcome == "applied"));
+    }
+
+    #[tokio::test]
+    async fn test_mark_noname_controlled_output_review_records_human_intent() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::Assisted);
+
+        let mut trace = NoNameTrace::empty(
+            "trace-review-1",
+            "session-1",
+            "turn-1",
+            NoNameMode::Assisted,
+        );
+        trace.record_proposal(crate::noname_types::NoNameProposal {
+            proposal_id: "proposal-review".to_string(),
+            kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "Director提案：山门危机".to_string(),
+            summary: "建议优先观察山门危机".to_string(),
+            focus: "山门危机".to_string(),
+            target_segment: crate::noname_types::NoNameTargetSegment::CurrentTurnTail,
+            intended_effect: "为下一轮低风险输出提供导向".to_string(),
+            rationale: "当前章节冲突正在汇聚".to_string(),
+            suggested_action: Some("进入人工确认后的二次 guardrail".to_string()),
+            labels: vec!["director".to_string(), "apply_preflight_ready".to_string()],
+            apply_scopes: vec![crate::noname_types::NoNameApplyScope::PlotTextHint],
+            status: crate::noname_types::NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            crate::noname_output_interface::NoNameControlledOutputKind::SceneAugmentation,
+            vec![crate::noname_output_interface::NoNameForbiddenOutputScope::FinalPlotState],
+            crate::noname_output_interface::NoNameControlledOutputReview {
+                request_id: "controlled-output-proposal-review-plot_text_hint".to_string(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "plot text hint requires human review".to_string(),
+                normalized_kind: Some(
+                    crate::noname_output_interface::NoNameControlledOutputKind::SceneAugmentation,
+                ),
+                safe_apply_scope: Some(crate::noname_types::NoNameApplyScope::PlotTextHint),
+                requires_human_review: true,
+            },
+        );
+
+        noname_runtime()
+            .lock()
+            .expect("noname runtime lock should be available")
+            .store_trace(trace)
+            .expect("trace should be stored");
+
+        let updated = mark_noname_controlled_output_review(
+            "trace-review-1".to_string(),
+            "controlled-output-proposal-review-plot_text_hint".to_string(),
+            NoNameHumanReviewDecision::ApprovedForHigherApply,
+        )
+        .await
+        .expect("review intent should be recorded");
+
+        let review = updated
+            .controlled_output_reviews
+            .iter()
+            .find(|item| item.request_id == "controlled-output-proposal-review-plot_text_hint")
+            .expect("review should exist");
+        assert_eq!(
+            review.human_review_decision,
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply)
+        );
+        assert!(review.human_reviewed_at.is_some());
+        assert!(review
+            .human_review_note
+            .as_ref()
+            .is_some_and(|note| note.contains("二次 guardrail")));
+        assert!(updated
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry
+                == "controlled-output-proposal-review-plot_text_hint:human_review:approved_for_higher_apply"));
+        assert!(updated.apply_plan_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.decision == "review_intent_ready"
+        }));
+        assert!(updated.apply_execution_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.outcome == "awaiting_second_guardrail"
+        }));
+        assert!(updated.proposal_transition_log.iter().any(|entry| entry
+            == "controlled-output-proposal-review-plot_text_hint:apply_intent:awaiting_second_guardrail"));
+        assert_eq!(
+            noname_runtime()
+                .lock()
+                .expect("noname runtime lock should be available")
+                .get_recent_traces()[0]
+                .controlled_output_reviews[0]
+                .human_review_decision,
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply)
+        );
+
+        let resolved = resolve_noname_second_guardrail(
+            "trace-review-1".to_string(),
+            "controlled-output-proposal-review-plot_text_hint".to_string(),
+            NoNameSecondGuardrailDecision::Allow,
+        )
+        .await
+        .expect("second guardrail should resolve");
+
+        assert!(resolved.apply_plan_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.decision == "second_guardrail_allow"
+        }));
+        assert!(resolved.apply_execution_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.outcome == "second_guardrail_allowed"
+        }));
+        assert!(resolved.proposal_transition_log.iter().any(|entry| {
+            entry == "controlled-output-proposal-review-plot_text_hint:second_guardrail:allow"
+        }));
+        assert_eq!(
+            resolved
+                .apply_result
+                .as_ref()
+                .map(|item| item.outcome.as_str()),
+            Some("second_guardrail_allow")
+        );
+
+        let plot_state = PlotState {
+            current_scene: crate::plot_engine::Scene {
+                id: "scene-1".to_string(),
+                name: "山门".to_string(),
+                description: "你看见山门风声渐紧。".to_string(),
+                location: "sect".to_string(),
+                available_options: vec![make_option(0, "继续观察")],
+            },
+            plot_history: vec!["你看见山门风声渐紧。".to_string()],
+            is_waiting_for_input: true,
+            interaction_state: PlotInteractionState::WaitingForChoice,
+            last_action_result: Some(crate::numerical_system::ActionResult {
+                success: true,
+                description: "你看见山门风声渐紧。".to_string(),
+                stat_changes: vec![],
+                events: vec![],
+            }),
+            settings: PlotSettings::default(),
+            current_chapter: crate::plot_engine::ChapterState {
+                index: 1,
+                title: "第一章".to_string(),
+                content: vec!["你看见山门风声渐紧。".to_string()],
+                summary: String::new(),
+                interaction_count: 1,
+                status: crate::plot_engine::ChapterLifecycle::InProgress,
+            },
+            chapters: vec![],
+            segment_count: 1,
+            last_generation_diagnostics: None,
+            last_option_generation_source: None,
+            last_consistency_risk_score: None,
+        };
+        let applied = apply_noname_manual_plot_text_hint_to_plot_state(
+            resolved,
+            "controlled-output-proposal-review-plot_text_hint",
+            plot_state,
+            1,
+            0,
+            "你看见山门风声渐紧。",
+        )
+        .expect("manual apply should update plot text");
+        assert!(applied.plot_state.current_chapter.content[0].contains("【NoName】重点关注"));
+        assert!(applied
+            .plot_state
+            .plot_history
+            .last()
+            .is_some_and(|item| item.contains("【NoName】重点关注")));
+        assert!(applied.trace.apply_execution_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.outcome == "manual_plot_text_applied"
+        }));
     }
 
     #[test]

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -87,6 +87,28 @@
 
       <section class="agent-trace-card">
         <p class="agent-trace-card-title">
+          应用生命周期
+        </p>
+        <ul class="agent-trace-lifecycle">
+          <li
+            v-for="step in applyLifecycleSteps"
+            :key="step.key"
+            class="agent-trace-lifecycle-step"
+            :class="`is-${step.tone}`"
+          >
+            <div class="agent-trace-lifecycle-head">
+              <span class="agent-trace-main-line">{{ step.label }}</span>
+              <span class="agent-trace-lifecycle-state">{{ step.state }}</span>
+            </div>
+            <p class="agent-trace-muted">
+              {{ step.detail }}
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section class="agent-trace-card">
+        <p class="agent-trace-card-title">
           状态迁移
         </p>
         <p
@@ -210,6 +232,109 @@
             >
               策略禁区：{{ review.policyForbiddenScopes.join(' / ') }}
             </p>
+            <p
+              v-if="review.requiresHumanReview"
+              class="agent-trace-review-state"
+            >
+              {{ humanReviewDecisionLabel(review.requestId) }}
+            </p>
+            <div
+              v-if="review.requiresHumanReview"
+              class="agent-trace-review-actions"
+            >
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                :class="{ 'is-active': humanReviewDecision(review.requestId) === 'approvedForHigherApply' }"
+                @click="markHumanReview(review.requestId, 'approvedForHigherApply')"
+              >
+                标记可进入高层 apply 设计
+              </button>
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                :class="{ 'is-active': humanReviewDecision(review.requestId) === 'rejectedForHigherApply' }"
+                @click="markHumanReview(review.requestId, 'rejectedForHigherApply')"
+              >
+                暂不应用
+              </button>
+              <button
+                v-if="humanReviewDecision(review.requestId) !== 'pending'"
+                type="button"
+                class="agent-trace-review-btn agent-trace-review-btn-ghost"
+                @click="markHumanReview(review.requestId, 'pending')"
+              >
+                重置待复核
+              </button>
+            </div>
+            <div
+              v-if="humanReviewDecision(review.requestId) === 'approvedForHigherApply'"
+              class="agent-trace-review-actions"
+            >
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                @click="resolveSecondGuardrail(review.requestId, 'allow')"
+              >
+                二次护栏允许
+              </button>
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                @click="resolveSecondGuardrail(review.requestId, 'reject')"
+              >
+                二次护栏拒绝
+              </button>
+              <button
+                type="button"
+                class="agent-trace-review-btn agent-trace-review-btn-ghost"
+                @click="resolveSecondGuardrail(review.requestId, 'fallback')"
+              >
+                回退经典链路
+              </button>
+            </div>
+            <div
+              v-if="hasSecondGuardrailAllow(review.requestId)"
+              class="agent-trace-manual-preview"
+              :class="manualApplyPreview(review.requestId).toneClass"
+            >
+              <p class="agent-trace-main-line">
+                人工写入预览：{{ manualApplyPreview(review.requestId).statusLabel }}
+              </p>
+              <p class="agent-trace-muted">
+                {{ manualApplyPreview(review.requestId).statusText }}
+              </p>
+              <div
+                v-if="manualApplyPreview(review.requestId).before && manualApplyPreview(review.requestId).after"
+                class="agent-trace-manual-preview-grid"
+              >
+                <div>
+                  <p class="agent-trace-preview-label">
+                    写入前
+                  </p>
+                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review.requestId).before }}</pre>
+                </div>
+                <div>
+                  <p class="agent-trace-preview-label">
+                    写入后
+                  </p>
+                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review.requestId).after }}</pre>
+                </div>
+              </div>
+            </div>
+            <div
+              v-if="hasSecondGuardrailAllow(review.requestId)"
+              class="agent-trace-review-actions"
+            >
+              <button
+                type="button"
+                class="agent-trace-review-btn is-active"
+                :disabled="!manualApplyPreview(review.requestId).canApply"
+                @click="applyManualPlotTextHint(review.requestId)"
+              >
+                显式人工写入正文提示
+              </button>
+            </div>
           </li>
         </ul>
       </section>
@@ -311,18 +436,38 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { NoNameTrace } from '../types/game';
+import type {
+  NoNameHumanReviewDecision,
+  NoNameHumanReviewMarkPayload,
+  NoNameManualApplySegmentSnapshot,
+  NoNameManualPlotTextApplyPayload,
+  NoNameProposal,
+  NoNameSecondGuardrailDecision,
+  NoNameSecondGuardrailResolvePayload,
+  NoNameTrace,
+} from '../types/game';
+import { buildNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
   trace: NoNameTrace | null;
   selectedIndex?: number;
   totalCount?: number;
   activeMode?: string;
+  reviewDecisions?: Record<string, NoNameHumanReviewDecision>;
+  manualApplySegment?: NoNameManualApplySegmentSnapshot | null;
 }>(), {
   selectedIndex: 0,
   totalCount: 0,
   activeMode: '',
+  reviewDecisions: () => ({}),
+  manualApplySegment: null,
 });
+
+const emit = defineEmits<{
+  (event: 'mark-controlled-output-review', payload: NoNameHumanReviewMarkPayload): void;
+  (event: 'resolve-second-guardrail', payload: NoNameSecondGuardrailResolvePayload): void;
+  (event: 'apply-manual-plot-text-hint', payload: NoNameManualPlotTextApplyPayload): void;
+}>();
 
 const latestProposal = computed(() => {
   if (!props.trace || props.trace.proposals.length === 0) {
@@ -334,6 +479,9 @@ const latestProposal = computed(() => {
 const relatedObservations = computed(() => props.trace?.relatedObservations ?? []);
 const protocolEvents = computed(() => props.trace?.protocolEvents ?? []);
 const controlledOutputReviews = computed(() => props.trace?.controlledOutputReviews ?? []);
+const applyLifecycleSteps = computed(() => (
+  props.trace ? buildNoNameApplyLifecycle(props.trace, props.reviewDecisions) : []
+));
 
 const guardrailLabel = computed(() => {
   const result = props.trace?.guardrailResult;
@@ -350,6 +498,145 @@ const applyResultLabel = computed(() => {
   }
   return result.reason ? `${result.outcome} (${result.reason})` : result.outcome;
 });
+
+function humanReviewDecision(requestId: string): NoNameHumanReviewDecision {
+  return props.reviewDecisions[requestId] ?? 'pending';
+}
+
+function humanReviewDecisionLabel(requestId: string) {
+  const decision = humanReviewDecision(requestId);
+  if (decision === 'approvedForHigherApply') {
+    return '人工结论：可进入下一阶段 apply 设计；当前不会自动写入剧情正文。';
+  }
+  if (decision === 'rejectedForHigherApply') {
+    return '人工结论：暂不应用；保持当前安全边界。';
+  }
+  return '等待开发者确认：当前只记录，不会自动写入剧情正文。';
+}
+
+function markHumanReview(requestId: string, decision: NoNameHumanReviewDecision) {
+  if (!props.trace) {
+    return;
+  }
+  emit('mark-controlled-output-review', {
+    traceId: props.trace.traceId,
+    requestId,
+    decision,
+  });
+}
+
+function resolveSecondGuardrail(requestId: string, decision: NoNameSecondGuardrailDecision) {
+  if (!props.trace) {
+    return;
+  }
+  emit('resolve-second-guardrail', {
+    traceId: props.trace.traceId,
+    requestId,
+    decision,
+  });
+}
+
+function hasSecondGuardrailAllow(requestId: string) {
+  const transition = `${requestId}:second_guardrail:allow`;
+  return Boolean(props.trace?.proposalTransitionLog?.includes(transition))
+    || Boolean(props.trace?.applyExecutionLog?.some((item) => (
+      (item.target === 'plot_text_hint' || item.target === 'plotTextHint')
+      && item.outcome === 'second_guardrail_allowed'
+    )));
+}
+
+function hasManualPlotTextApplied(requestId: string) {
+  return Boolean(props.trace?.proposalTransitionLog?.includes(`${requestId}:manual_apply:plot_text_hint`))
+    || Boolean(props.trace?.applyExecutionLog?.some((item) => (
+      (item.target === 'plot_text_hint' || item.target === 'plotTextHint')
+      && item.outcome === 'manual_plot_text_applied'
+    )));
+}
+
+function findProposalForReview(requestId: string): NoNameProposal | null {
+  const proposals = props.trace?.proposals ?? [];
+  return [...proposals].reverse().find((proposal) => requestId.includes(proposal.proposalId))
+    ?? proposals[proposals.length - 1]
+    ?? null;
+}
+
+function buildManualPlotText(proposal: NoNameProposal, segmentText: string) {
+  const hint = `【NoName】重点关注：${proposal.focus}`;
+  if (proposal.targetSegment === 'current_turn_head') {
+    return `${hint}\n\n${segmentText.trim()}`;
+  }
+  return `${segmentText.trim()}\n\n${hint}`;
+}
+
+function manualApplyPreview(requestId: string) {
+  if (hasManualPlotTextApplied(requestId)) {
+    return {
+      canApply: false,
+      toneClass: 'is-safe',
+      statusLabel: '已写入',
+      statusText: '这条 review 已记录 manual_plot_text_applied，避免重复写入同一条正文提示。',
+      before: '',
+      after: '',
+    };
+  }
+
+  const segment = props.manualApplySegment;
+  if (!segment || !segment.text.trim()) {
+    return {
+      canApply: false,
+      toneClass: 'is-warn',
+      statusLabel: '缺少当前段落快照',
+      statusText: '当前剧情段落为空，无法执行显式人工写入。',
+      before: '',
+      after: '',
+    };
+  }
+
+  if (segment.text.includes('【NoName】') || segment.text.includes('NoName提示')) {
+    return {
+      canApply: false,
+      toneClass: 'is-warn',
+      statusLabel: '疑似已包含 NoName 标记',
+      statusText: '当前段落已经包含 NoName 标记，为避免重复写入，按钮已禁用。',
+      before: segment.text,
+      after: '',
+    };
+  }
+
+  const proposal = findProposalForReview(requestId);
+  if (!proposal) {
+    return {
+      canApply: false,
+      toneClass: 'is-warn',
+      statusLabel: '找不到关联提案',
+      statusText: '无法从 requestId 反查 proposal，暂不允许写入。',
+      before: segment.text,
+      after: '',
+    };
+  }
+
+  return {
+    canApply: true,
+    toneClass: 'is-ready',
+    statusLabel: `将写入第 ${segment.chapterIndex} 章第 ${segment.segmentIndex + 1} 段`,
+    statusText: '请确认下方差异预览无误；后端还会再次校验章节、段落和正文快照。',
+    before: segment.text,
+    after: buildManualPlotText(proposal, segment.text),
+  };
+}
+
+function applyManualPlotTextHint(requestId: string) {
+  if (!props.trace) {
+    return;
+  }
+  if (!manualApplyPreview(requestId).canApply) {
+    return;
+  }
+  emit('apply-manual-plot-text-hint', {
+    traceId: props.trace.traceId,
+    requestId,
+  });
+}
 </script>
 
 <style scoped>
@@ -456,6 +743,51 @@ const applyResultLabel = computed(() => {
   gap: 8px;
 }
 
+.agent-trace-lifecycle {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.agent-trace-lifecycle-step {
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 72%, transparent);
+  background: color-mix(in srgb, var(--ink-card-bg) 90%, transparent);
+  padding: 10px 12px;
+}
+
+.agent-trace-lifecycle-step.is-done {
+  border-color: color-mix(in srgb, #2f6b4b 46%, var(--ink-border-soft));
+}
+
+.agent-trace-lifecycle-step.is-pending {
+  border-color: color-mix(in srgb, var(--ink-accent-main) 54%, var(--ink-border-soft));
+}
+
+.agent-trace-lifecycle-step.is-blocked,
+.agent-trace-lifecycle-step.is-fallback {
+  border-color: color-mix(in srgb, #9b4d2e 54%, var(--ink-border-soft));
+}
+
+.agent-trace-lifecycle-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+
+.agent-trace-lifecycle-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-accent) 72%, transparent);
+  padding: 3px 8px;
+  color: var(--ink-text-muted);
+  font-size: 12px;
+}
+
 .agent-trace-row {
   display: grid;
   gap: 4px;
@@ -465,8 +797,111 @@ const applyResultLabel = computed(() => {
   padding: 10px 12px;
 }
 
+.agent-trace-review-state {
+  margin: 8px 0 0;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-accent) 72%, transparent);
+  background: color-mix(in srgb, var(--ink-accent-main) 10%, var(--ink-card-bg));
+  color: var(--ink-text-primary);
+  padding: 8px 10px;
+  line-height: 1.5;
+}
+
+.agent-trace-review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.agent-trace-manual-preview {
+  margin-top: 10px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 72%, transparent);
+  background: color-mix(in srgb, var(--ink-card-bg) 90%, transparent);
+  padding: 10px 12px;
+}
+
+.agent-trace-manual-preview.is-ready {
+  border-color: color-mix(in srgb, #2f6b4b 44%, var(--ink-border-soft));
+}
+
+.agent-trace-manual-preview.is-warn {
+  border-color: color-mix(in srgb, #9b4d2e 54%, var(--ink-border-soft));
+}
+
+.agent-trace-manual-preview.is-safe {
+  border-color: color-mix(in srgb, var(--ink-accent-main) 48%, var(--ink-border-soft));
+}
+
+.agent-trace-manual-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.agent-trace-preview-label {
+  margin: 0 0 6px;
+  color: var(--ink-text-muted);
+  font-size: 12px;
+}
+
+.agent-trace-preview-text {
+  margin: 0;
+  max-height: 170px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 70%, transparent);
+  background: color-mix(in srgb, var(--ink-card-bg-soft) 88%, transparent);
+  padding: 8px;
+  color: var(--ink-text-primary);
+  font-family: "LXGW WenKai", "Noto Serif SC", serif;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.agent-trace-review-btn {
+  border: 1px solid color-mix(in srgb, var(--ink-border-accent) 78%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink-card-bg) 92%, transparent);
+  color: var(--ink-text-primary);
+  cursor: pointer;
+  padding: 7px 10px;
+  transition: background-color 180ms ease, border-color 180ms ease, transform 120ms ease;
+}
+
+.agent-trace-review-btn:hover {
+  transform: translateY(-1px);
+}
+
+.agent-trace-review-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+}
+
+.agent-trace-review-btn.is-active {
+  border-color: var(--ink-accent-main);
+  background: color-mix(in srgb, var(--ink-accent-main) 20%, var(--ink-card-bg));
+}
+
+.agent-trace-review-btn-ghost {
+  color: var(--ink-text-muted);
+}
+
 @media (max-width: 900px) {
   .agent-trace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-trace-lifecycle {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-trace-manual-preview-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/components/GameRuntimeView.vue
+++ b/src/components/GameRuntimeView.vue
@@ -124,9 +124,13 @@
       :traces="gameStore.noNameTraces ?? []"
       :no-name-mode="noNameMode"
       :is-dev-mode="isDevMode"
+      :manual-apply-segment="manualApplySegment"
       @close="showNoNameDebugConsole = false"
       @clear-traces="gameStore.clearNoNameTraces()"
       @set-no-name-mode="setNoNameMode"
+      @mark-controlled-output-review="gameStore.markNoNameControlledOutputReview"
+      @resolve-second-guardrail="gameStore.resolveNoNameSecondGuardrail"
+      @apply-manual-plot-text-hint="gameStore.applyNoNameManualPlotTextHint"
     />
     <NotificationCenter
       v-if="runtimeNotifications.length > 0"
@@ -153,7 +157,7 @@ import NotificationCenter from './NotificationCenter.vue';
 import NoNameDebugConsole from './NoNameDebugConsole.vue';
 import RuntimeQuickPanelsDialog from './RuntimeQuickPanelsDialog.vue';
 import StoryViewport from './StoryViewport.vue';
-import type { ConsistencyPolicy, NoNameMode } from '../types/game';
+import type { ConsistencyPolicy, NoNameManualApplySegmentSnapshot, NoNameMode } from '../types/game';
 import { invokeRuntime } from '../utils/tauriInvoke';
 import {
   createFreeTextAction,
@@ -224,6 +228,18 @@ const hasNoNameTraceHistory = computed(() => (gameStore.noNameTraces?.length ?? 
 const noNameDebugText = computed(() => {
   const getter = (gameStore as { getNoNameTraceDebugText?: () => string }).getNoNameTraceDebugText;
   return typeof getter === 'function' ? getter.call(gameStore) : '暂无 NoName Agent Trace。';
+});
+const manualApplySegment = computed<NoNameManualApplySegmentSnapshot | null>(() => {
+  const chapter = gameStore.plotState?.current_chapter;
+  if (!chapter || chapter.content.length === 0) {
+    return null;
+  }
+  const segmentIndex = chapter.content.length - 1;
+  return {
+    chapterIndex: chapter.index,
+    segmentIndex,
+    text: chapter.content[segmentIndex] ?? '',
+  };
 });
 
 const refreshNoNameMode = async () => {

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -112,6 +112,11 @@
             :selected-index="selectedIndex"
             :total-count="traces.length"
             :active-mode="noNameMode"
+            :review-decisions="selectedReviewDecisions"
+            :manual-apply-segment="manualApplySegment"
+            @mark-controlled-output-review="markControlledOutputReview"
+            @resolve-second-guardrail="resolveSecondGuardrail"
+            @apply-manual-plot-text-hint="applyManualPlotTextHint"
           />
         </main>
       </div>
@@ -122,21 +127,35 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import AgentTracePanel from './AgentTracePanel.vue';
-import type { NoNameMode, NoNameTrace } from '../types/game';
+import type {
+  NoNameHumanReviewDecision,
+  NoNameHumanReviewMarkPayload,
+  NoNameManualApplySegmentSnapshot,
+  NoNameManualPlotTextApplyPayload,
+  NoNameMode,
+  NoNameSecondGuardrailResolvePayload,
+  NoNameTrace,
+} from '../types/game';
+import { summarizeNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
   isOpen: boolean;
   traces: NoNameTrace[];
   noNameMode: NoNameMode;
   isDevMode?: boolean;
+  manualApplySegment?: NoNameManualApplySegmentSnapshot | null;
 }>(), {
   isDevMode: false,
+  manualApplySegment: null,
 });
 
-defineEmits<{
+const emit = defineEmits<{
   (event: 'close'): void;
   (event: 'clear-traces'): void;
   (event: 'set-no-name-mode', mode: NoNameMode): void;
+  (event: 'mark-controlled-output-review', payload: NoNameHumanReviewMarkPayload): void;
+  (event: 'resolve-second-guardrail', payload: NoNameSecondGuardrailResolvePayload): void;
+  (event: 'apply-manual-plot-text-hint', payload: NoNameManualPlotTextApplyPayload): void;
 }>();
 
 const modeOptions: Array<{ value: NoNameMode; label: string }> = [
@@ -183,8 +202,27 @@ const selectedTrace = computed(() => {
 });
 
 const copyStatus = ref('');
+const humanReviewDecisions = ref<Record<string, NoNameHumanReviewDecision>>({});
 
-const selectedTraceReport = computed(() => buildTraceReport(selectedTrace.value));
+const selectedReviewDecisions = computed<Record<string, NoNameHumanReviewDecision>>(() => {
+  const trace = selectedTrace.value;
+  if (!trace) {
+    return {};
+  }
+  return Object.fromEntries(
+    (trace.controlledOutputReviews ?? []).map((review) => [
+      review.requestId,
+      humanReviewDecisions.value[humanReviewDecisionKey(trace.traceId, review.requestId)]
+        ?? review.humanReviewDecision
+        ?? 'pending',
+    ]),
+  );
+});
+
+const selectedTraceReport = computed(() => buildTraceReport(
+  selectedTrace.value,
+  selectedReviewDecisions.value,
+));
 
 async function copySelectedTraceReport() {
   const report = selectedTraceReport.value;
@@ -199,7 +237,30 @@ async function copySelectedTraceReport() {
   }
 }
 
-function buildTraceReport(trace: NoNameTrace | null) {
+function markControlledOutputReview(payload: NoNameHumanReviewMarkPayload) {
+  humanReviewDecisions.value = {
+    ...humanReviewDecisions.value,
+    [humanReviewDecisionKey(payload.traceId, payload.requestId)]: payload.decision,
+  };
+  emit('mark-controlled-output-review', payload);
+}
+
+function resolveSecondGuardrail(payload: NoNameSecondGuardrailResolvePayload) {
+  emit('resolve-second-guardrail', payload);
+}
+
+function applyManualPlotTextHint(payload: NoNameManualPlotTextApplyPayload) {
+  emit('apply-manual-plot-text-hint', payload);
+}
+
+function humanReviewDecisionKey(traceId: string, requestId: string) {
+  return `${traceId}::${requestId}`;
+}
+
+function buildTraceReport(
+  trace: NoNameTrace | null,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+) {
   if (!trace) {
     return '';
   }
@@ -211,6 +272,18 @@ function buildTraceReport(trace: NoNameTrace | null) {
   const protocolEvents = trace.protocolEvents ?? [];
   const controlledReviews = trace.controlledOutputReviews ?? [];
   const humanReviewCount = controlledReviews.filter((review) => review.requiresHumanReview).length;
+  const reviewDecisionCounts = controlledReviews.reduce(
+    (counts, review) => {
+      const decision = reviewDecisions[review.requestId] ?? 'pending';
+      counts[decision] += 1;
+      return counts;
+    },
+    {
+      pending: 0,
+      approvedForHigherApply: 0,
+      rejectedForHigherApply: 0,
+    } satisfies Record<NoNameHumanReviewDecision, number>,
+  );
   const relatedObservations = trace.relatedObservations ?? [];
   const guardrail = trace.guardrailResult
     ? `${trace.guardrailResult.outcome}${trace.guardrailResult.reason ? ` (${trace.guardrailResult.reason})` : ''}`
@@ -218,6 +291,7 @@ function buildTraceReport(trace: NoNameTrace | null) {
   const applyResult = trace.applyResult
     ? `${trace.applyResult.outcome}${trace.applyResult.reason ? ` (${trace.applyResult.reason})` : ''}`
     : '无';
+  const lifecycle = summarizeNoNameApplyLifecycle(trace, reviewDecisions);
   return [
     `Trace: ${trace.traceId}`,
     `Mode: ${trace.mode}`,
@@ -228,8 +302,10 @@ function buildTraceReport(trace: NoNameTrace | null) {
     `Related Observations: ${relatedObservations.length}`,
     `Protocol Events: ${protocolEvents.length}`,
     `Controlled Reviews: ${controlledReviews.length} (${humanReviewCount} needs human review)`,
+    `Human Review Decisions: ${reviewDecisionCounts.approvedForHigherApply} approved / ${reviewDecisionCounts.rejectedForHigherApply} rejected / ${reviewDecisionCounts.pending} pending`,
     `Guardrail: ${guardrail}`,
     `Apply Result: ${applyResult}`,
+    `Apply Lifecycle: ${lifecycle}`,
     `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,
     `Elapsed: ${trace.elapsedMs} ms`,
   ].join('\n');

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -112,6 +112,9 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('preflight_ready');
     expect(wrapper.text()).toContain('未回退');
     expect(wrapper.text()).toContain('ApplyProposal');
+    expect(wrapper.text()).toContain('应用生命周期');
+    expect(wrapper.text()).toContain('提案阶段');
+    expect(wrapper.text()).toContain('低风险输出');
     expect(wrapper.text()).toContain('协作观察');
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('协议事件');
@@ -120,6 +123,114 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('sceneAugmentation · plotTextHint · needsReview');
     expect(wrapper.text()).toContain('需要人工复核');
     expect(wrapper.text()).toContain('策略禁区：finalPlotState / canonWorldFact');
+    expect(wrapper.text()).toContain('等待开发者确认');
+  });
+
+  it('emits a human review decision without applying plot text', async () => {
+    const wrapper = mount(AgentTracePanel, {
+      props: {
+        trace,
+        reviewDecisions: {
+          'controlled-output-proposal-2-plot_text_hint': 'pending',
+        },
+      },
+    });
+
+    const buttons = wrapper.findAll('.agent-trace-review-btn');
+    expect(buttons.map((button) => button.text())).toContain('标记可进入高层 apply 设计');
+
+    await buttons.find((button) => button.text() === '标记可进入高层 apply 设计')?.trigger('click');
+
+    expect(wrapper.emitted('mark-controlled-output-review')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      decision: 'approvedForHigherApply',
+    }]);
+
+    await wrapper.setProps({
+      reviewDecisions: {
+        'controlled-output-proposal-2-plot_text_hint': 'approvedForHigherApply',
+      },
+    });
+    expect(wrapper.text()).toContain('人工结论：可进入下一阶段 apply 设计');
+    expect(wrapper.text()).toContain('重置待复核');
+    expect(wrapper.text()).toContain('二次护栏允许');
+
+    await wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((button) => button.text() === '二次护栏允许')
+      ?.trigger('click');
+    expect(wrapper.emitted('resolve-second-guardrail')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      decision: 'allow',
+    }]);
+
+    await wrapper.setProps({
+      trace: {
+        ...trace,
+        proposalTransitionLog: [
+          ...(trace.proposalTransitionLog ?? []),
+          'controlled-output-proposal-2-plot_text_hint:second_guardrail:allow',
+        ],
+        applyExecutionLog: [
+          ...(trace.applyExecutionLog ?? []),
+          {
+            target: 'plot_text_hint',
+            outcome: 'second_guardrail_allowed',
+            note: '允许进入显式人工 apply',
+          },
+        ],
+      },
+      manualApplySegment: {
+        chapterIndex: 1,
+        segmentIndex: 0,
+        text: '你看见山门风声渐紧。',
+      },
+    });
+    expect(wrapper.text()).toContain('显式人工写入正文提示');
+    expect(wrapper.text()).toContain('人工写入');
+    expect(wrapper.text()).toContain('等待显式命令');
+    expect(wrapper.text()).toContain('人工写入预览');
+    expect(wrapper.text()).toContain('写入前');
+    expect(wrapper.text()).toContain('写入后');
+    expect(wrapper.text()).toContain('【NoName】重点关注：山门危机');
+    await wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((button) => button.text() === '显式人工写入正文提示')
+      ?.trigger('click');
+    expect(wrapper.emitted('apply-manual-plot-text-hint')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+    }]);
+  });
+
+  it('disables manual plot text apply when the current segment already has a NoName marker', async () => {
+    const wrapper = mount(AgentTracePanel, {
+      props: {
+        trace: {
+          ...trace,
+          proposalTransitionLog: [
+            ...(trace.proposalTransitionLog ?? []),
+            'controlled-output-proposal-2-plot_text_hint:second_guardrail:allow',
+          ],
+        },
+        manualApplySegment: {
+          chapterIndex: 1,
+          segmentIndex: 0,
+          text: '【NoName】重点关注：山门危机\n\n你看见山门风声渐紧。',
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('疑似已包含 NoName 标记');
+    const button = wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((item) => item.text() === '显式人工写入正文提示');
+    expect(button?.attributes('disabled')).toBeDefined();
+
+    await button?.trigger('click');
+    expect(wrapper.emitted('apply-manual-plot-text-hint')).toBeUndefined();
   });
 
   it('shows empty state when trace is missing', () => {

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -110,6 +110,8 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('当前模式：assisted');
     expect(wrapper.text()).toContain('Protocol Events: 1');
     expect(wrapper.text()).toContain('Controlled Reviews: 1 (1 needs human review)');
+    expect(wrapper.text()).toContain('Human Review Decisions: 0 approved / 0 rejected / 1 pending');
+    expect(wrapper.text()).toContain('Apply Lifecycle:');
     expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
     const traceButtons = wrapper.findAll('.noname-debug-console-trace-btn');
@@ -117,6 +119,37 @@ describe('NoNameDebugConsole', () => {
 
     await traceButtons[0].trigger('click');
     expect(wrapper.text()).toContain('Director提案：初始观察');
+  });
+
+  it('tracks local human review decisions for NeedsReview outputs', async () => {
+    const wrapper = mount(NoNameDebugConsole, {
+      props: {
+        isOpen: true,
+        traces,
+        noNameMode: 'assisted',
+        isDevMode: true,
+      },
+    });
+
+    expect(wrapper.text()).toContain('等待开发者确认');
+
+    const reviewButtons = wrapper.findAll('.agent-trace-review-btn');
+    await reviewButtons
+      .find((button) => button.text() === '标记可进入高层 apply 设计')
+      ?.trigger('click');
+
+    expect(wrapper.text()).toContain('人工结论：可进入下一阶段 apply 设计');
+    expect(wrapper.text()).toContain('Human Review Decisions: 1 approved / 0 rejected / 0 pending');
+
+    await wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((button) => button.text() === '二次护栏允许')
+      ?.trigger('click');
+    expect(wrapper.emitted('resolve-second-guardrail')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      decision: 'allow',
+    }]);
   });
 
   it('emits close, clear and mode change events', async () => {
@@ -159,6 +192,7 @@ describe('NoNameDebugConsole', () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace: trace-2'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Protocol Events: 1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Controlled Reviews: 1'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));
     expect(wrapper.text()).toContain('摘要已复制');
   });
 });

--- a/src/platform/webRuntime.test.ts
+++ b/src/platform/webRuntime.test.ts
@@ -38,7 +38,56 @@ describe('webRuntime', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('applies NoName plot hint to current turn head in assisted mode for free text actions', async () => {
+  it('skips NoName traces and diagnostics in disabled mode', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+    await invokeWebRuntime('set_noname_mode', { mode: 'disabled' });
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '观察山门灵气',
+        selected_option_id: null,
+      },
+    });
+
+    const plotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestParagraph = plotState.current_chapter.content[plotState.current_chapter.content.length - 1] ?? '';
+    expect(traces).toHaveLength(0);
+    expect(latestParagraph.includes('【NoName】重点关注')).toBe(false);
+    expect(plotState.last_generation_diagnostics ?? '').not.toContain('NoName.');
+  });
+
+  it('records observe-only trace without applying NoName outputs', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '观察山门灵气',
+        selected_option_id: null,
+      },
+    });
+
+    const plotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestTrace = traces[traces.length - 1];
+    const latestParagraph = plotState.current_chapter.content[plotState.current_chapter.content.length - 1] ?? '';
+    expect(latestTrace?.mode).toBe('observeOnly');
+    expect(latestTrace?.proposals[0]?.status).toBe('observed');
+    expect(latestTrace?.proposals[0]?.applyable).toBe(false);
+    expect(latestTrace?.applyResult?.outcome).toBe('skipped_observe_only');
+    expect(latestTrace?.applyExecutionLog).toHaveLength(0);
+    expect(latestParagraph.includes('【NoName】重点关注')).toBe(false);
+    expect(plotState.current_chapter.summary).not.toContain('NoName提示');
+    expect(plotState.last_generation_diagnostics).toContain('NoName.observeOnly');
+  });
+
+  it('queues NoName plot hint for review while applying low-risk hints in assisted mode', async () => {
     const script = await invokeWebRuntime<Script>('generate_random_script');
     await invokeWebRuntime('initialize_game', { script });
     await invokeWebRuntime('initialize_plot');
@@ -54,7 +103,7 @@ describe('webRuntime', () => {
 
     const plotState = await invokeWebRuntime<PlotState>('get_plot_state');
     const latestParagraph = plotState.current_chapter.content[plotState.current_chapter.content.length - 1] ?? '';
-    expect(latestParagraph.startsWith('【NoName】重点关注：观察灵脉回响')).toBe(true);
+    expect(latestParagraph.includes('【NoName】重点关注：观察灵脉回响')).toBe(false);
     expect(plotState.current_chapter.summary).toContain('NoName提示：后续重点关注观察灵脉回响');
     expect(plotState.last_generation_diagnostics).toContain('target_segment=current_turn_head');
 
@@ -63,9 +112,81 @@ describe('webRuntime', () => {
     expect(latestTrace?.applyPlanLog?.[0]?.order).toBe(1);
     expect(latestTrace?.proposals[0]?.targetSegment).toBe('current_turn_head');
     expect(latestTrace?.proposals[0]?.applyScopes).toContain('plotTextHint');
-    expect(latestTrace?.applyPlanLog?.[0]?.decision).toBe('apply');
+    expect(latestTrace?.applyPlanLog?.[0]?.decision).toBe('needs_review');
     expect(latestTrace?.applyPlanLog?.[0]?.priority).toBe(300);
+    expect(latestTrace?.controlledOutputReviews?.some((item) => (
+      item.safeApplyScope === 'plotTextHint' && item.decision === 'needsReview'
+    ))).toBe(true);
+    expect(latestTrace?.applyResult?.outcome).toBe('applied_summary_and_option_bias');
+    expect(latestTrace?.applyResult?.reason).toContain('plotTextHint 等待人工复核');
     expect(latestTrace?.applyResult?.reason).toContain('target=current_turn_head');
+  });
+
+  it('records human review apply intent without mutating plot text in web mode', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+    await invokeWebRuntime('set_noname_mode', { mode: 'assisted' });
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '观察灵脉回响',
+        selected_option_id: null,
+      },
+    });
+
+    const beforePlotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    const beforeContent = [...beforePlotState.current_chapter.content];
+    const segmentIndex = beforeContent.length - 1;
+    const expectedSegmentText = beforeContent[segmentIndex];
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestTrace = traces[traces.length - 1];
+    const review = latestTrace.controlledOutputReviews?.find((item) => item.requiresHumanReview);
+    expect(review?.decision).toBe('needsReview');
+
+    const updatedTrace = await invokeWebRuntime<NoNameTrace>('mark_noname_controlled_output_review', {
+      traceId: latestTrace.traceId,
+      requestId: review?.requestId,
+      decision: 'approvedForHigherApply',
+    });
+
+    const afterPlotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    expect(afterPlotState.current_chapter.content).toEqual(beforeContent);
+    expect(updatedTrace.controlledOutputReviews?.[3]?.humanReviewDecision).toBe('approvedForHigherApply');
+    expect(updatedTrace.applyPlanLog?.some((item) => (
+      item.target === 'plotTextHint' && item.decision === 'review_intent_ready'
+    ))).toBe(true);
+    expect(updatedTrace.applyExecutionLog?.some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'awaiting_second_guardrail'
+    ))).toBe(true);
+
+    const resolvedTrace = await invokeWebRuntime<NoNameTrace>('resolve_noname_second_guardrail', {
+      traceId: latestTrace.traceId,
+      requestId: review?.requestId,
+      decision: 'allow',
+    });
+    const finalPlotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    expect(finalPlotState.current_chapter.content).toEqual(beforeContent);
+    expect(resolvedTrace.applyPlanLog?.some((item) => (
+      item.target === 'plotTextHint' && item.decision === 'second_guardrail_allow'
+    ))).toBe(true);
+    expect(resolvedTrace.applyExecutionLog?.some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'second_guardrail_allowed'
+    ))).toBe(true);
+    expect(resolvedTrace.applyResult?.outcome).toBe('second_guardrail_allow');
+
+    const applied = await invokeWebRuntime<{ trace: NoNameTrace; plotState: PlotState }>('apply_noname_manual_plot_text_hint', {
+      traceId: latestTrace.traceId,
+      requestId: review?.requestId,
+      chapterIndex: beforePlotState.current_chapter.index,
+      segmentIndex,
+      expectedSegmentText,
+    });
+    expect(applied.plotState.current_chapter.content[segmentIndex]).toContain('【NoName】重点关注：观察灵脉回响');
+    expect(applied.trace.applyExecutionLog?.some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'manual_plot_text_applied'
+    ))).toBe(true);
   });
 
   it('applies NoName summary hint to chapter summary head for even option actions in assisted mode', async () => {

--- a/src/platform/webRuntime.ts
+++ b/src/platform/webRuntime.ts
@@ -424,6 +424,7 @@ function appendWebNoNameTrace(
       })),
       controlledOutputReviews: applyScopes.map((scope) => ({
         requestId: `controlled-output-${proposalId}-${scope === 'plotTextHint' ? 'plot_text_hint' : scope}`,
+        proposalId,
         requestedKind: scope === 'plotTextHint'
           ? 'sceneAugmentation'
           : scope === 'chapterSummaryHint'

--- a/src/platform/webRuntime.ts
+++ b/src/platform/webRuntime.ts
@@ -9,7 +9,9 @@ import {
   type GameState,
   type MapLocationOverview,
   type NoNameApplyScope,
+  type NoNameHumanReviewMarkPayload,
   type NoNameMode,
+  type NoNameSecondGuardrailResolvePayload,
   type NoNameTargetSegment,
   type NoNameTrace,
   type PlayerAction,
@@ -328,14 +330,6 @@ function deriveWebNoNameApplyScopes(targetSegment: NoNameTargetSegment): NoNameA
   return baseScopes;
 }
 
-function applyWebNoNamePlotHint(paragraph: string, focus: string, targetSegment: NoNameTargetSegment): string {
-  const hint = `【NoName】重点关注：${focus}`;
-  if (targetSegment === 'current_turn_head') {
-    return `${hint}\n\n${paragraph}`;
-  }
-  return `${paragraph}\n\n${hint}`;
-}
-
 function applyWebNoNameSummaryHint(summary: string, focus: string, targetSegment: NoNameTargetSegment): string {
   const hint = `NoName提示：后续重点关注${focus}`;
   if (!summary.trim()) {
@@ -399,35 +393,64 @@ function appendWebNoNameTrace(
       proposalTransitionLog: [
         `${proposalId}:ready`,
         `${proposalId}:apply_preflight:ready`,
-        ...applyScopes.map((scope) => `${proposalId}:applied:${scope}`),
+        ...applyScopes
+          .filter((scope) => scope !== 'plotTextHint')
+          .map((scope) => `${proposalId}:applied:${scope}`),
+        ...(applyScopes.includes('plotTextHint')
+          ? [`${proposalId}:controlled_output:plot_text_hint:needs_review`]
+          : []),
       ],
       applyPlanLog: applyScopes
         .map((scope) => ({
         target: scope,
-        decision: 'apply',
+        decision: scope === 'plotTextHint' ? 'needs_review' : 'apply',
         priority: scope === 'plotTextHint' ? 300 : scope === 'chapterSummaryHint' ? 200 : scope === 'optionBiasHint' ? 100 : 50,
-        note: `web mock 允许执行 ${scope}`,
+        note: scope === 'plotTextHint'
+          ? 'web mock plotTextHint 需要人工复核'
+          : `web mock 允许执行 ${scope}`,
       }))
         .sort((left, right) => right.priority - left.priority)
         .map((item, index) => ({ ...item, order: index + 1 })),
-      applyExecutionLog: applyScopes.map((scope) => ({
+      applyExecutionLog: applyScopes
+        .filter((scope) => scope !== 'plotTextHint')
+        .map((scope) => ({
         target: scope,
         outcome: 'applied',
-        note: scope === 'plotTextHint'
-          ? `已将提案提示写入正文，聚焦“${text}”`
-          : scope === 'chapterSummaryHint'
+        note: scope === 'chapterSummaryHint'
             ? `已补充章节摘要提示，聚焦“${text}”`
             : scope === 'optionBiasHint'
               ? `已补充下轮选项偏置提示，聚焦“${text}”`
               : `已补充诊断提示，聚焦“${text}”`,
       })),
+      controlledOutputReviews: applyScopes.map((scope) => ({
+        requestId: `controlled-output-${proposalId}-${scope === 'plotTextHint' ? 'plot_text_hint' : scope}`,
+        requestedKind: scope === 'plotTextHint'
+          ? 'sceneAugmentation'
+          : scope === 'chapterSummaryHint'
+            ? 'recapNote'
+            : scope === 'optionBiasHint'
+              ? 'intermediateNarrativeHint'
+              : 'narrativeNote',
+        decision: scope === 'plotTextHint' ? 'needsReview' : 'allow',
+        reason: scope === 'plotTextHint'
+          ? 'plot text hint requires human review before higher-layer apply'
+          : 'controlled output stays within allowed boundary',
+        normalizedKind: scope === 'plotTextHint'
+          ? 'sceneAugmentation'
+          : scope === 'chapterSummaryHint'
+            ? 'recapNote'
+            : scope === 'optionBiasHint'
+              ? 'intermediateNarrativeHint'
+              : 'narrativeNote',
+        safeApplyScope: scope,
+        policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
+        requiresHumanReview: scope === 'plotTextHint',
+      })),
       guardrailResult: { outcome: 'accept' },
       applyResult: {
         attempted: true,
-        outcome: applyScopes.includes('plotTextHint')
-          ? 'applied_summary_option_bias_and_plot_text'
-          : 'applied_summary_and_option_bias',
-        reason: `web mock 已将提案应用到低风险输出层，target=${targetSegment}，scopes=${applyScopes.join(',')}，正文为：${paragraph}`,
+        outcome: 'applied_summary_and_option_bias',
+        reason: `web mock 已将提案应用到低风险输出层，plotTextHint 等待人工复核，target=${targetSegment}，scopes=${applyScopes.join(',')}，正文为：${paragraph}`,
       },
       fallbackUsed: false,
       elapsedMs: 0,
@@ -481,6 +504,540 @@ function appendWebNoNameTrace(
   }
 }
 
+function markWebNoNameControlledOutputReview(payload: NoNameHumanReviewMarkPayload): NoNameTrace {
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === payload.traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${payload.traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? [])
+    .find((item) => item.requestId === payload.requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${payload.requestId}`);
+  }
+  if (review.decision !== 'needsReview' || !review.requiresHumanReview) {
+    throw new Error(`NoName controlled output review does not require human review: ${payload.requestId}`);
+  }
+
+  review.humanReviewDecision = payload.decision;
+  review.humanReviewedAt = Math.floor(Date.now() / 1000);
+  review.humanReviewNote = payload.decision === 'approvedForHigherApply'
+    ? '人工确认可进入高层 apply 设计，仍需后端二次 guardrail'
+    : payload.decision === 'rejectedForHigherApply'
+      ? '人工确认暂不应用，保持当前安全边界'
+      : '人工复核已重置为待确认，未触发高层 apply';
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${payload.requestId}:human_review:${payload.decision}`,
+  ];
+  const target = review.safeApplyScope ?? 'controlled_output';
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  const priority = review.safeApplyScope === 'plotTextHint'
+    ? 325
+    : review.safeApplyScope === 'chapterSummaryHint'
+      ? 225
+      : review.safeApplyScope === 'optionBiasHint'
+        ? 125
+        : 35;
+
+  if (payload.decision === 'pending') {
+    trace.applyPlanLog = [
+      ...(trace.applyPlanLog ?? []),
+      {
+        order: nextOrder,
+        target,
+        decision: 'review_intent_pending',
+        priority,
+        note: '人工复核已重置为待确认，未进入二次 guardrail',
+      },
+    ];
+    trace.applyExecutionLog = [
+      ...(trace.applyExecutionLog ?? []),
+      {
+        target,
+        outcome: 'human_review_pending',
+        note: '等待人工确认，不触发高层 apply',
+      },
+    ];
+    trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:pending`);
+    return trace;
+  }
+
+  if (payload.decision === 'rejectedForHigherApply') {
+    trace.applyPlanLog = [
+      ...(trace.applyPlanLog ?? []),
+      {
+        order: nextOrder,
+        target,
+        decision: 'reject',
+        priority,
+        note: '人工复核拒绝进入高层 apply，保持安全边界',
+      },
+    ];
+    trace.applyExecutionLog = [
+      ...(trace.applyExecutionLog ?? []),
+      {
+        target,
+        outcome: 'rejected_by_human_review',
+        note: '开发者选择暂不应用，未触发二次 guardrail',
+      },
+    ];
+    trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:rejected_by_human_review`);
+    return trace;
+  }
+
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => payload.requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  const secondGuardrailRejected = trace.mode !== 'assisted'
+    || review.safeApplyScope !== 'plotTextHint'
+    || !proposal
+    || proposal.status !== 'applied'
+    || !proposal.applyable
+    || !['current_turn_head', 'current_turn_tail'].includes(proposal.targetSegment);
+  if (secondGuardrailRejected) {
+    trace.applyPlanLog = [
+      ...(trace.applyPlanLog ?? []),
+      {
+        order: nextOrder,
+        target,
+        decision: 'second_guardrail_reject',
+        priority,
+        note: 'web mock 二次 guardrail 拒绝高层 apply intent',
+      },
+    ];
+    trace.applyExecutionLog = [
+      ...(trace.applyExecutionLog ?? []),
+      {
+        target,
+        outcome: 'second_guardrail_rejected',
+        note: 'web mock 未满足高层 apply intent 条件',
+      },
+    ];
+    trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:second_guardrail_rejected`);
+    return trace;
+  }
+
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target,
+      decision: 'review_intent_ready',
+      priority,
+      note: '人工确认已通过，已排入二次 guardrail / apply planner，未写入正文',
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target,
+      outcome: 'awaiting_second_guardrail',
+      note: '高层 apply intent 已记录，等待后续二次 guardrail 决策',
+    },
+  ];
+  trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:awaiting_second_guardrail`);
+  return trace;
+}
+
+function resolveWebNoNameSecondGuardrail(payload: NoNameSecondGuardrailResolvePayload): NoNameTrace {
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === payload.traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${payload.traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? [])
+    .find((item) => item.requestId === payload.requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${payload.requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for second guardrail: ${payload.requestId}`);
+  }
+
+  const target = review.safeApplyScope ?? 'controlled_output';
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  const priority = review.safeApplyScope === 'plotTextHint'
+    ? 350
+    : review.safeApplyScope === 'chapterSummaryHint'
+      ? 250
+      : review.safeApplyScope === 'optionBiasHint'
+        ? 150
+        : 60;
+  const isWaiting = (trace.proposalTransitionLog ?? [])
+    .includes(`${payload.requestId}:apply_intent:awaiting_second_guardrail`)
+    || (trace.applyExecutionLog ?? []).some((item) => item.outcome === 'awaiting_second_guardrail');
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => payload.requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  const revalidateRejected = !isWaiting
+    || trace.mode !== 'assisted'
+    || review.safeApplyScope !== 'plotTextHint'
+    || !proposal
+    || proposal.status !== 'applied'
+    || !proposal.applyable
+    || !['current_turn_head', 'current_turn_tail'].includes(proposal.targetSegment);
+
+  const finalDecision = revalidateRejected ? 'reject' : payload.decision;
+  const planDecision = finalDecision === 'allow'
+    ? 'second_guardrail_allow'
+    : finalDecision === 'fallback'
+      ? 'second_guardrail_fallback'
+      : 'second_guardrail_reject';
+  const outcome = finalDecision === 'allow'
+    ? 'second_guardrail_allowed'
+    : finalDecision === 'fallback'
+      ? 'second_guardrail_fallback'
+      : 'second_guardrail_rejected';
+  const note = revalidateRejected
+    ? 'web mock 二次 guardrail 复核未通过'
+    : finalDecision === 'allow'
+      ? '二次 guardrail 允许进入后续人工 apply 命令；当前不写正文'
+      : finalDecision === 'fallback'
+        ? '二次 guardrail 要求回退经典链路'
+        : '二次 guardrail 人工拒绝高层 apply';
+
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target,
+      decision: planDecision,
+      priority,
+      note,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target,
+      outcome,
+      note: finalDecision === 'allow'
+        ? '已允许进入下一步人工 apply，但未改写剧情正文'
+        : note,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${payload.requestId}:second_guardrail:${finalDecision}`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: planDecision,
+    reason: note,
+  };
+  if (finalDecision === 'fallback') {
+    trace.fallbackUsed = true;
+    trace.graphPath = [...trace.graphPath, 'ApplyFallback'];
+  }
+  return trace;
+}
+
+function applyWebNoNameManualPlotTextHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  segmentIndex?: unknown;
+  expectedSegmentText?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const segmentIndex = Number(args.segmentIndex);
+  const expectedSegmentText = String(args.expectedSegmentText ?? '');
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'plotTextHint') {
+    throw new Error('manual apply currently only supports plotTextHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web 模式下剧情未初始化。');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (plotState.current_chapter.content[segmentIndex] !== expectedSegmentText) {
+    throw new Error('segment snapshot mismatch; refusing stale manual apply');
+  }
+  if (expectedSegmentText.includes('【NoName】') || expectedSegmentText.includes('NoName提示')) {
+    throw new Error('segment already contains a NoName marker');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const hint = `【NoName】重点关注：${proposal.focus}`;
+  const updatedSegment = proposal.targetSegment === 'current_turn_head'
+    ? `${hint}\n\n${expectedSegmentText.trim()}`
+    : `${expectedSegmentText.trim()}\n\n${hint}`;
+  plotState.current_chapter.content[segmentIndex] = updatedSegment;
+  const historyIndex = plotState.plot_history.lastIndexOf(expectedSegmentText);
+  if (historyIndex < 0) {
+    throw new Error('plot history snapshot mismatch; refusing partial manual apply');
+  }
+  plotState.plot_history[historyIndex] = updatedSegment;
+  plotState.current_scene.description = plotState.current_chapter.content.join('\n\n');
+  if (plotState.last_action_result?.description === expectedSegmentText) {
+    plotState.last_action_result.description = updatedSegment;
+  }
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'plotTextHint',
+      decision: 'manual_apply',
+      priority: 375,
+      note: `显式人工 apply 已确认 chapter=${chapterIndex} segment=${segmentIndex}`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'plotTextHint',
+      outcome: 'manual_plot_text_applied',
+      note: `已由显式人工命令写入正文提示，聚焦“${proposal.focus}”`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:plot_text_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_plot_text_applied',
+    reason: '显式人工 apply 已写入正文提示',
+  };
+  return { trace, plotState };
+}
+
+function applyWebNoNameManualChapterSummaryHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  expectedSummary?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const expectedSummary = String(args.expectedSummary ?? '');
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'chapterSummaryHint') {
+    throw new Error('manual apply scope mismatch: expected chapterSummaryHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'chapterSummaryHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  if ((trace.applyExecutionLog ?? []).some((item) => (
+    item.target === 'chapterSummaryHint' && item.outcome === 'manual_chapter_summary_hint_applied'
+  ))) {
+    throw new Error('manual chapterSummaryHint has already been applied for this trace');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web runtime plot state is not initialized');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (plotState.current_chapter.summary !== expectedSummary) {
+    throw new Error('summary snapshot mismatch; refusing stale manual apply');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const focus = proposal.focus.trim();
+  const hint = `NoName summary hint: ${focus}`;
+  if (focus && (expectedSummary.includes(focus) || expectedSummary.includes(hint))) {
+    throw new Error('chapter summary already contains this NoName hint');
+  }
+  const currentSummary = expectedSummary.trim();
+  const updatedSummary = !currentSummary
+    ? hint
+    : proposal.targetSegment === 'chapter_summary_head'
+      ? `${hint}; ${currentSummary}`
+      : `${currentSummary}; ${hint}`;
+
+  plotState.current_chapter.summary = updatedSummary;
+  const chapter = plotState.chapters.find((item) => item.index === chapterIndex);
+  if (chapter) {
+    chapter.summary = updatedSummary;
+  }
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'chapterSummaryHint',
+      decision: 'manual_apply',
+      priority: 275,
+      note: `manual apply confirmed for chapter=${chapterIndex} scope=chapterSummaryHint`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'chapterSummaryHint',
+      outcome: 'manual_chapter_summary_hint_applied',
+      note: `manual chapter summary hint applied for focus=${proposal.focus}`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:chapter_summary_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_chapter_summary_hint_applied',
+    reason: 'manual chapter summary hint applied',
+  };
+  return { trace, plotState };
+}
+
+function applyWebNoNameManualOptionBiasHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  expectedGenerationDiagnostics?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const expectedGenerationDiagnostics = String(args.expectedGenerationDiagnostics ?? '');
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'optionBiasHint') {
+    throw new Error('manual apply scope mismatch: expected optionBiasHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'optionBiasHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  if ((trace.applyExecutionLog ?? []).some((item) => (
+    item.target === 'optionBiasHint' && item.outcome === 'manual_option_bias_hint_applied'
+  ))) {
+    throw new Error('manual optionBiasHint has already been applied for this trace');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web runtime plot state is not initialized');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (!plotState.is_waiting_for_input) {
+    throw new Error('optionBiasHint manual apply requires waiting-for-input state');
+  }
+  const currentDiagnostics = plotState.last_generation_diagnostics ?? '';
+  if (currentDiagnostics !== expectedGenerationDiagnostics) {
+    throw new Error('diagnostics snapshot mismatch; refusing stale manual apply');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const hint = `NoName option bias: next turn should prioritize actions around ${proposal.focus.trim()}`;
+  if (currentDiagnostics.includes(hint)) {
+    throw new Error('diagnostics already contains this NoName option bias hint');
+  }
+  plotState.last_generation_diagnostics = currentDiagnostics.trim()
+    ? `${currentDiagnostics}; ${hint}`
+    : hint;
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'optionBiasHint',
+      decision: 'manual_apply',
+      priority: 175,
+      note: `manual apply confirmed for chapter=${chapterIndex} scope=optionBiasHint`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'optionBiasHint',
+      outcome: 'manual_option_bias_hint_applied',
+      note: `manual option bias hint applied for focus=${proposal.focus}`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:option_bias_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_option_bias_hint_applied',
+    reason: 'manual option bias hint applied',
+  };
+  return { trace, plotState };
+}
+
 function resolveActionText(action: PlayerAction, options: PlayerOption[]): string {
   if (action.action_type === ActionType.FreeText) {
     return action.content.trim() || '你静静观察局势变化。';
@@ -499,9 +1056,7 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
   const baseParagraph = quickMode
     ? `你迅速执行“${text}”，局势发生了可控变化。`
     : `你选择“${text}”，新的线索逐渐浮现。`;
-  const paragraph = runtimeState.noNameMode === 'assisted' && applyScopes.includes('plotTextHint')
-    ? applyWebNoNamePlotHint(baseParagraph, text, targetSegment)
-    : baseParagraph;
+  const paragraph = baseParagraph;
 
   plotState.current_chapter.content.push(paragraph);
   plotState.plot_history.push(paragraph);
@@ -513,9 +1068,7 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
     plotState.last_generation_diagnostics += `；NoName.observeOnly：focus=${text}；target_segment=${targetSegment}；apply=skipped_observe_only`;
   }
   if (runtimeState.noNameMode === 'assisted') {
-    const applyOutcome = applyScopes.includes('plotTextHint')
-      ? 'applied_summary_option_bias_and_plot_text'
-      : 'applied_summary_and_option_bias';
+    const applyOutcome = 'applied_summary_and_option_bias';
     plotState.last_generation_diagnostics += `；NoName.assisted：focus=${text}；target_segment=${targetSegment}；scopes=${applyScopes.join(',')}；apply=${applyOutcome}`;
     if (applyScopes.includes('chapterSummaryHint')) {
       plotState.current_chapter.summary = applyWebNoNameSummaryHint(
@@ -730,6 +1283,34 @@ export async function invokeWebRuntime<T>(
       runtimeState.noNameTraces = [];
       persistState();
       return undefined as T;
+    case 'mark_noname_controlled_output_review': {
+      const trace = markWebNoNameControlledOutputReview(args as unknown as NoNameHumanReviewMarkPayload);
+      persistState();
+      return trace as T;
+    }
+    case 'resolve_noname_second_guardrail': {
+      const trace = resolveWebNoNameSecondGuardrail(args as unknown as NoNameSecondGuardrailResolvePayload);
+      persistState();
+      return trace as T;
+    }
+    case 'apply_noname_manual_plot_text_hint': {
+      const result = applyWebNoNameManualPlotTextHint(args);
+      persistState();
+      return result as T;
+    }
+    case 'apply_noname_reviewed_output': {
+      const result = args.scope === 'chapterSummaryHint'
+        ? applyWebNoNameManualChapterSummaryHint(args)
+        : args.scope === 'optionBiasHint'
+          ? applyWebNoNameManualOptionBiasHint(args)
+          : args.scope === 'plotTextHint'
+            ? applyWebNoNameManualPlotTextHint(args)
+            : (() => {
+              throw new Error(`Web mock reviewed apply currently does not support ${String(args.scope)}`);
+            })();
+      persistState();
+      return result as T;
+    }
     case 'get_noname_mode':
       return runtimeState.noNameMode as T;
     case 'set_noname_mode':

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -367,6 +367,7 @@ describe('gameStore', () => {
         safeApplyScope: 'plotTextHint',
         policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
         requiresHumanReview: true,
+        humanReviewDecision: 'approvedForHigherApply',
       }],
       relatedObservations: [{
         role: 'worldCurator',
@@ -413,9 +414,10 @@ describe('gameStore', () => {
 
     const text = store.getNoNameTraceDebugText();
     expect(text).toContain('预检：preflight_ready');
+    expect(text).toContain('应用生命周期：提案阶段:ready');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
-    expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact]');
+    expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact][人工=approvedForHigherApply]');
     expect(text).toContain('状态迁移：proposal-1:ready');
     expect(text).toContain('提案：Director提案：山门危机 / 山门危机 / ready');
     expect(text).toContain('目标段：current_turn_tail');
@@ -423,5 +425,164 @@ describe('gameStore', () => {
     expect(text).toContain('作用域：diagnostics, chapterSummaryHint');
     expect(text).toContain('agent:delegation:running');
     expect(text).toContain('协作观察：worldCurator:山门法阵');
+  });
+
+  it('marks a NoName controlled output review and updates local trace', async () => {
+    const store = useGameStore();
+    store.noNameTraces = [{
+      traceId: 'trace-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+      controlledOutputReviews: [{
+        requestId: 'review-1',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'requires review',
+        safeApplyScope: 'plotTextHint',
+        requiresHumanReview: true,
+      }],
+    }];
+    invokeMock.mockResolvedValue({
+      ...store.noNameTraces[0],
+      controlledOutputReviews: [{
+        requestId: 'review-1',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'requires review',
+        safeApplyScope: 'plotTextHint',
+        requiresHumanReview: true,
+        humanReviewDecision: 'rejectedForHigherApply',
+      }],
+    });
+
+    await store.markNoNameControlledOutputReview({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'rejectedForHigherApply',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('mark_noname_controlled_output_review', {
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'rejectedForHigherApply',
+    });
+    expect(store.noNameTraces[0].controlledOutputReviews?.[0].humanReviewDecision)
+      .toBe('rejectedForHigherApply');
+  });
+
+  it('resolves a NoName second guardrail decision and updates local trace', async () => {
+    const store = useGameStore();
+    store.noNameTraces = [{
+      traceId: 'trace-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+      applyPlanLog: [],
+      applyExecutionLog: [],
+    }];
+    invokeMock.mockResolvedValue({
+      ...store.noNameTraces[0],
+      applyPlanLog: [{
+        order: 1,
+        target: 'plot_text_hint',
+        decision: 'second_guardrail_allow',
+        priority: 350,
+        note: 'allowed',
+      }],
+    });
+
+    await store.resolveNoNameSecondGuardrail({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'allow',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('resolve_noname_second_guardrail', {
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'allow',
+    });
+    expect(store.noNameTraces[0].applyPlanLog?.[0]?.decision).toBe('second_guardrail_allow');
+  });
+
+  it('applies a manual NoName plot text hint with current segment snapshot', async () => {
+    const store = useGameStore();
+    const plotState = basePlotState();
+    plotState.current_chapter.index = 1;
+    plotState.current_chapter.content = ['你看见山门风声渐紧。'];
+    plotState.plot_history = ['你看见山门风声渐紧。'];
+    store.plotState = plotState;
+    store.noNameTraces = [{
+      traceId: 'trace-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+    }];
+    invokeMock.mockResolvedValue({
+      trace: {
+        ...store.noNameTraces[0],
+        applyExecutionLog: [{
+          target: 'plot_text_hint',
+          outcome: 'manual_plot_text_applied',
+          note: 'applied',
+        }],
+      },
+      plotState: {
+        ...plotState,
+        current_chapter: {
+          ...plotState.current_chapter,
+          content: ['你看见山门风声渐紧。\n\n【NoName】重点关注：山门危机'],
+        },
+      },
+    });
+
+    await store.applyNoNameManualPlotTextHint({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('apply_noname_reviewed_output', {
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      scope: 'plotTextHint',
+      chapterIndex: 1,
+      segmentIndex: 0,
+      expectedSegmentText: '你看见山门风声渐紧。',
+    });
+    expect(store.plotState?.current_chapter.content[0]).toContain('【NoName】重点关注');
+    expect(store.noNameTraces[0].applyExecutionLog?.[0]?.outcome)
+      .toBe('manual_plot_text_applied');
+  });
+
+  it('shows a friendly stale snapshot error for manual NoName plot text apply', async () => {
+    const store = useGameStore();
+    const plotState = basePlotState();
+    plotState.current_chapter.index = 1;
+    plotState.current_chapter.content = ['你看见山门风声渐紧。'];
+    store.plotState = plotState;
+    invokeMock.mockRejectedValue(new Error('segment snapshot mismatch; refusing stale manual apply'));
+
+    await expect(store.applyNoNameManualPlotTextHint({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+    })).rejects.toThrow('当前剧情段落已变化');
+
+    expect(store.error).toBe('NoName 人工写入已取消：当前剧情段落已变化，请重新打开调试台确认差异预览。');
   });
 });

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,5 +1,6 @@
 ﻿import { defineStore } from 'pinia';
 import { invokeRuntime, invokeWithTimeout } from '../utils/tauriInvoke';
+import { summarizeNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
 import type {
   Script,
   GameState,
@@ -11,6 +12,10 @@ import type {
   WorldRegistry,
   GenerationTimingSummary,
   GenerationFailureSummary,
+  NoNameHumanReviewMarkPayload,
+  NoNameManualPlotTextApplyPayload,
+  NoNameManualPlotTextApplyResult,
+  NoNameSecondGuardrailResolvePayload,
   NoNameTrace,
 } from '../types/game';
 
@@ -34,6 +39,26 @@ interface GameStoreState {
 const LLM_TIMEOUT_MS = 60 * 1000;
 const OPTION_LLM_STORY_BLOCKED_MARKER = '本轮为选项续写：未获得可用 LLM 剧情文本';
 const MAX_GENERATION_DIAGNOSTICS = 40;
+
+function humanizeNoNameManualApplyError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('segment snapshot mismatch')) {
+    return 'NoName 人工写入已取消：当前剧情段落已变化，请重新打开调试台确认差异预览。';
+  }
+  if (message.includes('segment already contains a NoName marker')) {
+    return 'NoName 人工写入已取消：当前段落已经包含 NoName 标记，避免重复写入。';
+  }
+  if (message.includes('manual plot text hint has already been applied')) {
+    return 'NoName 人工写入已取消：这条提示已经应用过了。';
+  }
+  if (message.includes('second guardrail has not allowed')) {
+    return 'NoName 人工写入已取消：二次护栏尚未允许该复核项。';
+  }
+  if (message.includes('chapter mismatch')) {
+    return 'NoName 人工写入已取消：当前章节已变化，请重新确认目标段落。';
+  }
+  return message;
+}
 
 export const useGameStore = defineStore('game', {
   state: (): GameStoreState => ({
@@ -176,6 +201,98 @@ export const useGameStore = defineStore('game', {
       }
     },
 
+    async markNoNameControlledOutputReview(payload: NoNameHumanReviewMarkPayload) {
+      try {
+        const updatedTrace = await invokeRuntime<NoNameTrace>(
+          'mark_noname_controlled_output_review',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            decision: payload.decision,
+          },
+        );
+        const index = this.noNameTraces.findIndex((trace) => trace.traceId === updatedTrace.traceId);
+        if (index >= 0) {
+          this.noNameTraces = [
+            ...this.noNameTraces.slice(0, index),
+            updatedTrace,
+            ...this.noNameTraces.slice(index + 1),
+          ];
+        } else {
+          this.noNameTraces = [...this.noNameTraces, updatedTrace];
+        }
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+        throw error;
+      }
+    },
+
+    async resolveNoNameSecondGuardrail(payload: NoNameSecondGuardrailResolvePayload) {
+      try {
+        const updatedTrace = await invokeRuntime<NoNameTrace>(
+          'resolve_noname_second_guardrail',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            decision: payload.decision,
+          },
+        );
+        const index = this.noNameTraces.findIndex((trace) => trace.traceId === updatedTrace.traceId);
+        if (index >= 0) {
+          this.noNameTraces = [
+            ...this.noNameTraces.slice(0, index),
+            updatedTrace,
+            ...this.noNameTraces.slice(index + 1),
+          ];
+        } else {
+          this.noNameTraces = [...this.noNameTraces, updatedTrace];
+        }
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+        throw error;
+      }
+    },
+
+    async applyNoNameManualPlotTextHint(payload: NoNameManualPlotTextApplyPayload) {
+      const chapterIndex = this.plotState?.current_chapter.index;
+      const segmentIndex = (this.plotState?.current_chapter.content.length ?? 0) - 1;
+      const expectedSegmentText = segmentIndex >= 0
+        ? this.plotState?.current_chapter.content[segmentIndex]
+        : undefined;
+      if (typeof chapterIndex !== 'number' || segmentIndex < 0 || !expectedSegmentText) {
+        this.error = '无法执行 NoName 人工写入：当前剧情段落为空。';
+        throw new Error(this.error);
+      }
+
+      try {
+        const result = await invokeRuntime<NoNameManualPlotTextApplyResult>(
+          'apply_noname_reviewed_output',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            scope: 'plotTextHint',
+            chapterIndex,
+            segmentIndex,
+            expectedSegmentText,
+          },
+        );
+        this.plotState = result.plotState;
+        const index = this.noNameTraces.findIndex((trace) => trace.traceId === result.trace.traceId);
+        if (index >= 0) {
+          this.noNameTraces = [
+            ...this.noNameTraces.slice(0, index),
+            result.trace,
+            ...this.noNameTraces.slice(index + 1),
+          ];
+        } else {
+          this.noNameTraces = [...this.noNameTraces, result.trace];
+        }
+      } catch (error) {
+        this.error = humanizeNoNameManualApplyError(error);
+        throw new Error(this.error);
+      }
+    },
+
     getGenerationDiagnosticsText() {
       if (this.generationDiagnostics.length === 0) {
         return '暂无诊断数据。';
@@ -230,10 +347,14 @@ export const useGameStore = defineStore('game', {
             const policyScopes = item.policyForbiddenScopes?.length
               ? `[禁区=${item.policyForbiddenScopes.join('/')}]`
               : '';
-            return `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}${policyScopes}`;
+            const humanDecision = item.humanReviewDecision
+              ? `[人工=${item.humanReviewDecision}]`
+              : '';
+            return `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}${policyScopes}${humanDecision}`;
           })
           .join(', ')
         : '无';
+      const applyLifecycle = summarizeNoNameApplyLifecycle(latest);
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -247,6 +368,7 @@ export const useGameStore = defineStore('game', {
         `预期效果：${proposal?.intendedEffect || '无'}`,
         `作用域：${proposalScopes}`,
         `预检：${latest.applyResult ? `${latest.applyResult.outcome}${latest.applyResult.reason ? ` (${latest.applyResult.reason})` : ''}` : '无'}`,
+        `应用生命周期：${applyLifecycle}`,
         `应用计划：${applyPlans}`,
         `应用执行：${applyExecutions}`,
         `状态迁移：${latest.proposalTransitionLog && latest.proposalTransitionLog.length > 0 ? latest.proposalTransitionLog.join(', ') : '无'}`,

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -349,6 +349,44 @@ export interface NoNameControlledOutputReviewRecord {
   safeApplyScope?: NoNameApplyScope | null;
   policyForbiddenScopes?: NoNameForbiddenOutputScope[];
   requiresHumanReview: boolean;
+  humanReviewDecision?: NoNameHumanReviewDecision | null;
+  humanReviewedAt?: number | null;
+  humanReviewNote?: string | null;
+}
+
+export type NoNameHumanReviewDecision =
+  | 'pending'
+  | 'approvedForHigherApply'
+  | 'rejectedForHigherApply';
+
+export interface NoNameHumanReviewMarkPayload {
+  traceId: string;
+  requestId: string;
+  decision: NoNameHumanReviewDecision;
+}
+
+export type NoNameSecondGuardrailDecision = 'allow' | 'reject' | 'fallback';
+
+export interface NoNameSecondGuardrailResolvePayload {
+  traceId: string;
+  requestId: string;
+  decision: NoNameSecondGuardrailDecision;
+}
+
+export interface NoNameManualPlotTextApplyPayload {
+  traceId: string;
+  requestId: string;
+}
+
+export interface NoNameManualApplySegmentSnapshot {
+  chapterIndex: number;
+  segmentIndex: number;
+  text: string;
+}
+
+export interface NoNameManualPlotTextApplyResult {
+  trace: NoNameTrace;
+  plotState: PlotState;
 }
 
 export type NoNameProposalStatus = 'observed' | 'ready' | 'blocked' | 'applied' | 'fallback';

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -342,6 +342,7 @@ export type NoNameForbiddenOutputScope =
 
 export interface NoNameControlledOutputReviewRecord {
   requestId: string;
+  proposalId?: string | null;
   requestedKind: NoNameControlledOutputKind;
   decision: NoNameControlledOutputDecision;
   reason: string;

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -1,0 +1,204 @@
+import type {
+  NoNameHumanReviewDecision,
+  NoNameTrace,
+} from '../types/game';
+
+export type NoNameApplyLifecycleTone = 'done' | 'pending' | 'blocked' | 'fallback' | 'info';
+
+export interface NoNameApplyLifecycleStep {
+  key: string;
+  label: string;
+  state: string;
+  detail: string;
+  tone: NoNameApplyLifecycleTone;
+}
+
+function normalizeTarget(value: string | undefined) {
+  return (value ?? '').replace(/_/g, '').toLowerCase();
+}
+
+function hasExecution(trace: NoNameTrace, target: string, outcome: string) {
+  const normalizedTarget = normalizeTarget(target);
+  return Boolean(trace.applyExecutionLog?.some((item) => (
+    normalizeTarget(item.target) === normalizedTarget
+    && item.outcome === outcome
+  )));
+}
+
+function hasExecutionOutcome(trace: NoNameTrace, outcome: string) {
+  return Boolean(trace.applyExecutionLog?.some((item) => item.outcome === outcome));
+}
+
+function hasTransition(trace: NoNameTrace, suffix: string) {
+  return Boolean(trace.proposalTransitionLog?.some((item) => item.endsWith(suffix)));
+}
+
+function resolvePreflightTone(outcome: string | undefined): NoNameApplyLifecycleTone {
+  if (!outcome) {
+    return 'pending';
+  }
+  if (outcome.includes('fallback')) {
+    return 'fallback';
+  }
+  if (outcome.includes('reject') || outcome.includes('rejected') || outcome.includes('blocked')) {
+    return 'blocked';
+  }
+  if (
+    outcome.includes('ready')
+    || outcome.includes('applied')
+    || outcome.includes('allow')
+    || outcome.includes('manual_plot_text_applied')
+  ) {
+    return 'done';
+  }
+  return 'info';
+}
+
+function lifecycleHumanDecision(
+  trace: NoNameTrace,
+  requestId: string,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision>,
+) {
+  return reviewDecisions[requestId]
+    ?? trace.controlledOutputReviews?.find((item) => item.requestId === requestId)?.humanReviewDecision
+    ?? 'pending';
+}
+
+export function buildNoNameApplyLifecycle(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+): NoNameApplyLifecycleStep[] {
+  const latestProposal = trace.proposals[trace.proposals.length - 1] ?? null;
+  const controlledReviews = trace.controlledOutputReviews ?? [];
+  const humanReviews = controlledReviews.filter((item) => item.requiresHumanReview);
+  const pendingHumanReviewCount = humanReviews.filter((item) => (
+    lifecycleHumanDecision(trace, item.requestId, reviewDecisions) === 'pending'
+  )).length;
+  const lowRiskTargets = ['diagnostics', 'chapterSummaryHint', 'optionBiasHint'];
+  const appliedLowRiskTargets = lowRiskTargets.filter((target) => hasExecution(trace, target, 'applied'));
+  const secondGuardrailAllowed = hasExecutionOutcome(trace, 'second_guardrail_allowed')
+    || hasTransition(trace, ':second_guardrail:allow');
+  const secondGuardrailRejected = hasExecutionOutcome(trace, 'second_guardrail_rejected')
+    || hasTransition(trace, ':second_guardrail:reject');
+  const secondGuardrailFallback = hasExecutionOutcome(trace, 'second_guardrail_fallback')
+    || hasTransition(trace, ':second_guardrail:fallback');
+  const awaitingSecondGuardrail = hasExecutionOutcome(trace, 'awaiting_second_guardrail')
+    || hasTransition(trace, ':apply_intent:awaiting_second_guardrail');
+  const manualApplied = hasExecutionOutcome(trace, 'manual_plot_text_applied')
+    || hasTransition(trace, ':manual_apply:plot_text_hint');
+  const preflightOutcome = trace.applyResult?.outcome;
+
+  const steps: NoNameApplyLifecycleStep[] = [
+    {
+      key: 'proposal',
+      label: '提案阶段',
+      state: latestProposal
+        ? (latestProposal.status ?? (latestProposal.applyable ? 'ready' : 'observed'))
+        : '无提案',
+      detail: latestProposal
+        ? `${latestProposal.producerRole} · ${latestProposal.targetSegment} · ${latestProposal.applyScopes?.join('/') || 'no-scope'}`
+        : '尚未生成 NoName proposal',
+      tone: latestProposal?.applyable || latestProposal?.status === 'applied' || latestProposal?.status === 'ready'
+        ? 'done'
+        : 'info',
+    },
+    {
+      key: 'preflight',
+      label: 'Apply 预检',
+      state: preflightOutcome ?? '未尝试',
+      detail: trace.applyResult?.reason ?? '尚未记录 applyResult',
+      tone: resolvePreflightTone(preflightOutcome),
+    },
+    {
+      key: 'low-risk',
+      label: '低风险输出',
+      state: appliedLowRiskTargets.length > 0 ? '已应用' : '未应用',
+      detail: appliedLowRiskTargets.length > 0
+        ? `已应用：${appliedLowRiskTargets.join(' / ')}`
+        : '尚未看到 diagnostics / chapterSummaryHint / optionBiasHint 的 applied 记录',
+      tone: appliedLowRiskTargets.length > 0 ? 'done' : 'pending',
+    },
+    {
+      key: 'review',
+      label: '人工复核',
+      state: humanReviews.length === 0
+        ? '无需人工'
+        : pendingHumanReviewCount === 0
+          ? '已确认'
+          : `待确认 ${pendingHumanReviewCount}`,
+      detail: controlledReviews.length > 0
+        ? `受控输出 ${controlledReviews.length} 条，其中人工复核 ${humanReviews.length} 条`
+        : '无 controlled output review',
+      tone: pendingHumanReviewCount > 0 ? 'pending' : 'done',
+    },
+  ];
+
+  if (humanReviews.length > 0 || awaitingSecondGuardrail || secondGuardrailAllowed || secondGuardrailRejected || secondGuardrailFallback) {
+    steps.push({
+      key: 'second-guardrail',
+      label: '二次护栏',
+      state: secondGuardrailFallback
+        ? 'fallback'
+        : secondGuardrailRejected
+          ? 'rejected'
+          : secondGuardrailAllowed
+            ? 'allow'
+            : awaitingSecondGuardrail
+              ? 'waiting'
+              : '未进入',
+      detail: secondGuardrailAllowed
+        ? '已允许进入显式人工 apply；仍不会自动写正文'
+        : secondGuardrailFallback
+          ? '已要求回退经典链路'
+          : secondGuardrailRejected
+            ? '已拒绝高层 apply'
+            : '等待人工批准后进入二次护栏',
+      tone: secondGuardrailFallback
+        ? 'fallback'
+        : secondGuardrailRejected
+          ? 'blocked'
+          : secondGuardrailAllowed
+            ? 'done'
+            : 'pending',
+    });
+  }
+
+  if (humanReviews.some((item) => item.safeApplyScope === 'plotTextHint') || secondGuardrailAllowed || manualApplied) {
+    steps.push({
+      key: 'manual-plot-text',
+      label: '人工写入',
+      state: manualApplied
+        ? '已写入'
+        : secondGuardrailAllowed
+          ? '等待显式命令'
+          : '未就绪',
+      detail: manualApplied
+        ? '已记录 manual_plot_text_applied'
+        : secondGuardrailAllowed
+          ? '需要开发者确认差异预览后手动写入'
+          : 'PlotTextHint 需要人工复核与二次护栏',
+      tone: manualApplied ? 'done' : secondGuardrailAllowed ? 'pending' : 'info',
+    });
+  }
+
+  if (trace.fallbackUsed) {
+    steps.push({
+      key: 'fallback',
+      label: '回退',
+      state: '已回退',
+      detail: 'fallbackUsed=true，后续继续依赖经典链路',
+      tone: 'fallback',
+    });
+  }
+
+  return steps;
+}
+
+export function summarizeNoNameApplyLifecycle(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+) {
+  return buildNoNameApplyLifecycle(trace, reviewDecisions)
+    .map((step) => `${step.label}:${step.state}`)
+    .join(' -> ');
+}


### PR DESCRIPTION
## Summary
- add reusable NoName reviewed apply runtime for PlotTextHint, ChapterSummaryHint, and OptionBiasHint
- add frontend lifecycle visibility for apply/review/guardrail/manual apply states
- update Web runtime mocks, tests, and architecture docs for T7 reviewed apply progress

## Validation
- cargo test noname_apply -- --nocapture
- cargo clippy -- -D warnings
- npm test -- --run src/platform/webRuntime.test.ts src/stores/__tests__/gameStore.test.ts src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts
- npm run build
- git diff --check

Do not merge yet.