### PR TITLE
refactor(noname): extract reviewed apply helpers

### DIFF
--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -51,6 +51,12 @@
   - review / second guardrail / manual apply 共用逻辑
   - 尽量让命令层只做参数接收与结果返回
 
+当前状态：
+
+- 已完成第一轮下沉
+- reviewed apply 的 request builder 与 plotText manual apply helper 已进入 `noname_apply.rs`
+- `tauri_commands.rs` 在 reviewed apply 路径上已减少内联快照构造与包装逻辑
+
 ## P2：收口后继续推进
 
 ### 任务 5：增强记忆检索质量

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -53,9 +53,10 @@
 
 当前状态：
 
-- 已完成第一轮下沉
+- 已完成第二轮下沉
 - reviewed apply 的 request builder 与 plotText manual apply helper 已进入 `noname_apply.rs`
 - `tauri_commands.rs` 在 reviewed apply 路径上已减少内联快照构造与包装逻辑
+- reviewed apply 命令已开始复用共享的 trace 读取、plot state 更新和 trace 回写壳层
 
 ## P2：收口后继续推进
 

--- a/docs/项目文档/03-规划/04-未来两周开发排期.md
+++ b/docs/项目文档/03-规划/04-未来两周开发排期.md
@@ -89,6 +89,12 @@
 - 最小验证：
   - `cargo test noname_ -- --nocapture`
 
+当前状态：
+
+- 第一轮已完成
+- `NoNameReviewedApplyRequest` 构造与 plotText manual apply helper 已从命令层下沉到 `noname_apply.rs`
+- 下一轮可继续抽离 trace 获取 / result 回写的共用壳层
+
 ### 任务 A3：建立 `NoName` 主链变更的文档闭环
 
 - 目标：

--- a/docs/项目文档/03-规划/04-未来两周开发排期.md
+++ b/docs/项目文档/03-规划/04-未来两周开发排期.md
@@ -91,9 +91,10 @@
 
 当前状态：
 
-- 第一轮已完成
+- 第二轮已完成
 - `NoNameReviewedApplyRequest` 构造与 plotText manual apply helper 已从命令层下沉到 `noname_apply.rs`
-- 下一轮可继续抽离 trace 获取 / result 回写的共用壳层
+- trace 获取 / result 回写的共用壳层已开始抽出并复用到两个 reviewed apply 命令
+- 下一轮可继续观察 review / second guardrail 命令是否也值得抽出同类 runtime helper
 
 ### 任务 A3：建立 `NoName` 主链变更的文档闭环
 

--- a/src-tauri/src/noname_apply.rs
+++ b/src-tauri/src/noname_apply.rs
@@ -36,6 +36,78 @@ pub struct NoNameReviewedApplyOutcome {
     pub plot_state: PlotState,
 }
 
+pub fn build_manual_plot_text_apply_request(
+    request_id: impl Into<String>,
+    chapter_index: u32,
+    segment_index: usize,
+    expected_segment_text: impl Into<String>,
+) -> NoNameReviewedApplyRequest {
+    NoNameReviewedApplyRequest {
+        request_id: request_id.into(),
+        scope: NoNameApplyScope::PlotTextHint,
+        segment_snapshot: Some(NoNameApplySegmentSnapshot {
+            chapter_index,
+            segment_index,
+            expected_segment_text: expected_segment_text.into(),
+        }),
+        summary_snapshot: None,
+        diagnostics_snapshot: None,
+    }
+}
+
+pub fn build_reviewed_apply_request(
+    request_id: String,
+    scope: NoNameApplyScope,
+    chapter_index: Option<u32>,
+    segment_index: Option<usize>,
+    expected_segment_text: Option<String>,
+    expected_summary: Option<String>,
+    expected_generation_diagnostics: Option<String>,
+) -> Result<NoNameReviewedApplyRequest, String> {
+    let segment_snapshot = match scope {
+        NoNameApplyScope::PlotTextHint => Some(NoNameApplySegmentSnapshot {
+            chapter_index: chapter_index
+                .ok_or_else(|| "plot_text_hint manual apply requires chapter_index".to_string())?,
+            segment_index: segment_index
+                .ok_or_else(|| "plot_text_hint manual apply requires segment_index".to_string())?,
+            expected_segment_text: expected_segment_text.ok_or_else(|| {
+                "plot_text_hint manual apply requires expected_segment_text".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+    let summary_snapshot = match scope {
+        NoNameApplyScope::ChapterSummaryHint => Some(NoNameApplySummarySnapshot {
+            chapter_index: chapter_index.ok_or_else(|| {
+                "chapter_summary_hint manual apply requires chapter_index".to_string()
+            })?,
+            expected_summary: expected_summary.ok_or_else(|| {
+                "chapter_summary_hint manual apply requires expected_summary".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+    let diagnostics_snapshot = match scope {
+        NoNameApplyScope::OptionBiasHint => Some(NoNameApplyDiagnosticsSnapshot {
+            chapter_index: chapter_index.ok_or_else(|| {
+                "option_bias_hint manual apply requires chapter_index".to_string()
+            })?,
+            expected_generation_diagnostics: expected_generation_diagnostics.ok_or_else(|| {
+                "option_bias_hint manual apply requires expected_generation_diagnostics".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+
+    Ok(NoNameReviewedApplyRequest {
+        request_id,
+        scope,
+        segment_snapshot,
+        summary_snapshot,
+        diagnostics_snapshot,
+    })
+}
+
 fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
     match scope {
         NoNameApplyScope::PlotTextHint => 300,
@@ -443,6 +515,26 @@ pub fn apply_reviewed_output_to_plot_state(
             scope.as_str()
         )),
     }
+}
+
+pub fn apply_manual_plot_text_hint_to_plot_state(
+    trace: NoNameTrace,
+    request_id: &str,
+    plot_state: PlotState,
+    chapter_index: u32,
+    segment_index: usize,
+    expected_segment_text: &str,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    apply_reviewed_output_to_plot_state(
+        trace,
+        build_manual_plot_text_apply_request(
+            request_id,
+            chapter_index,
+            segment_index,
+            expected_segment_text,
+        ),
+        plot_state,
+    )
 }
 
 #[cfg(test)]

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -215,6 +215,57 @@ pub struct NoNameManualPlotTextApplyResult {
     pub plot_state: PlotState,
 }
 
+fn load_noname_trace(trace_id: &str) -> Result<NoNameTrace, String> {
+    let runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    runtime
+        .get_recent_traces()
+        .into_iter()
+        .rev()
+        .find(|trace| trace.trace_id == trace_id)
+        .ok_or_else(|| format!("NoName trace not found: {}", trace_id))
+}
+
+fn replace_noname_trace(trace_id: &str, trace: NoNameTrace) -> Result<(), String> {
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    if !runtime.replace_trace(trace) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+    Ok(())
+}
+
+fn apply_noname_outcome_with_engine<F>(
+    trace_id: &str,
+    engine: &State<'_, Mutex<GameEngine>>,
+    apply: F,
+) -> Result<NoNameManualPlotTextApplyResult, String>
+where
+    F: FnOnce(NoNameTrace, PlotState) -> Result<crate::noname_apply::NoNameReviewedApplyOutcome, String>,
+{
+    let trace = load_noname_trace(trace_id)?;
+    let result = {
+        let engine = match engine.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
+        let outcome = apply(trace, plot_state)?;
+        let result = NoNameManualPlotTextApplyResult {
+            trace: outcome.trace,
+            plot_state: outcome.plot_state,
+        };
+        engine
+            .update_plot_state(result.plot_state.clone())
+            .map_err(|e| e.to_string())?;
+        result
+    };
+    replace_noname_trace(trace_id, result.trace.clone())?;
+    Ok(result)
+}
+
 fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
     match scope {
         NoNameApplyScope::PlotTextHint => 300,
@@ -4442,50 +4493,16 @@ pub async fn apply_noname_manual_plot_text_hint(
     expected_segment_text: String,
     engine: State<'_, Mutex<GameEngine>>,
 ) -> Result<NoNameManualPlotTextApplyResult, String> {
-    let trace = {
-        let runtime = noname_runtime()
-            .lock()
-            .map_err(|_| "NoName runtime lock poisoned".to_string())?;
-        runtime
-            .get_recent_traces()
-            .into_iter()
-            .rev()
-            .find(|trace| trace.trace_id == trace_id)
-            .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?
-    };
-
-    let result = {
-        let engine = match engine.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
-        let outcome = apply_manual_plot_text_hint_to_plot_state(
+    apply_noname_outcome_with_engine(&trace_id, &engine, |trace, plot_state| {
+        apply_manual_plot_text_hint_to_plot_state(
             trace,
             &request_id,
             plot_state,
             chapter_index,
             segment_index,
             &expected_segment_text,
-        )?;
-        let result = NoNameManualPlotTextApplyResult {
-            trace: outcome.trace,
-            plot_state: outcome.plot_state,
-        };
-        engine
-            .update_plot_state(result.plot_state.clone())
-            .map_err(|e| e.to_string())?;
-        result
-    };
-
-    let mut runtime = noname_runtime()
-        .lock()
-        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
-    if !runtime.replace_trace(result.trace.clone()) {
-        return Err(format!("NoName trace not found: {}", trace_id));
-    }
-
-    Ok(result)
+        )
+    })
 }
 
 #[tauri::command]
@@ -4510,43 +4527,9 @@ pub async fn apply_noname_reviewed_output(
         expected_summary,
         expected_generation_diagnostics,
     )?;
-    let trace = {
-        let runtime = noname_runtime()
-            .lock()
-            .map_err(|_| "NoName runtime lock poisoned".to_string())?;
-        runtime
-            .get_recent_traces()
-            .into_iter()
-            .rev()
-            .find(|trace| trace.trace_id == trace_id)
-            .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?
-    };
-
-    let result = {
-        let engine = match engine.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
-        let outcome = apply_reviewed_output_to_plot_state(trace, request, plot_state)?;
-        let result = NoNameManualPlotTextApplyResult {
-            trace: outcome.trace,
-            plot_state: outcome.plot_state,
-        };
-        engine
-            .update_plot_state(result.plot_state.clone())
-            .map_err(|e| e.to_string())?;
-        result
-    };
-
-    let mut runtime = noname_runtime()
-        .lock()
-        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
-    if !runtime.replace_trace(result.trace.clone()) {
-        return Err(format!("NoName trace not found: {}", trace_id));
-    }
-
-    Ok(result)
+    apply_noname_outcome_with_engine(&trace_id, &engine, |trace, plot_state| {
+        apply_reviewed_output_to_plot_state(trace, request, plot_state)
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -15,8 +15,8 @@ use crate::llm_runtime_config::{
 use crate::llm_service::{LLMConfig, LLMRequest, LLMService};
 use crate::memory_layers::{ChapterSummary, MemoryEntry, WorldFact};
 use crate::noname_apply::{
-    apply_reviewed_output_to_plot_state, NoNameApplyDiagnosticsSnapshot,
-    NoNameApplySegmentSnapshot, NoNameApplySummarySnapshot, NoNameReviewedApplyRequest,
+    apply_manual_plot_text_hint_to_plot_state, apply_reviewed_output_to_plot_state,
+    build_reviewed_apply_request,
 };
 use crate::noname_config::NoNameConfig;
 use crate::noname_context_builder::build_context_packet;
@@ -713,100 +713,6 @@ fn record_noname_second_guardrail_decision(
     }
 
     Ok(())
-}
-
-fn apply_noname_manual_plot_text_hint_to_plot_state(
-    trace: NoNameTrace,
-    request_id: &str,
-    plot_state: PlotState,
-    chapter_index: u32,
-    segment_index: usize,
-    expected_segment_text: &str,
-) -> Result<NoNameManualPlotTextApplyResult, String> {
-    let outcome = apply_reviewed_output_to_plot_state(
-        trace,
-        NoNameReviewedApplyRequest {
-            request_id: request_id.to_string(),
-            scope: NoNameApplyScope::PlotTextHint,
-            segment_snapshot: Some(NoNameApplySegmentSnapshot {
-                chapter_index,
-                segment_index,
-                expected_segment_text: expected_segment_text.to_string(),
-            }),
-            summary_snapshot: None,
-            diagnostics_snapshot: None,
-        },
-        plot_state,
-    )?;
-    Ok(NoNameManualPlotTextApplyResult {
-        trace: outcome.trace,
-        plot_state: outcome.plot_state,
-    })
-}
-
-fn build_noname_reviewed_apply_request(
-    request_id: String,
-    scope: NoNameApplyScope,
-    chapter_index: Option<u32>,
-    segment_index: Option<usize>,
-    expected_segment_text: Option<String>,
-    expected_summary: Option<String>,
-    expected_generation_diagnostics: Option<String>,
-) -> Result<NoNameReviewedApplyRequest, String> {
-    let segment_snapshot = match scope {
-        NoNameApplyScope::PlotTextHint => Some(NoNameApplySegmentSnapshot {
-            chapter_index: chapter_index
-                .ok_or_else(|| "plot_text_hint manual apply requires chapter_index".to_string())?,
-            segment_index: segment_index
-                .ok_or_else(|| "plot_text_hint manual apply requires segment_index".to_string())?,
-            expected_segment_text: expected_segment_text.ok_or_else(|| {
-                "plot_text_hint manual apply requires expected_segment_text".to_string()
-            })?,
-        }),
-        _ => None,
-    };
-    let summary_snapshot = match scope {
-        NoNameApplyScope::ChapterSummaryHint => Some(NoNameApplySummarySnapshot {
-            chapter_index: chapter_index.ok_or_else(|| {
-                "chapter_summary_hint manual apply requires chapter_index".to_string()
-            })?,
-            expected_summary: expected_summary.ok_or_else(|| {
-                "chapter_summary_hint manual apply requires expected_summary".to_string()
-            })?,
-        }),
-        _ => None,
-    };
-    let diagnostics_snapshot = match scope {
-        NoNameApplyScope::OptionBiasHint => Some(NoNameApplyDiagnosticsSnapshot {
-            chapter_index: chapter_index.ok_or_else(|| {
-                "option_bias_hint manual apply requires chapter_index".to_string()
-            })?,
-            expected_generation_diagnostics: expected_generation_diagnostics.ok_or_else(|| {
-                "option_bias_hint manual apply requires expected_generation_diagnostics".to_string()
-            })?,
-        }),
-        _ => None,
-    };
-
-    Ok(NoNameReviewedApplyRequest {
-        request_id,
-        scope,
-        segment_snapshot,
-        summary_snapshot,
-        diagnostics_snapshot,
-    })
-}
-
-fn apply_noname_reviewed_output_to_plot_state(
-    trace: NoNameTrace,
-    request: NoNameReviewedApplyRequest,
-    plot_state: PlotState,
-) -> Result<NoNameManualPlotTextApplyResult, String> {
-    let outcome = apply_reviewed_output_to_plot_state(trace, request, plot_state)?;
-    Ok(NoNameManualPlotTextApplyResult {
-        trace: outcome.trace,
-        plot_state: outcome.plot_state,
-    })
 }
 
 fn apply_noname_plot_text_hint(
@@ -4554,7 +4460,7 @@ pub async fn apply_noname_manual_plot_text_hint(
             Err(poisoned) => poisoned.into_inner(),
         };
         let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
-        let result = apply_noname_manual_plot_text_hint_to_plot_state(
+        let outcome = apply_manual_plot_text_hint_to_plot_state(
             trace,
             &request_id,
             plot_state,
@@ -4562,6 +4468,10 @@ pub async fn apply_noname_manual_plot_text_hint(
             segment_index,
             &expected_segment_text,
         )?;
+        let result = NoNameManualPlotTextApplyResult {
+            trace: outcome.trace,
+            plot_state: outcome.plot_state,
+        };
         engine
             .update_plot_state(result.plot_state.clone())
             .map_err(|e| e.to_string())?;
@@ -4591,7 +4501,7 @@ pub async fn apply_noname_reviewed_output(
     expected_generation_diagnostics: Option<String>,
     engine: State<'_, Mutex<GameEngine>>,
 ) -> Result<NoNameManualPlotTextApplyResult, String> {
-    let request = build_noname_reviewed_apply_request(
+    let request = build_reviewed_apply_request(
         request_id,
         scope,
         chapter_index,
@@ -4618,7 +4528,11 @@ pub async fn apply_noname_reviewed_output(
             Err(poisoned) => poisoned.into_inner(),
         };
         let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
-        let result = apply_noname_reviewed_output_to_plot_state(trace, request, plot_state)?;
+        let outcome = apply_reviewed_output_to_plot_state(trace, request, plot_state)?;
+        let result = NoNameManualPlotTextApplyResult {
+            trace: outcome.trace,
+            plot_state: outcome.plot_state,
+        };
         engine
             .update_plot_state(result.plot_state.clone())
             .map_err(|e| e.to_string())?;
@@ -7553,7 +7467,7 @@ mod tests {
             last_option_generation_source: None,
             last_consistency_risk_score: None,
         };
-        let applied = apply_noname_manual_plot_text_hint_to_plot_state(
+        let applied = crate::noname_apply::apply_manual_plot_text_hint_to_plot_state(
             resolved,
             "controlled-output-proposal-review-plot_text_hint",
             plot_state,
@@ -7561,6 +7475,10 @@ mod tests {
             0,
             "你看见山门风声渐紧。",
         )
+        .map(|outcome| NoNameManualPlotTextApplyResult {
+            trace: outcome.trace,
+            plot_state: outcome.plot_state,
+        })
         .expect("manual apply should update plot text");
         assert!(applied.plot_state.current_chapter.content[0].contains("【NoName】重点关注"));
         assert!(applied


### PR DESCRIPTION
## Summary
- move reviewed-apply request building into noname_apply
- move plotText manual apply helper into noname_apply and keep tauri command handlers thinner
- update roadmap docs to record the first A2 extraction milestone

## Testing
- cargo test noname_ -- --nocapture
- cargo test tauri_commands -- --nocapture