### PR TITLE
feat(noname): extend apply runtime and role context observability

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,10 +4,14 @@
 
 ## 当前状态
 
-截至 `2026-04-09`：
+截至 `2026-04-18`：
 
 - `NoName Agent V1` 基础闭环已完成
-- 当前代码进度已经超过原始 `T6` 计划，进入 `assisted skeleton`
+- 当前代码进度已经超过原始 `T6` 计划，进入 `T7 assisted skeleton / 受控应用 proposal` 阶段
+- `T7-0.6` 已完成：`PlotTextHint` 只有在人工批准、二次护栏 allow、显式命令与段落快照一致时才会写入正文
+- `T7-0.7` 已完成：前端调试台已补显式人工 apply 的差异预览、重复写入禁用与 stale snapshot 友好提示
+- `T7-3` 已完成最小可视化基线：apply lifecycle 已统一展示到调试面板、复制摘要与 Info 调试文本
+- `T7-1` 已完成第三切片：后端 reviewed apply runtime 与通用命令入口 `apply_noname_reviewed_output` 已复用到 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，三者都要求人工批准、二次护栏 allow 与快照一致
 - 如果要继续推进实现，优先阅读 `noname-v1-blueprint.md`、`noname-v1-task-list.md` 与 `noname-t7-file-checklist.md`
 
 ## 推荐阅读顺序
@@ -51,7 +55,7 @@
   - 面向实现的 V1 蓝图、阶段目标、当前状态与下一阶段方向。
 
 - `noname-v1-task-list.md`
-  - 可执行的开发任务清单，现已补充 `T0-T6` 完成状态与 `T7 assisted skeleton` 说明。
+  - 可执行的开发任务清单，现已补充 `T0-T6` 完成状态与 `T7 assisted skeleton` / 显式人工 apply 说明。
 
 - `noname-t1-file-checklist.md`
   - `T1 Core 类型与配置骨架` 的文件级实现清单，明确每个文件该放什么、先做什么、做到什么算完成。

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,7 +11,7 @@
 - `T7-0.6` 已完成：`PlotTextHint` 只有在人工批准、二次护栏 allow、显式命令与段落快照一致时才会写入正文
 - `T7-0.7` 已完成：前端调试台已补显式人工 apply 的差异预览、重复写入禁用与 stale snapshot 友好提示
 - `T7-3` 已完成最小可视化基线：apply lifecycle 已统一展示到调试面板、复制摘要与 Info 调试文本
-- `T7-1` 已完成第三切片：后端 reviewed apply runtime 与通用命令入口 `apply_noname_reviewed_output` 已复用到 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，三者都要求人工批准、二次护栏 allow 与快照一致
+- `T7-1` 已完成第七切片：后端 reviewed apply runtime 与通用命令入口 `apply_noname_reviewed_output` 已复用到 `PlotTextHint`、`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint`；`PlotAugmentationHint` 会进入 `pending_plot_augmentation_hints`，并已能作为“非最终、可忽略”的安全上下文进入下一轮 plot prompt，成功由 plot_engine 消费后按快照清空
 - 如果要继续推进实现，优先阅读 `noname-v1-blueprint.md`、`noname-v1-task-list.md` 与 `noname-t7-file-checklist.md`
 
 ## 推荐阅读顺序
@@ -80,3 +80,78 @@
 - 如果内容已经下钻到文件级或提交级，补充到对应专项清单，如 `noname-t1-file-checklist.md` 与 `noname-t7-file-checklist.md`。
 - 如果代码进度超出原始计划，先更新本索引中的“当前状态”，避免阅读者被旧计划误导。
 - 废弃文档不直接删除，先在本索引中标记为“历史补充”。
+
+## 2026-04-18 T7-1.5 Update
+
+- Pending plot augmentation observability has been closed: runtime traces now record `pending_plot_augmentation_consumed` or `pending_plot_augmentation_retained` in `applyExecutionLog`, proposal transition logs include the same lifecycle signal, and the frontend apply lifecycle surfaces this as `剧情增强消费`.
+- Web mock behavior and focused tests were updated so non-quick assisted generation consumes staged `PlotAugmentationHint` entries, while quick-mode retains them with an explicit reason.
+
+## 2026-04-18 T7-1.6 Update
+
+- Trace UX cleanup has started with a compact pending plot augmentation summary: debug copy reports now include `Plot Augmentation: ...`, and Info debug text includes `剧情增强提示：...`.
+- This keeps the operator-facing view aligned with lifecycle details while preserving the existing safe boundary: pending augmentation remains non-final prompt context only.
+
+## 2026-04-19 T7-1.7 Update
+
+- The compact pending plot augmentation summary is now visible in `AgentTracePanel` run overview as well, so the trace panel, debug copy report, and Info debug text all describe the same consumed/retained/staged state.
+
+## 2026-04-19 T7-1.8 Update
+
+- `AgentTracePanel` now translates pending plot augmentation execution rows into readable labels while preserving the original target/outcome line for debugging.
+
+## 2026-04-19 T7-1.9 Update
+
+- The same readable apply execution mapping now powers `gameStore` Info debug text and `InfoTabsDialog`, keeping all operator-facing debug surfaces aligned.
+
+## 2026-04-19 T7-2.0 Update
+
+- Copied `NoNameDebugConsole` trace reports now include readable apply execution summaries with raw target/outcome details for translated pending plot augmentation records.
+
+## 2026-04-19 T7-2.1 Update
+
+- Apply execution summary formatting is now centralized in `summarizeNoNameApplyExecutions`, shared by Info debug text and copied debug-console reports.
+
+## 2026-04-19 T7-2.2 Update
+
+- A focused full-regression pass for T7 apply/trace UX completed successfully across Rust tests, clippy, frontend NoName trace tests, frontend build, and diff whitespace checks.
+
+## 2026-04-19 T7-2.3 Update
+
+- T7 documentation wording was cleaned up: current remaining items are now framed as optional future extensions rather than unfinished core functionality.
+
+## 2026-04-19 T8-1 Update
+
+- The next NoName line has started with multi-role observe fan-out cleanup: `NoNameRuntime` now specializes context per role before dispatching non-Director agents through the protocol runtime.
+- This keeps assisted apply authority unchanged while making `WorldCurator / NpcIntent / CombatNarrator` observe results depend on role-specific context slices.
+
+## 2026-04-19 T8-2 Update
+
+- Multi-role observe prompts and tool args now receive `roleGoal / forbiddenScopes`, so role-specific boundaries are visible inside the local prompt/tool pipeline as well as the protocol delegation events.
+
+## 2026-04-19 T8-3 Update
+
+- `NoNameAgentRegistry` now accepts `NoNameRoleContextPacket` directly for observe dispatch, so runtime fan-out no longer owns the flattened-context compatibility adapter.
+
+## 2026-04-19 T8-4 Update
+
+- Multi-role related observations now expose role context summaries in trace/debug surfaces, including role goal, scene focus, and forbidden scopes.
+
+## 2026-04-19 T8-5 Update
+
+- Structured notes now influence role context ordering: active note types are ranked per role before entering narrative context and chapter-summary context.
+- This connects A2 structured notes to the multi-role observe fan-out while keeping NoName in the observe-only boundary.
+
+## 2026-04-19 T8-6 Update
+
+- Related observations and role-context debug summaries now expose `noteTypeHits`, so operators can see which structured note types were prioritized for each role.
+- This makes the A2 -> T8 role-context ranking path observable in trace panel, copied debug reports, and store-level debug text.
+
+## 2026-04-19 T8-7 Update
+
+- Related observations now also expose role-context `sourceStats` and `contextTokenBudgetUsed`, so operators can compare both note-priority hits and upstream context shape.
+- Trace panel, copied debug-console reports, and store-level debug text now show those compact source summaries without changing runtime authority boundaries.
+
+## 2026-04-20 T8-8 Update
+
+- Role-context packets now emit `contextSliceStats`, summarizing how each role-specific section was trimmed from source-count to visible-count.
+- Trace/debug surfaces now show compact slice deltas such as `worldFacts:4->3`, making per-role context clipping easier to audit.

--- a/docs/architecture/noname-protocol-runtime-v1.md
+++ b/docs/architecture/noname-protocol-runtime-v1.md
@@ -72,3 +72,39 @@
 1. 用 protocol runtime 驱动多角色 observe fan-out
 2. 再考虑把 tool/resource/prompt 都统一挂到协议 runtime
 3. 最后再评估是否需要真实 transport 或跨 runtime 适配
+
+## 2026-04-19 T8-1 Update
+
+- `NoNameRuntime` 的多角色 observe fan-out 已开始使用 role context specialization：每个非 Director 角色会先生成 `NoNameRoleContextPacket`，再压回现有 agent registry 可读取的 `NoNameContextPacket`。
+- protocol delegation payload 现在会携带 `roleGoal / sceneFocus / forbiddenScopes`，让协议层 task lifecycle 能看见本次分发使用的角色目标与边界。
+- assisted apply 主执行链仍保持隔离；本切片只增强 observe fan-out 的上下文分发质量。
+
+## 2026-04-19 T8-2 Update
+
+- multi-role observe prompt templates now require `roleGoal` and `forbiddenScopes`, so role boundaries are visible to the local prompt pipeline rather than only to protocol delegation payloads.
+- observe tool calls also receive the same role boundary fields in args, preparing the later move toward protocol-runtime-managed tool envelopes.
+- The current implementation still keeps tool/resource/prompt execution local and lightweight; assisted apply authority is unchanged.
+
+## 2026-04-19 T8-3 Update
+
+- Runtime fan-out now passes `NoNameRoleContextPacket` directly into `NoNameAgentRegistry`, moving flattened-context compatibility out of `NoNameRuntime`.
+- This keeps protocol lifecycle orchestration focused on task dispatch while the registry owns role-agent compatibility.
+
+## 2026-04-19 T8-4 Update
+
+- Role context summaries now flow from observe fan-out into trace related observations, making protocol/debug views show role goals, scene focus, and forbidden scopes alongside each role's proposal.
+
+## 2026-04-19 T8-6 Update
+
+- The observe fan-out trace path now also carries `noteTypeHits`, so protocol-facing debug output can show which structured note types were selected for each role context.
+- This keeps protocol runtime observability aligned with the role-context ranking that now happens before dispatch.
+
+## 2026-04-19 T8-7 Update
+
+- Protocol-facing related observations now include compact context-source stats and token budget usage alongside role goals and note hits.
+- This extends the observe fan-out audit trail without moving tool/resource/prompt execution authority into the protocol runtime.
+
+## 2026-04-20 T8-8 Update
+
+- Protocol-facing related observations now also include compact role-context slice deltas, so debug output can show per-section clipping such as `recentSignals:5->3`.
+- This remains an observe-only audit enhancement; protocol runtime authority boundaries are unchanged.

--- a/docs/architecture/noname-role-context-packets-v1.md
+++ b/docs/architecture/noname-role-context-packets-v1.md
@@ -102,12 +102,12 @@
 
 - 角色上下文包还没有接入 runtime fan-out，当前仍是独立 builder 能力。
 - 当前差异化是规则式裁剪，不是 LLM 动态裁剪。
-- `visibleConstraints` 和 `forbiddenScopes` 先作为显式文本约束，后续可接 guardrail。
+- `forbiddenScopes` 已开始接入受控输出策略，用于生成 `policyForbiddenScopes` trace；`visibleConstraints` 仍先作为显式文本约束。
 
 ## 后续建议
 
 下一步可以继续:
 
 1. 在 B4 observe fan-out 中改用 `build_role_context_packet` 或由基础包生成角色视图。
-2. 让每个角色 prompt 读取 `roleGoal / forbiddenScopes`。
+2. 让每个角色 prompt 继续读取 `roleGoal / forbiddenScopes`，并与受控输出策略保持一致。
 3. 与 A2 structured notes 联动，让不同角色优先读取不同 note type。

--- a/docs/architecture/noname-role-context-packets-v1.md
+++ b/docs/architecture/noname-role-context-packets-v1.md
@@ -100,7 +100,9 @@
 
 ## 当前限制
 
-- 角色上下文包还没有接入 runtime fan-out，当前仍是独立 builder 能力。
+- 角色上下文包已接入 runtime fan-out：runtime 现在生成 `NoNameRoleContextPacket` 并直接交给 agent registry。
+- agent registry 当前内部仍通过 `flatten_role_context_packet` 兼容现有角色 agent，避免一次性重写全部 prompt/tool/resource pipeline。
+- prompt/tool pipeline 已开始读取 `roleGoal / forbiddenScopes`；但当前仍通过 flattened context metadata 传递，不是最终的原生角色上下文接口。
 - 当前差异化是规则式裁剪，不是 LLM 动态裁剪。
 - `forbiddenScopes` 已开始接入受控输出策略，用于生成 `policyForbiddenScopes` trace；`visibleConstraints` 仍先作为显式文本约束。
 
@@ -108,6 +110,51 @@
 
 下一步可以继续:
 
-1. 在 B4 observe fan-out 中改用 `build_role_context_packet` 或由基础包生成角色视图。
-2. 让每个角色 prompt 继续读取 `roleGoal / forbiddenScopes`，并与受控输出策略保持一致。
-3. 与 A2 structured notes 联动，让不同角色优先读取不同 note type。
+1. 逐步让具体角色 agent / registry builder 原生消费 `NoNameRoleContextPacket`，移除内部 flattened context 适配层。
+2. 继续细化 role context 摘要的 debug 体验，例如展示更细的裁剪原因或 token 预算分配依据。
+3. 继续细化 note type 命中统计的呈现粒度，例如展示更多来源统计或排序前后的裁剪差异。
+
+## 2026-04-19 T8-1 Update
+
+- 新增 `flatten_role_context_packet`，用于把角色专属视图安全压回现有 `NoNameContextPacket`，让当前 agent registry 无需大改即可消费 role context。
+- `NoNameRuntime` observe fan-out 已改为“基础 context -> role context specialization -> flattened agent context”的分发路径。
+- 当前仍不接入 assisted apply；多角色结果继续作为 observe-only 相关观察写入 trace。
+
+## 2026-04-19 T8-2 Update
+
+- role observe prompt templates now include `roleGoal` and `forbiddenScopes` variables.
+- `run_observe_capability_pipeline` fills those variables from flattened role context metadata and passes them into tool args as well.
+- This keeps the current adapter shape but makes each role's prompt/tool execution aware of its role-specific boundary.
+
+## 2026-04-19 T8-3 Update
+
+- `NoNameAgentRegistry` now exposes `dispatch_role_context_observe_turn`, accepting `NoNameRoleContextPacket` directly.
+- `NoNameRuntime` no longer calls `flatten_role_context_packet`; runtime fan-out only specializes context and delegates the compatibility adapter to the registry boundary.
+- The internal flatten adapter remains temporary until individual role agents and registry builders can consume role context natively.
+
+## 2026-04-19 T8-4 Update
+
+- fan-out related observations now carry `roleGoal / sceneFocus / forbiddenScopes` into `NoNameTrace`.
+- `AgentTracePanel`, copied debug-console reports, and `gameStore` debug text surface role context summaries so operators can compare what each role saw.
+- This remains observe-only debug visibility; it does not grant multi-role agents assisted apply authority.
+
+## 2026-04-19 T8-5 Update
+
+- Active structured notes are now ranked per role before entering `narrative_notes` and `chapter_summaries`.
+- Director prioritizes conflict/goal/thread notes, WorldCurator prioritizes goal/foreshadowing/thread notes, NpcIntent prioritizes character-arc/conflict/thread notes, and CombatNarrator prioritizes conflict/character-arc notes.
+- This is the first direct A2 -> A3/T8 integration point inside context construction.
+
+## 2026-04-19 T8-6 Update
+
+- `NoNameRoleContextPacket` now carries `note_type_hits`, summarizing the top structured note types selected for each role after ranking.
+- Observe fan-out copies those hit summaries into related observations and frontend debug surfaces, so operators can inspect why different roles received different note ordering.
+
+## 2026-04-19 T8-7 Update
+
+- Observe fan-out now also copies `source_stats` and `token_budget_used` into related observations.
+- Frontend trace/debug surfaces render compact source summaries such as `semantic:3 / narrative:2` plus token budget, making role-context slicing easier to audit.
+
+## 2026-04-20 T8-8 Update
+
+- `NoNameRoleContextPacket` now carries `context_slice_stats`, recording section-level `source_count -> visible_count` deltas for role-specific context slices.
+- Observe fan-out, trace records, and frontend debug summaries surface those deltas so operators can compare how much context each role retained per section.

--- a/docs/architecture/noname-safe-output-interface-v1.md
+++ b/docs/architecture/noname-safe-output-interface-v1.md
@@ -74,7 +74,7 @@
 
 当前 T7-3 已补 apply lifecycle 可视化基线：前端会从 trace 的 plan、execution、review、transition 与 fallback 字段推导“提案阶段 / Apply 预检 / 低风险输出 / 人工复核 / 二次护栏 / 人工写入 / 回退”进度，并统一展示到调试台、复制摘要和 Info 调试文本。
 
-当前 T7-1 第三切片已新增 `noname_apply.rs` reviewed apply runtime：人工批准、二次护栏、scope 匹配、快照校验、剧情写入和 trace 留痕已从 `tauri_commands.rs` 抽出；前端显式写入改走通用命令 `apply_noname_reviewed_output(scope=plotTextHint)`，旧命令保留兼容；`ChapterSummaryHint` 和 `OptionBiasHint` 也已接入同一 runtime，分别要求提交章节摘要快照、诊断提示快照一致后才写入对应低风险提示层。
+当前 T7-1 第七切片已新增 `noname_apply.rs` reviewed apply runtime：人工批准、二次护栏、scope 匹配、快照校验、剧情写入和 trace 留痕已从 `tauri_commands.rs` 抽出；前端显式写入改走通用命令 `apply_noname_reviewed_output(scope=plotTextHint)`，旧命令保留兼容；`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint` 也已接入同一 runtime。前两者分别要求提交章节摘要快照、诊断提示快照一致后才写入对应低风险提示层；`PlotAugmentationHint` 要求提交 pending augmentation 列表快照一致后，只写入 `pending_plot_augmentation_hints`。下一轮生成时，pending augmentation 会以“非最终、可忽略、不得直接改写状态”的安全上下文进入 plot prompt；只有 plot_engine 结果真正落地、没有预设回退且未被双通道叙事覆盖时才按快照清空。
 
 ## V1 决策规则
 
@@ -109,11 +109,18 @@
 - `apply_noname_manual_plot_text_hint` 可在人工批准 + 二次护栏 allow + 正文快照一致时显式写入 `PlotTextHint`，并拒绝陈旧段落、重复 NoName 标记和不匹配的章节。
 - 前端调试台可在写入前展示差异预览，并对重复应用 / stale snapshot 给出明确提示。
 - apply lifecycle 可视化可以稳定表达 apply / review / guardrail / manual apply / fallback 当前状态。
-- reviewed apply runtime 已提供统一入口，当前覆盖 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，后续可继续评估 `plot_engine` 低风险输出层入口。
+- reviewed apply runtime 已提供统一入口，当前覆盖 `PlotTextHint`、`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint`；其中低风险提示层已通过 `plot_engine` 入口落地，non-final plot augmentation 已进入 pending 提示列表并可被下一轮 plot prompt 安全消费。
 
 ## 后续建议
 
 下一步可以继续:
 
-1. 继续扩展 `noname_apply.rs` 的落地边界，让 `plot_engine` 低风险输出层复用 reviewed apply runtime，但仍要求快照校验和 trace 留痕。
-2. 将更多输出类型接入现有 lifecycle 可视化与测试基线，继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。
+1. 继续观察 pending augmentation 被消费后的生成质量，必要时增加更细的“已消费/保留原因”trace 记录。
+2. 将更多输出类型接入现有 lifecycle 可视化与测试基线，继续保持高权重输出与最终剧情正文写入之间的人工/护栏边界。
+
+## 2026-04-18 T7-1.5 Safe Output Update
+
+- `PlotAugmentationHint` consumption is now observable without expanding its authority.
+- Safe boundary remains unchanged: pending augmentation is only prompt context for the next generation and must not directly mutate final plot state, canon world facts, options, or scene structure.
+- New trace outcomes: `pending_plot_augmentation_consumed` and `pending_plot_augmentation_retained`.
+- Frontend lifecycle now surfaces this safe-output boundary as `剧情增强消费`, making it clear whether the non-final hint was consumed or deliberately retained.

--- a/docs/architecture/noname-safe-output-interface-v1.md
+++ b/docs/architecture/noname-safe-output-interface-v1.md
@@ -64,6 +64,18 @@
 
 当前 V2 后续切片已把 A3 角色上下文中的 `forbiddenScopes` 映射到 `NoNameControlledOutputPolicy.forbiddenScopes`，并在 trace 的 `controlledOutputReviews[].policyForbiddenScopes` 中显式记录当次 review 使用的策略禁区。
 
+当前前端调试台已为 `NeedsReview` 增加人工复核入口：开发者可以把单条 review 标记为“可进入高层 apply 设计”或“暂不应用”。该标记会通过 `mark_noname_controlled_output_review` 写回最近 trace，形成可追踪的 review intent；当人工批准 `PlotTextHint` 时，后端会记录 `review_intent_ready / awaiting_second_guardrail` 计划与执行日志，但不会直接触发剧情正文写入。
+
+当前后续切片已新增 `resolve_noname_second_guardrail`：只处理已人工批准且处于 `awaiting_second_guardrail` 的 review，输出 `allow / reject / fallback` 决策，并写入 trace 的 apply plan、execution 与 transition log。`allow` 也只是进入“等待显式人工 apply 命令”的下一站，不会自动写最终剧情正文。
+
+当前 T7-0.6 已新增 `apply_noname_manual_plot_text_hint`：只有在 `PlotTextHint` 已人工批准、二次护栏 `allow`、并且调用方再次提交 `chapterIndex / segmentIndex / expectedSegmentText` 快照一致时，才会把正文提示写入当前剧情段落；写入后 trace 会记录 `manual_apply / manual_plot_text_applied / manual_apply:plot_text_hint`，用于区分“人工显式写入”和普通低风险自动 apply。
+
+当前 T7-0.7 已补前端显式人工 apply 预览：调试台会展示当前段落的“写入前 / 写入后”，在段落已经包含 NoName 标记或 trace 已记录 `manual_plot_text_applied` 时禁用按钮；后端返回 stale snapshot / 重复写入 / 章节变化等错误时，前端会转成更明确的中文提示。
+
+当前 T7-3 已补 apply lifecycle 可视化基线：前端会从 trace 的 plan、execution、review、transition 与 fallback 字段推导“提案阶段 / Apply 预检 / 低风险输出 / 人工复核 / 二次护栏 / 人工写入 / 回退”进度，并统一展示到调试台、复制摘要和 Info 调试文本。
+
+当前 T7-1 第三切片已新增 `noname_apply.rs` reviewed apply runtime：人工批准、二次护栏、scope 匹配、快照校验、剧情写入和 trace 留痕已从 `tauri_commands.rs` 抽出；前端显式写入改走通用命令 `apply_noname_reviewed_output(scope=plotTextHint)`，旧命令保留兼容；`ChapterSummaryHint` 和 `OptionBiasHint` 也已接入同一 runtime，分别要求提交章节摘要快照、诊断提示快照一致后才写入对应低风险提示层。
+
 ## V1 决策规则
 
 - 空 request id、空 title、空 content 会被拒绝。
@@ -90,10 +102,18 @@
 - scene augmentation 映射到 plot text hint 时需要人工复核。
 - policy 明确列出 allowlist 和 forbidden scopes。
 - A3 role context 的 `forbiddenScopes` 可以映射为 controlled output policy，并随 review trace 输出。
+- 前端调试台可以对 `NeedsReview` review 做人工标记，并在复制摘要里体现待复核/通过/拒绝数量。
+- 后端可记录 `humanReviewDecision / humanReviewedAt / humanReviewNote`，并把人工复核 intent 写入 trace 状态迁移日志。
+- 人工批准后的 `PlotTextHint` 会进入二次 guardrail / apply planner 等待队列，trace 会记录 `review_intent_ready` 与 `awaiting_second_guardrail`，但不会直接 apply 到正文。
+- `resolve_noname_second_guardrail` 可记录 `second_guardrail_allow / second_guardrail_reject / second_guardrail_fallback`，用于完整表达二次护栏决策。
+- `apply_noname_manual_plot_text_hint` 可在人工批准 + 二次护栏 allow + 正文快照一致时显式写入 `PlotTextHint`，并拒绝陈旧段落、重复 NoName 标记和不匹配的章节。
+- 前端调试台可在写入前展示差异预览，并对重复应用 / stale snapshot 给出明确提示。
+- apply lifecycle 可视化可以稳定表达 apply / review / guardrail / manual apply / fallback 当前状态。
+- reviewed apply runtime 已提供统一入口，当前覆盖 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，后续可继续评估 `plot_engine` 低风险输出层入口。
 
 ## 后续建议
 
 下一步可以继续:
 
-1. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
-2. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。
+1. 继续扩展 `noname_apply.rs` 的落地边界，让 `plot_engine` 低风险输出层复用 reviewed apply runtime，但仍要求快照校验和 trace 留痕。
+2. 将更多输出类型接入现有 lifecycle 可视化与测试基线，继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。

--- a/docs/architecture/noname-safe-output-interface-v1.md
+++ b/docs/architecture/noname-safe-output-interface-v1.md
@@ -62,6 +62,8 @@
 
 当前 V2 切片已把 review 结果接入 `NoNameRuntime` trace：`assisted` 预检通过后会记录每个 apply scope 的 controlled output review，其中 `PlotTextHint` 仍保持 `NeedsReview`，不会自动接管最终剧情正文。
 
+当前 V2 后续切片已把 A3 角色上下文中的 `forbiddenScopes` 映射到 `NoNameControlledOutputPolicy.forbiddenScopes`，并在 trace 的 `controlledOutputReviews[].policyForbiddenScopes` 中显式记录当次 review 使用的策略禁区。
+
 ## V1 决策规则
 
 - 空 request id、空 title、空 content 会被拒绝。
@@ -87,11 +89,11 @@
 - 触碰 canon world fact 的 request 会被拒绝。
 - scene augmentation 映射到 plot text hint 时需要人工复核。
 - policy 明确列出 allowlist 和 forbidden scopes。
+- A3 role context 的 `forbiddenScopes` 可以映射为 controlled output policy，并随 review trace 输出。
 
 ## 后续建议
 
 下一步可以继续:
 
-1. 把 A3 的 `forbiddenScopes` 映射到本接口的 forbidden scopes。
-2. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
-3. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。
+1. 为 `NeedsReview` 设计更完整的前端确认入口，让开发者手动确认是否进入更高层 apply。
+2. 继续保持 `PlotTextHint` 与最终剧情正文写入之间的人工/护栏边界。

--- a/docs/architecture/noname-structured-notes-v1.md
+++ b/docs/architecture/noname-structured-notes-v1.md
@@ -81,6 +81,7 @@
 ## 当前限制
 
 - 当前没有接 UI，也没有直接接游戏主线。
+- structured notes 已开始影响 role context 排序，但仍只服务 observe fan-out 的上下文构建，不自动生成或应用剧情内容。
 - `close` 目前等价于 `resolve`，后续如需要可以拆成更细状态。
 - 章节整理只做生命周期归档和结构化 review，不自动生成新剧情内容。
 
@@ -89,5 +90,16 @@
 下一步可以继续:
 
 1. 让 A1 compaction 在生成 summary 时自动创建或更新相关 note。
-2. 让 A3 role context packets 针对不同角色读取不同 note 类型。
-3. 视需要补 note merge / split / supersede 语义，避免长线剧情里 note 过多。
+2. 视需要补 note merge / split / supersede 语义，避免长线剧情里 note 过多。
+3. 继续扩展 role context trace 的 note type 命中细节，例如补充更丰富的排序依据或压缩前后对照。
+
+## 2026-04-19 T8-5 Update
+
+- `build_context_packet` now ranks active structured notes by role before placing them into narrative context and chapter-summary context.
+- Director prioritizes conflict/goal/thread notes, WorldCurator prioritizes goal/foreshadowing/thread notes, NpcIntent prioritizes character-arc/conflict/thread notes, and CombatNarrator prioritizes conflict/character-arc notes.
+- This connects A2 structured notes to role context construction while keeping runtime behavior observe-only.
+
+## 2026-04-19 T8-6 Update
+
+- Role-ranked note priorities now emit `note_type_hits` summaries into trace/debug, making structured-note selection visible per role.
+- This closes the first observability loop for A2 -> T8 integration without changing apply authority or story-writing behavior.

--- a/docs/architecture/noname-t7-file-checklist.md
+++ b/docs/architecture/noname-t7-file-checklist.md
@@ -1,6 +1,6 @@
 # NoName Agent T7 文件级实现清单
 
-更新时间: 2026-04-09
+更新时间: 2026-04-17
 状态: 文件级执行清单
 目标: 将 `T7 Assisted Skeleton 与受控应用预备` 拆到可直接实施的文件粒度
 关联文档:
@@ -27,7 +27,7 @@
 
 ## 1.1 当前进度
 
-截至 `2026-04-09`，`T7` 第一批已经完成：
+截至 `2026-04-17`，`T7` 第一批已经完成：
 
 - `NoNameProposal` 已补 `status`
   - `observed / ready / blocked / applied / fallback`
@@ -37,12 +37,22 @@
 - apply 阶段已补独立 guardrail 入口
 - 调试诊断已输出 `proposal_status` 与 `apply=...`
 - 前端调试文本已优先展示显式 `status`、apply preflight 与状态迁移
+- 已补 `disabled / observe_only / assisted` 模式矩阵测试，并在命令层确保 disabled 跳过 NoName turn
+- 前端调试台已为 `NeedsReview` 受控输出增加本地人工复核标记入口，用于记录“可进入高层 apply 设计 / 暂不应用”
+- 后端已提供 `mark_noname_controlled_output_review`，可把人工复核 intent 写回最近 trace
+- 人工批准后的 `PlotTextHint` intent 已进入二次 guardrail / apply planner 等待队列，trace 会记录 `review_intent_ready / awaiting_second_guardrail`
+- 后端已提供 `resolve_noname_second_guardrail`，可记录 `allow / reject / fallback` 二次护栏决策
+- `T7-0.6` 已接入 `apply_noname_manual_plot_text_hint`，要求人工批准、二次护栏 allow、章节/段落快照一致后才显式写入正文提示，并记录 `manual_plot_text_applied`
+- `T7-0.7` 已补前端差异预览、重复写入禁用与 stale snapshot 友好错误提示，显式人工写入前能看到“写入前 / 写入后”
+- `T7-3` 已补 `noNameApplyLifecycle` 前端收敛层，统一从 plan / execution / review / transition / fallback 推导 apply 生命周期，并展示到调试台、复制摘要和 Info 文本
+- `T7-1` 第三切片已新增 `src-tauri/src/noname_apply.rs`，把 reviewed apply 校验、快照校验、剧情写入和 trace 记录从命令层抽成可复用 runtime；前端已改走 `apply_noname_reviewed_output(scope=plotTextHint)`，后端与 Web mock 已扩展支持 `ChapterSummaryHint` 和 `OptionBiasHint`
 
 当前仍未完成的部分：
 
 - proposal 已可进入“诊断层 + 章节摘要提示 + 选项偏置提示”低风险 apply，但还没有进入更高权重的剧情输出层
-- trace 已有 apply transition log，并已记录诊断层 / 章节摘要提示 / 选项偏置提示 apply；但还没有更高权重输出层的 apply/reject/fallback 执行明细
+- trace 已有 apply transition log、执行明细和 lifecycle 可视化；`PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint` 已补人工显式 apply 执行明细，但还没有通用化到所有高权重输出层
 - `plot_engine` 侧还没有低风险输出层应用入口
+- reviewed apply runtime 目前支持 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，下一步重点是评估 `plot_engine` 低风险输出层入口
 
 ## 2. 建议文件范围
 
@@ -53,6 +63,7 @@
 - `src-tauri/src/tauri_commands.rs`
 - `src-tauri/src/noname_trace.rs`
 - `src-tauri/src/noname_types.rs`
+- `src-tauri/src/noname_apply.rs`
 
 ### 高概率配套修改文件
 
@@ -170,6 +181,7 @@
 
 - 增加显式的 apply 分支，例如：
   - `maybe_apply_assisted_proposal()`
+  - `apply_noname_manual_plot_text_hint()`
 - 明确三种模式行为：
   - `disabled`: 完全跳过 NoName
   - `observe_only`: 记录 proposal，但不尝试应用
@@ -340,12 +352,11 @@
 
 如果下一步开始写代码，建议按这个顺序推进：
 
-1. `noname_types.rs`
+1. `tauri_commands.rs`
 2. `noname_trace.rs`
-3. `noname_guardrails.rs`
-4. `noname_runtime.rs`
-5. `tauri_commands.rs`
-6. `game.ts`
-7. `gameStore.ts`
-8. `webRuntime.ts`
-这个顺序的好处是：先把状态机和边界讲清楚，再碰真正容易引发回归的应用分支。
+3. `game.ts`
+4. `gameStore.ts`
+5. `AgentTracePanel.vue`
+6. `webRuntime.ts`
+7. 对应前后端测试
+这个顺序的好处是：在已有 lifecycle 可视化基线下，先把当前显式 apply 命令抽象成可复用 runtime，再补更多输出类型的回归测试。

--- a/docs/architecture/noname-t7-file-checklist.md
+++ b/docs/architecture/noname-t7-file-checklist.md
@@ -45,14 +45,14 @@
 - `T7-0.6` 已接入 `apply_noname_manual_plot_text_hint`，要求人工批准、二次护栏 allow、章节/段落快照一致后才显式写入正文提示，并记录 `manual_plot_text_applied`
 - `T7-0.7` 已补前端差异预览、重复写入禁用与 stale snapshot 友好错误提示，显式人工写入前能看到“写入前 / 写入后”
 - `T7-3` 已补 `noNameApplyLifecycle` 前端收敛层，统一从 plan / execution / review / transition / fallback 推导 apply 生命周期，并展示到调试台、复制摘要和 Info 文本
-- `T7-1` 第三切片已新增 `src-tauri/src/noname_apply.rs`，把 reviewed apply 校验、快照校验、剧情写入和 trace 记录从命令层抽成可复用 runtime；前端已改走 `apply_noname_reviewed_output(scope=plotTextHint)`，后端与 Web mock 已扩展支持 `ChapterSummaryHint` 和 `OptionBiasHint`
+- `T7-1` 第七切片已新增 `src-tauri/src/noname_apply.rs`，把 reviewed apply 校验、快照校验、剧情写入和 trace 记录从命令层抽成可复用 runtime；前端已改走 `apply_noname_reviewed_output(scope=plotTextHint)`，后端与 Web mock 已扩展支持 `ChapterSummaryHint`、`OptionBiasHint` 和 `PlotAugmentationHint`，并已把低风险状态写入下沉到 `plot_engine`；`PlotAugmentationHint` 进入 pending augmentation 列表后，下一轮会以非最终安全上下文注入 plot prompt，成功消费后按快照清空
 
-当前仍未完成的部分：
+当前边界与后续可选项：
 
-- proposal 已可进入“诊断层 + 章节摘要提示 + 选项偏置提示”低风险 apply，但还没有进入更高权重的剧情输出层
-- trace 已有 apply transition log、执行明细和 lifecycle 可视化；`PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint` 已补人工显式 apply 执行明细，但还没有通用化到所有高权重输出层
-- `plot_engine` 侧还没有低风险输出层应用入口
-- reviewed apply runtime 目前支持 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，下一步重点是评估 `plot_engine` 低风险输出层入口
+- T7 主体已完成“诊断层 + 章节摘要提示 + 选项偏置提示 + pending 剧情增强提示”的受控 apply 预备层；这些输出不会自动接管最终剧情正文。
+- trace 已覆盖 apply transition log、执行明细、lifecycle 可视化、pending augmentation 消费/保留摘要，以及复制报告/Info 面板的人类可读执行摘要。
+- `plot_engine` 侧已有章节摘要提示、generation diagnostics 提示与 pending plot augmentation 提示入口；仍不直接改 `new_scene / available_options / 主剧情全文主体`。
+- 后续如果继续扩展，应作为新阶段评估新的受控输出类型或更细 trace 体验，而不是继续在 T7 内扩大剧情写入权限。
 
 ## 2. 建议文件范围
 
@@ -279,6 +279,8 @@
 - 第一个 apply 版本只影响“低风险输出层”
 - 不直接篡改核心剧情状态机
 
+当前状态：已新增 `PlotState::apply_low_risk_chapter_summary_hint` 与 `PlotState::apply_low_risk_generation_diagnostics_hint`，`noname_apply.rs` 中的 `ChapterSummaryHint / OptionBiasHint` reviewed apply 已委托到这两个入口；仍不直接改 `new_scene / available_options / 主剧情全文主体`。
+
 ## F8 `game.ts` / `gameStore.ts`
 
 ### 目标
@@ -360,3 +362,58 @@
 6. `webRuntime.ts`
 7. 对应前后端测试
 这个顺序的好处是：在已有 lifecycle 可视化基线下，先把当前显式 apply 命令抽象成可复用 runtime，再补更多输出类型的回归测试。
+
+## 2026-04-18 T7-1.5 Current Status
+
+- Done: `PlotAugmentationHint` pending consumption now has explicit trace observability.
+- Done: backend `execute_player_action` records `pending_plot_augmentation_consumed` when pending hints are consumed after a real plot_engine generation, and records `pending_plot_augmentation_retained` when quick mode, preset fallback, turn-update override, or stale snapshot prevents consumption.
+- Done: frontend lifecycle adds a `plot-augmentation-consumption` step labelled `剧情增强消费`, so debug panels and summaries can distinguish `已消费`, `已保留`, and `待观察`.
+- Done: Web mock and focused tests now mirror the same consumption/retention behavior.
+
+## 2026-04-18 T7-1.6 Current Status
+
+- Done: pending plot augmentation now has a compact human-readable summary helper, `summarizeNoNamePendingPlotAugmentation`.
+- Done: NoName debug console copy reports include `Plot Augmentation: ...`, so consumed/retained/staged states are visible without reading raw execution log rows.
+- Done: `gameStore.getNoNameTraceDebugText()` includes `剧情增强提示：...`, keeping the Info debug text aligned with the trace panel lifecycle.
+
+## 2026-04-19 T7-1.7 Current Status
+
+- Done: `AgentTracePanel` now shows the pending plot augmentation summary directly in its run overview.
+- Done: the same `summarizeNoNamePendingPlotAugmentation` helper now powers trace panel, debug copy reports, and Info debug text, keeping operator-facing views consistent.
+- Done: focused UI tests cover the visible `剧情增强提示` summary for consumed pending augmentation.
+
+## 2026-04-19 T7-1.8 Current Status
+
+- Done: `AgentTracePanel` execution rows now render human-readable labels for pending plot augmentation execution records.
+- Done: raw trace target/outcome is still shown under the readable label, preserving debugging fidelity for `pending_plot_augmentation_consumed` and `pending_plot_augmentation_retained`.
+- Done: `formatNoNameApplyExecutionRecord` centralizes the display mapping for plot augmentation execution outcomes.
+
+## 2026-04-19 T7-1.9 Current Status
+
+- Done: `gameStore.getNoNameTraceDebugText()` now uses `formatNoNameApplyExecutionRecord` for apply execution rows, while keeping raw target/outcome in-line for translated records.
+- Done: `InfoTabsDialog` structured debug execution rows now share the same readable labels and raw-record fallback as `AgentTracePanel`.
+- Done: focused tests cover the shared execution display behavior across Trace panel, Info drawer, Info text, and lifecycle utilities.
+
+## 2026-04-19 T7-2.0 Current Status
+
+- Done: `NoNameDebugConsole` copy reports now include `Apply Executions: ...` using the shared `formatNoNameApplyExecutionRecord` mapping.
+- Done: copied trace summaries now preserve raw target/outcome details for translated pending plot augmentation execution records.
+- Done: focused debug-console tests cover the copied execution summary.
+
+## 2026-04-19 T7-2.1 Current Status
+
+- Done: `summarizeNoNameApplyExecutions` centralizes the execution-summary string used by copy reports and Info debug text.
+- Done: `gameStore.getNoNameTraceDebugText()` and `NoNameDebugConsole` now reuse the same helper instead of duplicating execution formatting logic.
+- Done: tests cover the helper with both compact Info text formatting and copy-report formatting.
+
+## 2026-04-19 T7-2.2 Current Status
+
+- Done: completed a focused full-regression pass for the T7 apply/trace UX line.
+- Passed: `cargo fmt`, `cargo test plot_augmentation -- --nocapture`, `cargo test low_risk -- --nocapture`, `cargo clippy -- -D warnings`.
+- Passed: `npm test -- --run src/utils/noNameApplyLifecycle.test.ts src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/components/__tests__/InfoTabsDialog.test.ts src/stores/__tests__/gameStore.test.ts src/platform/webRuntime.test.ts`.
+- Passed: `npm run build` and `git diff --check`; build still reports the existing Vite dynamic-import warning for `@tauri-apps/api/core.js`.
+
+## 2026-04-19 T7-2.3 Current Status
+
+- Done: cleaned the T7 checklist wording from "unfinished parts" to "current boundaries and optional next steps".
+- Done: documented that T7's remaining work is future-stage optional expansion, not missing core apply functionality.

--- a/docs/architecture/noname-v1-blueprint.md
+++ b/docs/architecture/noname-v1-blueprint.md
@@ -253,12 +253,12 @@ V1 的核心目标：
 - `apply_noname_manual_plot_text_hint` 已提供显式人工 apply 命令，要求人工批准、二次护栏 allow、章节/段落快照一致后才写入 `PlotTextHint`，并记录 `manual_plot_text_applied`
 - 前端调试台已补应用前差异预览、重复写入禁用与 stale snapshot 友好错误提示
 - `T7-3` 已补 apply lifecycle 可视化基线，能从提案、预检、低风险输出、人工复核、二次护栏、人工写入、fallback 等阶段阅读当前 trace
-- `T7-1` 第三切片已抽出 reviewed apply runtime，并新增 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 人工写入已改走该入口，旧命令保留兼容，`ChapterSummaryHint` 与 `OptionBiasHint` 已复用同一入口和快照校验
+- `T7-1` 第七切片已抽出 reviewed apply runtime，并新增 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 人工写入已改走该入口，旧命令保留兼容，`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint` 已复用同一入口和快照校验，且低风险/非最终提示写入已下沉到 `plot_engine`；pending augmentation 已能作为安全上下文进入下一轮 plot prompt，前端调试台已补四类 scope 的显式 reviewed apply 入口
 
 当前未完成：
 
 - proposal 仍不会自动影响最终剧情文本或核心状态；`PlotTextHint` 只允许在人工批准 + 二次护栏 + 显式命令下写入
-- reviewed apply runtime 已接入 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，尚未扩展到 `plot_engine` 低风险输出层入口
+- reviewed apply runtime 已接入 `PlotTextHint`、`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint`，后两层已通过 `plot_engine` 低风险/非最终提示入口落地；pending augmentation 已能被下一轮 prompt/context 安全消费，下一步可补更细 trace 可观测性或继续拓展新的受控输出类型
 
 阶段完成标准：
 
@@ -400,3 +400,9 @@ V1 的核心目标：
 - 有 guardrail
 
 因此，`V1` 可以视为已完成。真正的下一阶段目标，不是再重复搭框架，而是把 `assisted skeleton` 推进成“受控应用 proposal”的稳定实现。
+
+## 2026-04-18 T7-1.5 Blueprint Note
+
+- The current T7 line has moved from "can stage non-final plot augmentation" to "can stage, consume or retain, and observe that lifecycle".
+- Implementation boundary: `tauri_commands.rs` only records orchestration-level consume/retain outcomes, while `plot_engine.rs` remains the only layer that turns prompt context into actual plot output.
+- UX boundary: `noNameApplyLifecycle` now exposes the pending augmentation lifecycle, so operators can see whether a reviewed hint is still waiting, has been consumed, or was retained for safety reasons.

--- a/docs/architecture/noname-v1-blueprint.md
+++ b/docs/architecture/noname-v1-blueprint.md
@@ -1,7 +1,7 @@
 # NoName Agent V1 实施蓝图
 
-更新时间: 2026-04-09
-状态: V1 已完成，`assisted skeleton` 进行中
+更新时间: 2026-04-17
+状态: V1 已完成，`T7 assisted skeleton / 受控应用 proposal` 进行中
 目标: 将 `NoName Agent` 从设计文档推进到可运行的 V1 骨架，并为后续受控应用阶段建立基线
 关联文档:
 - `noname-agent-v1.md`
@@ -23,15 +23,16 @@ V1 的核心目标：
 
 ## 1.1 当前状态快照
 
-截至 `2026-04-09`，当前代码状态为：
+截至 `2026-04-17`，当前代码状态为：
 
 - `V1` 基础闭环已经完成
 - `DirectorAgent` 已接入 `execute_player_action`
 - 结构化 `NoNameProposal` 已落地
 - Guardrail 已接入并可产出 `accept / repair / reject`
 - 前端已经能查看 trace、proposal、guardrail、fallback 调试摘要
-- 当前正在推进 `assisted skeleton`
-- 当前尚未进入“真正应用 proposal 到主剧情结果”的阶段
+- 当前正在推进 `T7 assisted skeleton / 受控应用 proposal`
+- `assisted` 已可自动应用诊断层、章节摘要提示、选项偏置提示这三类低风险输出
+- `PlotTextHint` 已进入人工批准、二次护栏、显式命令、段落快照校验后的人工写入链路，不会自动接管最终剧情生成
 
 ## 2. V1 范围边界
 
@@ -244,12 +245,20 @@ V1 的核心目标：
 - runtime 可将 proposal 标记为 `applyable`
 - trace 可记录 proposal、guardrail、fallback、阶段跳转
 - 前端调试信息可显示 proposal 是否 `ready`
+- 已补 `disabled / observe_only / assisted` 模式矩阵测试，确保 disabled 不影响主链路、observe-only 仅记录、assisted 才进入受控低风险 apply
+- 前端调试台已为 `NeedsReview` 受控输出补本地人工复核入口，支持标记“可进入高层 apply 设计 / 暂不应用”
+- `mark_noname_controlled_output_review` 已可把人工复核 intent 写回最近 trace，记录 `humanReviewDecision / humanReviewedAt / humanReviewNote`
+- 人工批准后的 `PlotTextHint` intent 已可进入二次 guardrail / apply planner 等待队列，trace 记录 `review_intent_ready / awaiting_second_guardrail`
+- `resolve_noname_second_guardrail` 已可输出 `allow / reject / fallback` 决策，并记录 `second_guardrail_*` apply plan / execution / transition
+- `apply_noname_manual_plot_text_hint` 已提供显式人工 apply 命令，要求人工批准、二次护栏 allow、章节/段落快照一致后才写入 `PlotTextHint`，并记录 `manual_plot_text_applied`
+- 前端调试台已补应用前差异预览、重复写入禁用与 stale snapshot 友好错误提示
+- `T7-3` 已补 apply lifecycle 可视化基线，能从提案、预检、低风险输出、人工复核、二次护栏、人工写入、fallback 等阶段阅读当前 trace
+- `T7-1` 第三切片已抽出 reviewed apply runtime，并新增 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 人工写入已改走该入口，旧命令保留兼容，`ChapterSummaryHint` 与 `OptionBiasHint` 已复用同一入口和快照校验
 
 当前未完成：
 
-- proposal 还没有真正影响最终剧情文本或状态落地
-- 还没有“应用 proposal 后的二次 guardrail + 回退”链路
-- 还没有完整的 `disabled / observe_only / assisted` 集成测试矩阵
+- proposal 仍不会自动影响最终剧情文本或核心状态；`PlotTextHint` 只允许在人工批准 + 二次护栏 + 显式命令下写入
+- reviewed apply runtime 已接入 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`，尚未扩展到 `plot_engine` 低风险输出层入口
 
 阶段完成标准：
 

--- a/docs/architecture/noname-v1-task-list.md
+++ b/docs/architecture/noname-v1-task-list.md
@@ -1,7 +1,7 @@
 # NoName Agent V1 开发任务清单
 
-更新时间: 2026-04-09
-状态: V1 基础闭环已完成，已进入 `assisted skeleton` 阶段
+更新时间: 2026-04-17
+状态: V1 基础闭环已完成，已进入 `T7 assisted skeleton / 受控应用 proposal` 阶段
 目标: 将 `NoName Agent` V1 设计拆解为可按顺序实施的开发任务
 关联文档:
 - `noname-agent-v1.md`
@@ -24,12 +24,12 @@
 
 ## 1.1 当前实现状态
 
-截至 `2026-04-09`，当前仓库中的 `NoName Agent` 实现状态如下：
+截至 `2026-04-17`，当前仓库中的 `NoName Agent` 实现状态如下：
 
 - `T0` 到 `T6` 已完成
 - `V1 Done` 条件已满足
 - 代码已超出原始 V1 任务清单，进入 `T7 assisted skeleton`
-- 当前 `assisted` 仅完成“可判定 / 可标记 / 可调试”，尚未进入真正的受控应用分支
+- 当前 `assisted` 已进入受控应用分支：低风险输出可自动 apply，`PlotTextHint` 仅允许人工批准 + 二次护栏 + 显式命令 + 快照校验后写入
 - 当前验证基线：
   - `cargo test -q` 通过
   - 前端定向测试通过
@@ -474,18 +474,26 @@
 - 前端调试台已展示 controlled output review，并支持复制当前 Trace 摘要
 - A3 `forbiddenScopes` 已映射到 controlled output policy，review trace 会显示 `policyForbiddenScopes`
 - apply 阶段已补独立 guardrail 入口
+- `T7-4` 已补 `disabled / observe_only / assisted` 模式矩阵测试，覆盖 disabled 跳过、observe-only 只记录、assisted 受控低风险 apply
+- `NeedsReview` 已补前端本地人工复核入口，可标记“可进入高层 apply 设计 / 暂不应用 / 重置待复核”，但不直接写入剧情正文
+- `mark_noname_controlled_output_review` 已接入，人工复核 intent 会写回最近 trace 并记录状态迁移
+- 人工批准后的 `PlotTextHint` intent 已进入二次 guardrail / apply planner 等待队列，trace 会记录 `review_intent_ready / awaiting_second_guardrail`
+- `resolve_noname_second_guardrail` 已接入，能记录 `allow / reject / fallback` 二次护栏决策，但仍不直接写入剧情正文
+- `T7-0.6` 已接入 `apply_noname_manual_plot_text_hint`，只有人工批准 + 二次护栏 allow + 当前章节/段落快照一致时，才允许显式写入 `PlotTextHint`
+- `T7-0.7` 已补显式人工 apply 的前端差异预览、重复写入禁用与 stale snapshot 友好提示
+- `T7-3` 已补 apply lifecycle 展示与测试基线，调试面板、复制摘要、Info 调试文本可以统一展示 apply / review / guardrail / manual apply / fallback 进度
+- `T7-1` 第三切片已新增 `noname_apply.rs` reviewed apply runtime，提供 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 显式写入已改走该入口，`ChapterSummaryHint` 与 `OptionBiasHint` 也已接入人工批准 + 二次护栏 + 快照一致的显式 reviewed apply
 
 ### 当前边界
 
-- proposal 目前不会改写剧情正文与状态机，但已可写入章节摘要提示这类低风险输出
-- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出；`plotTextHint` 会先进入 controlled output review，仍不直接接管最终剧情应用分支
+- proposal 目前不会自动改写剧情正文与状态机，但已可写入章节摘要提示这类低风险输出
+- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出；`plotTextHint` 会先进入 controlled output review、人工复核 intent、二次护栏，再由显式人工命令写入当前剧情段落
+- reviewed apply runtime 已形成统一通道，目前支持 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`；`plot_engine` 低风险输出层入口还需要继续评估
 - 仍然保持“经典主链路优先，NoName 仅辅助”
 
 ### 下一步子任务
 
-- `T7-1` 将受控应用边界从选项偏置提示继续扩展到下一层低风险输出
-- `T7-3` 明确 apply / reject / fallback 的 trace 记录
-- `T7-4` 增加 `disabled / observe_only / assisted` 的集成测试矩阵
+- `T7-1.2` 已完成两个扩展 scope：`ChapterSummaryHint` 与 `OptionBiasHint` 可复用 reviewed apply runtime；下一步可继续评估 `plot_engine` 低风险输出层入口
 
 ### 验收标准
 
@@ -577,6 +585,6 @@
 
 如果继续推进实现，当前最推荐的是：
 
-1. 推进 `T7`，把 `assisted skeleton` 变成真正的“受控应用 proposal”
-2. 为 `disabled / observe_only / assisted` 补完整集成测试矩阵
+1. 继续推进 `T7-1.2` 的后续落地层，让 `plot_engine` 低风险输出层复用 `noname_apply.rs` reviewed apply runtime
+2. 把新增 scope 持续接入现有 apply lifecycle，让后续更多输出类型复用同一套可视化与测试基线
 这会比继续扩文档或继续堆更多角色更有价值，因为它决定 `NoName Agent` 是否能从“可观察”走向“可辅助落地”。

--- a/docs/architecture/noname-v1-task-list.md
+++ b/docs/architecture/noname-v1-task-list.md
@@ -472,6 +472,7 @@
 - trace 已记录 controlled output review，能区分 `Allow / Reject / NeedsReview`
 - 前端调试文本已显示 apply preflight 与 proposal transition log
 - 前端调试台已展示 controlled output review，并支持复制当前 Trace 摘要
+- A3 `forbiddenScopes` 已映射到 controlled output policy，review trace 会显示 `policyForbiddenScopes`
 - apply 阶段已补独立 guardrail 入口
 
 ### 当前边界

--- a/docs/architecture/noname-v1-task-list.md
+++ b/docs/architecture/noname-v1-task-list.md
@@ -482,18 +482,20 @@
 - `T7-0.6` 已接入 `apply_noname_manual_plot_text_hint`，只有人工批准 + 二次护栏 allow + 当前章节/段落快照一致时，才允许显式写入 `PlotTextHint`
 - `T7-0.7` 已补显式人工 apply 的前端差异预览、重复写入禁用与 stale snapshot 友好提示
 - `T7-3` 已补 apply lifecycle 展示与测试基线，调试面板、复制摘要、Info 调试文本可以统一展示 apply / review / guardrail / manual apply / fallback 进度
-- `T7-1` 第三切片已新增 `noname_apply.rs` reviewed apply runtime，提供 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 显式写入已改走该入口，`ChapterSummaryHint` 与 `OptionBiasHint` 也已接入人工批准 + 二次护栏 + 快照一致的显式 reviewed apply
+- `T7-1` 第七切片已新增 `noname_apply.rs` reviewed apply runtime，提供 `apply_noname_reviewed_output` 通用命令入口；现有 `PlotTextHint` 显式写入已改走该入口，`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint` 也已接入人工批准 + 二次护栏 + 快照一致的显式 reviewed apply，并把低风险/非最终提示状态写入下沉到 `plot_engine`；pending augmentation 已能作为安全上下文进入下一轮 plot prompt，前端调试台已可显式触发四类 scope 的 reviewed apply
 
 ### 当前边界
 
-- proposal 目前不会自动改写剧情正文与状态机，但已可写入章节摘要提示这类低风险输出
-- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示”三类低风险输出；`plotTextHint` 会先进入 controlled output review、人工复核 intent、二次护栏，再由显式人工命令写入当前剧情段落
-- reviewed apply runtime 已形成统一通道，目前支持 `PlotTextHint`、`ChapterSummaryHint` 与 `OptionBiasHint`；`plot_engine` 低风险输出层入口还需要继续评估
+- proposal 目前不会自动改写剧情正文与状态机，但已可写入章节摘要提示、选项偏置提示与 pending 剧情增强提示这类非最终输出
+- 当前已完成 `assisted preflight`，并可应用到“诊断层 + 章节摘要提示 + 选项偏置提示 + pending 剧情增强提示”四类受控输出；`plotTextHint` 仍会先进入 controlled output review、人工复核 intent、二次护栏，再由显式人工命令写入当前剧情段落
+- reviewed apply runtime 已形成统一通道，目前支持 `PlotTextHint`、`ChapterSummaryHint`、`OptionBiasHint` 与 `PlotAugmentationHint`；`plot_engine` 已提供章节摘要提示、诊断提示与 pending augmentation 的受控输出层入口，并能在下一轮 prompt 中安全消费 pending augmentation
 - 仍然保持“经典主链路优先，NoName 仅辅助”
 
 ### 下一步子任务
 
-- `T7-1.2` 已完成两个扩展 scope：`ChapterSummaryHint` 与 `OptionBiasHint` 可复用 reviewed apply runtime；下一步可继续评估 `plot_engine` 低风险输出层入口
+- `T7-1.2` 已完成两个扩展 scope：`ChapterSummaryHint` 与 `OptionBiasHint` 可复用 reviewed apply runtime，并已通过 `plot_engine` 低风险输出层落地；前端调试台已补显式 apply 入口和快照预览
+- `T7-1.3` 已完成 non-final plot augmentation 最小接入：`PlotAugmentationHint` 可复用 reviewed apply runtime，要求 pending 列表快照一致后写入 `pending_plot_augmentation_hints`，并已接入前端调试台预览与 Web mock
+- `T7-1.4` 已完成 pending augmentation 安全消费：下一轮 plot prompt 会注入非最终安全上下文，成功由 plot_engine 生成并落地后按快照清空；quick mode、预设回退或双通道叙事覆盖时会保留 pending hints
 
 ### 验收标准
 
@@ -585,6 +587,60 @@
 
 如果继续推进实现，当前最推荐的是：
 
-1. 继续推进 `T7-1.2` 的后续落地层，让 `plot_engine` 低风险输出层复用 `noname_apply.rs` reviewed apply runtime
-2. 把新增 scope 持续接入现有 apply lifecycle，让后续更多输出类型复用同一套可视化与测试基线
+1. 继续评估是否需要更高一层的受控输出类型，例如 non-final plot augmentation，但仍不得直接接管最终剧情正文。
+2. 把后续新增 scope 持续接入现有 apply lifecycle，让更多输出类型复用同一套可视化与测试基线。
 这会比继续扩文档或继续堆更多角色更有价值，因为它决定 `NoName Agent` 是否能从“可观察”走向“可辅助落地”。
+
+## 2026-04-18 T7-1.5 Progress Note
+
+- `T7-1.5` has completed the pending plot augmentation observability slice.
+- `PlotAugmentationHint` remains a non-final, reviewed, manually staged hint. The next generation may consume it, but final plot state mutation is still owned by `plot_engine`.
+- The consume/retain result is now visible in trace execution logs, proposal transition logs, frontend lifecycle summaries, Web mock, and focused tests.
+- Recommended next direction after T7-1.5: review whether more controlled output scopes need the same pending-consume lifecycle pattern, or move to a broader trace UX cleanup instead of adding new plot authority.
+
+## 2026-04-18 T7-1.6 Progress Note
+
+- `T7-1.6` has completed the first trace UX cleanup slice for pending plot augmentation.
+- Debug copy reports and `gameStore` Info debug text now show a compact plot augmentation summary, making `已消费 / 已保留 / 待消费 / 待观察 / 无` readable without opening raw JSON.
+- No plot authority was expanded in this slice; it only improves trace interpretation and operator visibility.
+
+## 2026-04-19 T7-1.7 Progress Note
+
+- `T7-1.7` extends the same trace UX cleanup to the visible `AgentTracePanel` overview.
+- The pending plot augmentation summary now appears in the panel, debug copy report, and Info debug text through one shared helper.
+- This keeps the assisted apply observability path consistent while preserving the non-final prompt-context boundary.
+
+## 2026-04-19 T7-1.8 Progress Note
+
+- `T7-1.8` improves execution-log readability for pending plot augmentation records.
+- `AgentTracePanel` now shows readable execution labels such as `剧情增强提示 · 已消费`, while keeping the original trace target/outcome visible for low-level debugging.
+- No runtime behavior changed; this is an operator-facing trace interpretation slice only.
+
+## 2026-04-19 T7-1.9 Progress Note
+
+- `T7-1.9` extends the readable apply execution mapping to `gameStore` Info text and `InfoTabsDialog`.
+- Operator-facing debug surfaces now consistently translate pending plot augmentation execution records while preserving raw target/outcome details.
+- This remains a trace UX cleanup slice and does not alter assisted apply runtime behavior.
+
+## 2026-04-19 T7-2.0 Progress Note
+
+- `T7-2.0` extends readable apply execution summaries to copied `NoNameDebugConsole` trace reports.
+- Copy/paste debugging now includes both readable execution labels and raw trace target/outcome for translated pending plot augmentation records.
+- Runtime behavior and safe-output authority remain unchanged.
+
+## 2026-04-19 T7-2.1 Progress Note
+
+- `T7-2.1` centralizes apply execution summary formatting in `summarizeNoNameApplyExecutions`.
+- Info debug text and copied debug-console reports now share one execution-summary implementation with configurable raw/note formatting.
+- This reduces future drift across debug surfaces when new execution outcomes are added.
+
+## 2026-04-19 T7-2.2 Progress Note
+
+- `T7-2.2` completed a focused full-regression verification pass for the current T7 line.
+- Backend T7 tests, clippy, frontend NoName trace tests, frontend build, and diff whitespace checks passed.
+- The only build note remains the existing Vite dynamic-import warning for `@tauri-apps/api/core.js`; no new blocker was found.
+
+## 2026-04-19 T7-2.3 Progress Note
+
+- `T7-2.3` cleaned the T7 status language so optional future expansion is no longer described as unfinished core work.
+- T7 can now be treated as functionally complete pending final pre-PR review/commit preparation.

--- a/src-tauri/src/entity_store.rs
+++ b/src-tauri/src/entity_store.rs
@@ -53,7 +53,7 @@ impl EntityStore {
             let lower = keyword.to_lowercase();
             out.retain(|e| e.payload.to_string().to_lowercase().contains(&lower));
         }
-        out.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        out.sort_by_key(|entity| std::cmp::Reverse(entity.updated_at));
         out
     }
 }

--- a/src-tauri/src/game_engine.rs
+++ b/src-tauri/src/game_engine.rs
@@ -1,12 +1,14 @@
 use crate::event_log::{EventImportance, EventLog};
 use crate::game_state::{Character, GameState, GameTime, WorldState};
 use crate::models::{CharacterStats, Element, Grade, Lifespan, SpiritualRoot};
+use crate::noname_types::NoNameMode;
 use crate::npc::{CoreValue, Goal, NPCMemory, Personality, PersonalityTrait, NPC};
 use crate::npc_engine::{NPCDecision, NPCEngine, NPCEvent};
 use crate::numerical_system::NumericalSystem;
-use crate::noname_types::NoNameMode;
 use crate::plot_engine::{PlotEngine, PlotState, Scene};
-use crate::save_load::{MigrationBatchReport, NoNameSaveSettings, SaveData, SaveInfo, SaveLoadSystem};
+use crate::save_load::{
+    MigrationBatchReport, NoNameSaveSettings, SaveData, SaveInfo, SaveLoadSystem,
+};
 use crate::script::{Script, ScriptType};
 use crate::script_manager::ScriptManager;
 use crate::world_registry::WorldRegistry;
@@ -390,12 +392,11 @@ impl GameEngine {
             let registry_lock = self.world_registry.lock().unwrap();
             registry_lock.clone()
         };
-        let save_data = SaveData::from_game_state_with_plot(
-            save_state,
-            plot_snapshot,
-            registry_snapshot,
-        )
-        .with_noname_settings(NoNameSaveSettings { mode: self.noname_mode() });
+        let save_data =
+            SaveData::from_game_state_with_plot(save_state, plot_snapshot, registry_snapshot)
+                .with_noname_settings(NoNameSaveSettings {
+                    mode: self.noname_mode(),
+                });
         self.save_load_system.save_game(slot_id, &save_data)?;
 
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,9 +13,10 @@ pub mod llm_service;
 pub mod memory_layers;
 pub mod memory_manager;
 pub mod models;
+pub mod noname_agent_registry;
+pub mod noname_apply;
 pub mod noname_capability_base;
 pub mod noname_capability_registry;
-pub mod noname_agent_registry;
 pub mod noname_config;
 pub mod noname_context_builder;
 pub mod noname_context_types;
@@ -24,8 +25,8 @@ pub mod noname_graph;
 pub mod noname_guardrails;
 pub mod noname_knowledge_retrieval;
 pub mod noname_knowledge_store;
-pub mod noname_memory_manager;
 pub mod noname_memory_compaction;
+pub mod noname_memory_manager;
 pub mod noname_memory_retrieval;
 pub mod noname_memory_store;
 pub mod noname_memory_types;
@@ -80,6 +81,10 @@ pub fn run() {
             tauri_commands::execute_player_action,
             tauri_commands::get_noname_recent_traces,
             tauri_commands::clear_noname_recent_traces,
+            tauri_commands::mark_noname_controlled_output_review,
+            tauri_commands::resolve_noname_second_guardrail,
+            tauri_commands::apply_noname_manual_plot_text_hint,
+            tauri_commands::apply_noname_reviewed_output,
             tauri_commands::get_noname_mode,
             tauri_commands::set_noname_mode,
             tauri_commands::travel_to_location,

--- a/src-tauri/src/noname_agent_registry.rs
+++ b/src-tauri/src/noname_agent_registry.rs
@@ -40,28 +40,32 @@ impl NoNameAgentRegistry {
                     responsibility: "统筹当前回合的剧情观察焦点与低风险推进方向",
                     primary_inputs: &["narrative_notes", "episodic_memory", "chapter_summaries"],
                     output_kind: NoNameProposalKind::PlotCandidate,
-                    boundary_with_director: "Director 负责统筹，不负责直接补全世界事实或 NPC/战斗细节。",
+                    boundary_with_director:
+                        "Director 负责统筹，不负责直接补全世界事实或 NPC/战斗细节。",
                 },
                 NoNameRoleProfile {
                     role: NoNameRole::WorldCurator,
                     responsibility: "补全世界事实、场景约束和设定锚点，维持世界一致性",
                     primary_inputs: &["hard_facts", "chapter_summaries", "referenced_entities"],
                     output_kind: NoNameProposalKind::WorldPatchProposal,
-                    boundary_with_director: "WorldCurator 不负责决定剧情主冲突，只负责提供世界层约束与补丁候选。",
+                    boundary_with_director:
+                        "WorldCurator 不负责决定剧情主冲突，只负责提供世界层约束与补丁候选。",
                 },
                 NoNameRoleProfile {
                     role: NoNameRole::NpcIntent,
                     responsibility: "推断 NPC 动机、立场变化和关系反应",
                     primary_inputs: &["referenced_entities", "recent_context", "episodic_memory"],
                     output_kind: NoNameProposalKind::NpcIntentProposal,
-                    boundary_with_director: "NpcIntent 不负责编排整段剧情，只补足角色行为动机与反应。",
+                    boundary_with_director:
+                        "NpcIntent 不负责编排整段剧情，只补足角色行为动机与反应。",
                 },
                 NoNameRoleProfile {
                     role: NoNameRole::CombatNarrator,
                     responsibility: "观察冲突节奏、动作反馈与战斗描写锚点",
                     primary_inputs: &["recent_context", "episodic_memory", "action_summary"],
                     output_kind: NoNameProposalKind::CombatNarration,
-                    boundary_with_director: "CombatNarrator 不负责世界规则或人物动机，只服务于冲突表现层。",
+                    boundary_with_director:
+                        "CombatNarrator 不负责世界规则或人物动机，只服务于冲突表现层。",
                 },
             ],
         }
@@ -192,7 +196,10 @@ mod tests {
                 .expect("npc intent dispatch should work"),
         ];
 
-        assert_eq!(observations[0].proposal.kind, NoNameProposalKind::PlotCandidate);
+        assert_eq!(
+            observations[0].proposal.kind,
+            NoNameProposalKind::PlotCandidate
+        );
         assert_eq!(
             observations[1].proposal.kind,
             NoNameProposalKind::WorldPatchProposal

--- a/src-tauri/src/noname_agent_registry.rs
+++ b/src-tauri/src/noname_agent_registry.rs
@@ -1,4 +1,5 @@
-use crate::noname_context_types::NoNameContextPacket;
+use crate::noname_context_builder::flatten_role_context_packet;
+use crate::noname_context_types::{NoNameContextPacket, NoNameRoleContextPacket};
 use crate::noname_errors::NoNameError;
 use crate::noname_roles::{
     unsupported_role_error, CombatNarratorAgent, DirectorAgent, NoNameRoleObservation,
@@ -118,11 +119,35 @@ impl NoNameAgentRegistry {
             NoNameRole::System => Err(unsupported_role_error(role)),
         }
     }
+
+    pub fn dispatch_role_context_observe_turn(
+        &self,
+        trace: &mut NoNameTrace,
+        context_packet: &NoNameRoleContextPacket,
+        action_summary: &str,
+    ) -> Result<NoNameRoleObservation, NoNameError> {
+        let flattened_context = flatten_role_context_packet(context_packet);
+        let mut observation = self.dispatch_observe_turn(
+            context_packet.role,
+            trace,
+            &flattened_context,
+            action_summary,
+        )?;
+        observation.role_goal = Some(context_packet.role_goal.clone());
+        observation.scene_focus = Some(context_packet.scene_focus.clone());
+        observation.forbidden_scopes = context_packet.forbidden_scopes.clone();
+        observation.note_type_hits = context_packet.note_type_hits.clone();
+        observation.source_stats = context_packet.source_stats.clone();
+        observation.context_token_budget_used = Some(context_packet.token_budget_used);
+        observation.context_slice_stats = context_packet.context_slice_stats.clone();
+        Ok(observation)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::noname_context_builder::specialize_context_packet;
     use crate::noname_context_types::{NoNameContextPacket, NoNameContextSourceStat};
     use crate::noname_types::NoNameMode;
 
@@ -225,5 +250,46 @@ mod tests {
             .expect_err("system should not dispatch");
 
         assert_eq!(err.code, "noname.agent.unsupported_role");
+    }
+
+    #[test]
+    fn registry_can_dispatch_role_context_packet_directly() {
+        let registry = NoNameAgentRegistry::new_default();
+        let mut trace =
+            NoNameTrace::empty("trace-3", "session-3", "turn-3", NoNameMode::ObserveOnly);
+        let role_context = specialize_context_packet(&sample_packet(NoNameRole::WorldCurator));
+
+        let observation = registry
+            .dispatch_role_context_observe_turn(&mut trace, &role_context, "检查护山法阵")
+            .expect("role context dispatch should work");
+
+        assert_eq!(observation.role, NoNameRole::WorldCurator);
+        assert_eq!(
+            observation.proposal.kind,
+            NoNameProposalKind::WorldPatchProposal
+        );
+        assert!(observation.prompt_preview.contains(&role_context.role_goal));
+        assert!(observation
+            .prompt_preview
+            .contains(&role_context.forbidden_scopes[0]));
+        assert_eq!(
+            observation.role_goal.as_deref(),
+            Some(role_context.role_goal.as_str())
+        );
+        assert_eq!(
+            observation.scene_focus.as_deref(),
+            Some(role_context.scene_focus.as_str())
+        );
+        assert_eq!(observation.forbidden_scopes, role_context.forbidden_scopes);
+        assert_eq!(observation.note_type_hits, role_context.note_type_hits);
+        assert_eq!(observation.source_stats, role_context.source_stats);
+        assert_eq!(
+            observation.context_token_budget_used,
+            Some(role_context.token_budget_used)
+        );
+        assert_eq!(
+            observation.context_slice_stats,
+            role_context.context_slice_stats
+        );
     }
 }

--- a/src-tauri/src/noname_apply.rs
+++ b/src-tauri/src/noname_apply.rs
@@ -22,12 +22,19 @@ pub struct NoNameApplyDiagnosticsSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplyPlotAugmentationSnapshot {
+    pub chapter_index: u32,
+    pub expected_plot_augmentation_hints: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NoNameReviewedApplyRequest {
     pub request_id: String,
     pub scope: NoNameApplyScope,
     pub segment_snapshot: Option<NoNameApplySegmentSnapshot>,
     pub summary_snapshot: Option<NoNameApplySummarySnapshot>,
     pub diagnostics_snapshot: Option<NoNameApplyDiagnosticsSnapshot>,
+    pub plot_augmentation_snapshot: Option<NoNameApplyPlotAugmentationSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -39,6 +46,7 @@ pub struct NoNameReviewedApplyOutcome {
 fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
     match scope {
         NoNameApplyScope::PlotTextHint => 300,
+        NoNameApplyScope::PlotAugmentationHint => 250,
         NoNameApplyScope::ChapterSummaryHint => 200,
         NoNameApplyScope::OptionBiasHint => 100,
         NoNameApplyScope::Diagnostics => 50,
@@ -72,7 +80,7 @@ fn target_segment_supports_apply_scope(
     scope: NoNameApplyScope,
 ) -> bool {
     match scope {
-        NoNameApplyScope::PlotTextHint => matches!(
+        NoNameApplyScope::PlotTextHint | NoNameApplyScope::PlotAugmentationHint => matches!(
             target_segment,
             NoNameTargetSegment::CurrentTurnHead | NoNameTargetSegment::CurrentTurnTail
         ),
@@ -110,9 +118,18 @@ fn build_option_bias_hint(proposal: &NoNameProposal) -> String {
     )
 }
 
+fn build_plot_augmentation_hint(proposal: &NoNameProposal) -> String {
+    format!(
+        "NoName plot augmentation: focus={} | effect={}",
+        proposal.focus.trim(),
+        proposal.intended_effect.trim()
+    )
+}
+
 fn manual_apply_outcome_for_scope(scope: NoNameApplyScope) -> &'static str {
     match scope {
         NoNameApplyScope::PlotTextHint => "manual_plot_text_applied",
+        NoNameApplyScope::PlotAugmentationHint => "manual_plot_augmentation_hint_applied",
         NoNameApplyScope::ChapterSummaryHint => "manual_chapter_summary_hint_applied",
         NoNameApplyScope::OptionBiasHint => "manual_option_bias_hint_applied",
         NoNameApplyScope::Diagnostics => "manual_diagnostics_applied",
@@ -294,24 +311,12 @@ fn apply_chapter_summary_hint(
         return Err("chapter summary already contains this NoName hint".to_string());
     }
 
-    let summary = snapshot.expected_summary.trim();
-    let updated_summary = if summary.is_empty() {
-        hint.clone()
-    } else {
-        match proposal.target_segment {
-            NoNameTargetSegment::ChapterSummaryHead => format!("{}; {}", hint, summary),
-            _ => format!("{}; {}", summary, hint),
-        }
-    };
-
-    plot_state.current_chapter.summary = updated_summary.clone();
-    if let Some(history_chapter) = plot_state
-        .chapters
-        .iter_mut()
-        .find(|chapter| chapter.index == snapshot.chapter_index)
-    {
-        history_chapter.summary = updated_summary;
-    }
+    plot_state.apply_low_risk_chapter_summary_hint(
+        snapshot.chapter_index,
+        &snapshot.expected_summary,
+        &hint,
+        proposal.target_segment == NoNameTargetSegment::ChapterSummaryHead,
+    )?;
 
     let order = next_apply_plan_order(&trace);
     trace.record_apply_plan(
@@ -355,34 +360,21 @@ fn apply_option_bias_hint(
     let Some(snapshot) = &request.diagnostics_snapshot else {
         return Err("option_bias_hint manual apply requires a diagnostics snapshot".to_string());
     };
-    if plot_state.current_chapter.index != snapshot.chapter_index {
-        return Err(format!(
-            "chapter mismatch: expected {}, current {}",
-            snapshot.chapter_index, plot_state.current_chapter.index
-        ));
-    }
-    if !plot_state.is_waiting_for_input {
-        return Err("option_bias_hint manual apply requires waiting-for-input state".to_string());
-    }
-
     let current_diagnostics = plot_state
         .last_generation_diagnostics
         .clone()
         .unwrap_or_default();
-    if current_diagnostics != snapshot.expected_generation_diagnostics {
-        return Err("diagnostics snapshot mismatch; refusing stale manual apply".to_string());
-    }
 
     let hint = build_option_bias_hint(proposal);
     if current_diagnostics.contains(&hint) {
         return Err("diagnostics already contains this NoName option bias hint".to_string());
     }
 
-    plot_state.last_generation_diagnostics = Some(if current_diagnostics.trim().is_empty() {
-        hint.clone()
-    } else {
-        format!("{}; {}", current_diagnostics, hint)
-    });
+    plot_state.apply_low_risk_generation_diagnostics_hint(
+        snapshot.chapter_index,
+        &snapshot.expected_generation_diagnostics,
+        &hint,
+    )?;
 
     let order = next_apply_plan_order(&trace);
     trace.record_apply_plan(
@@ -417,6 +409,66 @@ fn apply_option_bias_hint(
     Ok(NoNameReviewedApplyOutcome { trace, plot_state })
 }
 
+fn apply_plot_augmentation_hint(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.plot_augmentation_snapshot else {
+        return Err(
+            "plot_augmentation_hint manual apply requires a plot augmentation snapshot".to_string(),
+        );
+    };
+
+    let hint = build_plot_augmentation_hint(proposal);
+    if snapshot
+        .expected_plot_augmentation_hints
+        .iter()
+        .any(|existing| existing == &hint)
+    {
+        return Err("plot augmentation already contains this NoName hint".to_string());
+    }
+
+    plot_state.apply_pending_plot_augmentation_hint(
+        snapshot.chapter_index,
+        &snapshot.expected_plot_augmentation_hints,
+        &hint,
+    )?;
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "manual apply confirmed for chapter={} scope={}",
+            snapshot.chapter_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        manual_apply_outcome_for_scope(request.scope),
+        Some(format!(
+            "manual plot augmentation hint staged for focus={}",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:plot_augmentation_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        manual_apply_outcome_for_scope(request.scope),
+        Some("manual plot augmentation hint staged".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
 pub fn apply_reviewed_output_to_plot_state(
     trace: NoNameTrace,
     request: NoNameReviewedApplyRequest,
@@ -432,6 +484,9 @@ pub fn apply_reviewed_output_to_plot_state(
         }
         NoNameApplyScope::OptionBiasHint => {
             apply_option_bias_hint(trace, plot_state, &request, &proposal)
+        }
+        NoNameApplyScope::PlotAugmentationHint => {
+            apply_plot_augmentation_hint(trace, plot_state, &request, &proposal)
         }
         scope => Err(format!(
             "manual reviewed apply currently does not support {}",
@@ -546,6 +601,49 @@ mod tests {
         (trace, request_id)
     }
 
+    fn make_trace_for_plot_augmentation_apply() -> (NoNameTrace, String) {
+        let proposal_id = "proposal-plot-augmentation".to_string();
+        let request_id =
+            "controlled-output-proposal-plot-augmentation-plot_augmentation_hint".to_string();
+        let mut trace = NoNameTrace::empty("trace-3", "session-1", "turn-3", NoNameMode::Assisted);
+        trace.record_proposal(NoNameProposal {
+            proposal_id,
+            kind: NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "plot augmentation hint".to_string(),
+            summary: "suggest non-final plot augmentation".to_string(),
+            focus: "hidden cave".to_string(),
+            target_segment: NoNameTargetSegment::CurrentTurnTail,
+            intended_effect: "stage a reversible narrative beat".to_string(),
+            rationale: "keep plot augmentation outside final text".to_string(),
+            suggested_action: Some("manual apply".to_string()),
+            labels: vec!["test".to_string()],
+            apply_scopes: vec![NoNameApplyScope::PlotAugmentationHint],
+            status: NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            NoNameControlledOutputKind::NonFinalPlotAugmentation,
+            Vec::new(),
+            NoNameControlledOutputReview {
+                request_id: request_id.clone(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "plot augmentation hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::NonFinalPlotAugmentation),
+                safe_apply_scope: Some(NoNameApplyScope::PlotAugmentationHint),
+                requires_human_review: true,
+            },
+        );
+        trace.controlled_output_reviews[0].human_review_decision =
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply);
+        trace.record_apply_execution(
+            NoNameApplyScope::PlotAugmentationHint.as_str(),
+            "second_guardrail_allowed",
+            None,
+        );
+        (trace, request_id)
+    }
+
     #[test]
     fn reviewed_apply_can_write_chapter_summary_hint() {
         let (trace, request_id) = make_trace_for_summary_apply();
@@ -562,6 +660,7 @@ mod tests {
                     expected_summary: "existing summary".to_string(),
                 }),
                 diagnostics_snapshot: None,
+                plot_augmentation_snapshot: None,
             },
             plot_state,
         )
@@ -599,6 +698,7 @@ mod tests {
                     expected_summary: "older summary".to_string(),
                 }),
                 diagnostics_snapshot: None,
+                plot_augmentation_snapshot: None,
             },
             plot_state,
         )
@@ -624,6 +724,7 @@ mod tests {
                     chapter_index: 1,
                     expected_generation_diagnostics: "base diagnostics".to_string(),
                 }),
+                plot_augmentation_snapshot: None,
             },
             plot_state,
         )
@@ -662,11 +763,77 @@ mod tests {
                     chapter_index: 1,
                     expected_generation_diagnostics: "older diagnostics".to_string(),
                 }),
+                plot_augmentation_snapshot: None,
             },
             plot_state,
         )
         .expect_err("stale diagnostics should be rejected");
 
         assert!(error.contains("diagnostics snapshot mismatch"));
+    }
+
+    #[test]
+    fn reviewed_apply_can_stage_plot_augmentation_hint() {
+        let (trace, request_id) = make_trace_for_plot_augmentation_apply();
+        let mut plot_state = make_plot_state("");
+        plot_state
+            .pending_plot_augmentation_hints
+            .push("existing hint".to_string());
+
+        let outcome = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::PlotAugmentationHint,
+                segment_snapshot: None,
+                summary_snapshot: None,
+                diagnostics_snapshot: None,
+                plot_augmentation_snapshot: Some(NoNameApplyPlotAugmentationSnapshot {
+                    chapter_index: 1,
+                    expected_plot_augmentation_hints: vec!["existing hint".to_string()],
+                }),
+            },
+            plot_state,
+        )
+        .expect("plot augmentation hint should be staged");
+
+        assert_eq!(outcome.plot_state.pending_plot_augmentation_hints.len(), 2);
+        assert!(outcome
+            .plot_state
+            .pending_plot_augmentation_hints
+            .iter()
+            .any(|hint| hint.contains("NoName plot augmentation: focus=hidden cave")));
+        assert!(outcome.trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "plot_augmentation_hint"
+                && entry.outcome == "manual_plot_augmentation_hint_applied"
+        }));
+    }
+
+    #[test]
+    fn reviewed_apply_rejects_stale_plot_augmentation_snapshot() {
+        let (trace, request_id) = make_trace_for_plot_augmentation_apply();
+        let mut plot_state = make_plot_state("");
+        plot_state
+            .pending_plot_augmentation_hints
+            .push("new hint".to_string());
+
+        let error = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::PlotAugmentationHint,
+                segment_snapshot: None,
+                summary_snapshot: None,
+                diagnostics_snapshot: None,
+                plot_augmentation_snapshot: Some(NoNameApplyPlotAugmentationSnapshot {
+                    chapter_index: 1,
+                    expected_plot_augmentation_hints: vec!["old hint".to_string()],
+                }),
+            },
+            plot_state,
+        )
+        .expect_err("stale plot augmentation snapshot should be rejected");
+
+        assert!(error.contains("plot augmentation snapshot mismatch"));
     }
 }

--- a/src-tauri/src/noname_apply.rs
+++ b/src-tauri/src/noname_apply.rs
@@ -1,0 +1,672 @@
+use crate::noname_trace::{NoNameHumanReviewDecision, NoNameTrace};
+use crate::noname_types::{NoNameApplyScope, NoNameProposal, NoNameTargetSegment};
+use crate::plot_engine::PlotState;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplySegmentSnapshot {
+    pub chapter_index: u32,
+    pub segment_index: usize,
+    pub expected_segment_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplySummarySnapshot {
+    pub chapter_index: u32,
+    pub expected_summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameApplyDiagnosticsSnapshot {
+    pub chapter_index: u32,
+    pub expected_generation_diagnostics: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoNameReviewedApplyRequest {
+    pub request_id: String,
+    pub scope: NoNameApplyScope,
+    pub segment_snapshot: Option<NoNameApplySegmentSnapshot>,
+    pub summary_snapshot: Option<NoNameApplySummarySnapshot>,
+    pub diagnostics_snapshot: Option<NoNameApplyDiagnosticsSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoNameReviewedApplyOutcome {
+    pub trace: NoNameTrace,
+    pub plot_state: PlotState,
+}
+
+fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
+    match scope {
+        NoNameApplyScope::PlotTextHint => 300,
+        NoNameApplyScope::ChapterSummaryHint => 200,
+        NoNameApplyScope::OptionBiasHint => 100,
+        NoNameApplyScope::Diagnostics => 50,
+    }
+}
+
+fn next_apply_plan_order(trace: &NoNameTrace) -> u32 {
+    trace
+        .apply_plan_log
+        .iter()
+        .map(|item| item.order)
+        .max()
+        .unwrap_or_default()
+        + 1
+}
+
+fn find_review_proposal<'a>(
+    trace: &'a NoNameTrace,
+    request_id: &str,
+) -> Option<&'a NoNameProposal> {
+    trace
+        .proposals
+        .iter()
+        .rev()
+        .find(|proposal| request_id.contains(&proposal.proposal_id))
+        .or_else(|| trace.proposals.last())
+}
+
+fn target_segment_supports_apply_scope(
+    target_segment: NoNameTargetSegment,
+    scope: NoNameApplyScope,
+) -> bool {
+    match scope {
+        NoNameApplyScope::PlotTextHint => matches!(
+            target_segment,
+            NoNameTargetSegment::CurrentTurnHead | NoNameTargetSegment::CurrentTurnTail
+        ),
+        _ => true,
+    }
+}
+
+fn trace_has_second_guardrail_allow(
+    trace: &NoNameTrace,
+    request_id: &str,
+    scope: NoNameApplyScope,
+) -> bool {
+    let transition = format!("{}:second_guardrail:allow", request_id);
+    trace
+        .proposal_transition_log
+        .iter()
+        .any(|entry| entry == &transition)
+        || trace.apply_execution_log.iter().any(|entry| {
+            entry.target == scope.as_str() && entry.outcome == "second_guardrail_allowed"
+        })
+}
+
+fn build_plot_text_hint(proposal: &NoNameProposal) -> String {
+    format!("【NoName】重点关注：{}", proposal.focus.trim())
+}
+
+fn build_chapter_summary_hint(proposal: &NoNameProposal) -> String {
+    format!("NoName summary hint: {}", proposal.focus.trim())
+}
+
+fn build_option_bias_hint(proposal: &NoNameProposal) -> String {
+    format!(
+        "NoName option bias: next turn should prioritize actions around {}",
+        proposal.focus.trim()
+    )
+}
+
+fn manual_apply_outcome_for_scope(scope: NoNameApplyScope) -> &'static str {
+    match scope {
+        NoNameApplyScope::PlotTextHint => "manual_plot_text_applied",
+        NoNameApplyScope::ChapterSummaryHint => "manual_chapter_summary_hint_applied",
+        NoNameApplyScope::OptionBiasHint => "manual_option_bias_hint_applied",
+        NoNameApplyScope::Diagnostics => "manual_diagnostics_applied",
+    }
+}
+
+fn validate_reviewed_apply_request<'a>(
+    trace: &'a NoNameTrace,
+    request: &'a NoNameReviewedApplyRequest,
+) -> Result<&'a NoNameProposal, String> {
+    let review = trace
+        .controlled_output_reviews
+        .iter()
+        .find(|review| review.request_id == request.request_id)
+        .ok_or_else(|| {
+            format!(
+                "NoName controlled output review not found: {}",
+                request.request_id
+            )
+        })?;
+
+    if review.human_review_decision != Some(NoNameHumanReviewDecision::ApprovedForHigherApply) {
+        return Err(format!(
+            "NoName controlled output review is not approved for manual apply: {}",
+            request.request_id
+        ));
+    }
+    if review.safe_apply_scope != Some(request.scope) {
+        return Err(format!(
+            "manual apply scope mismatch: expected {}, review scope {:?}",
+            request.scope.as_str(),
+            review.safe_apply_scope
+        ));
+    }
+    if !trace_has_second_guardrail_allow(trace, &request.request_id, request.scope) {
+        return Err("second guardrail has not allowed this review".to_string());
+    }
+    if trace.apply_execution_log.iter().any(|entry| {
+        entry.target == request.scope.as_str()
+            && entry.outcome == manual_apply_outcome_for_scope(request.scope)
+    }) {
+        return Err(format!(
+            "manual {} has already been applied for this trace",
+            request.scope.as_str()
+        ));
+    }
+
+    let proposal = find_review_proposal(trace, &request.request_id)
+        .ok_or_else(|| "NoName proposal not found for manual apply".to_string())?;
+    if !target_segment_supports_apply_scope(proposal.target_segment, request.scope) {
+        return Err(format!(
+            "target_segment={} does not support manual {}",
+            proposal.target_segment.as_str(),
+            request.scope.as_str()
+        ));
+    }
+
+    Ok(proposal)
+}
+
+fn apply_plot_text_hint_to_segment(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.segment_snapshot else {
+        return Err("plot_text_hint manual apply requires a segment snapshot".to_string());
+    };
+    if plot_state.current_chapter.index != snapshot.chapter_index {
+        return Err(format!(
+            "chapter mismatch: expected {}, current {}",
+            snapshot.chapter_index, plot_state.current_chapter.index
+        ));
+    }
+    let Some(current_segment) = plot_state
+        .current_chapter
+        .content
+        .get(snapshot.segment_index)
+    else {
+        return Err(format!(
+            "segment index out of range: {}",
+            snapshot.segment_index
+        ));
+    };
+    if current_segment != &snapshot.expected_segment_text {
+        return Err("segment snapshot mismatch; refusing stale manual apply".to_string());
+    }
+    if snapshot.expected_segment_text.contains("【NoName】")
+        || snapshot.expected_segment_text.contains("NoName提示")
+    {
+        return Err("segment already contains a NoName marker".to_string());
+    }
+
+    let hint = build_plot_text_hint(proposal);
+    let updated_segment = match proposal.target_segment {
+        NoNameTargetSegment::CurrentTurnHead => {
+            format!("{}\n\n{}", hint, snapshot.expected_segment_text.trim())
+        }
+        _ => format!("{}\n\n{}", snapshot.expected_segment_text.trim(), hint),
+    };
+
+    plot_state.current_chapter.content[snapshot.segment_index] = updated_segment.clone();
+    if let Some(history_segment) = plot_state
+        .plot_history
+        .iter_mut()
+        .rev()
+        .find(|item| item.as_str() == snapshot.expected_segment_text)
+    {
+        *history_segment = updated_segment.clone();
+    } else {
+        return Err("plot history snapshot mismatch; refusing partial manual apply".to_string());
+    }
+    plot_state.current_scene.description = plot_state.current_chapter.content.join("\n\n");
+    if let Some(result) = plot_state.last_action_result.as_mut() {
+        if result.description == snapshot.expected_segment_text {
+            result.description = updated_segment;
+        }
+    }
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "显式人工 apply 已确认 chapter={} segment={}，准备写入 {}",
+            snapshot.chapter_index,
+            snapshot.segment_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        "manual_plot_text_applied",
+        Some(format!(
+            "已由显式人工命令写入正文提示，聚焦“{}”",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:plot_text_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        "manual_plot_text_applied",
+        Some("显式人工 apply 已写入正文提示".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
+fn apply_chapter_summary_hint(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.summary_snapshot else {
+        return Err("chapter_summary_hint manual apply requires a summary snapshot".to_string());
+    };
+    if plot_state.current_chapter.index != snapshot.chapter_index {
+        return Err(format!(
+            "chapter mismatch: expected {}, current {}",
+            snapshot.chapter_index, plot_state.current_chapter.index
+        ));
+    }
+    if plot_state.current_chapter.summary != snapshot.expected_summary {
+        return Err("summary snapshot mismatch; refusing stale manual apply".to_string());
+    }
+
+    let focus = proposal.focus.trim();
+    let hint = build_chapter_summary_hint(proposal);
+    if !focus.is_empty()
+        && (snapshot.expected_summary.contains(focus) || snapshot.expected_summary.contains(&hint))
+    {
+        return Err("chapter summary already contains this NoName hint".to_string());
+    }
+
+    let summary = snapshot.expected_summary.trim();
+    let updated_summary = if summary.is_empty() {
+        hint.clone()
+    } else {
+        match proposal.target_segment {
+            NoNameTargetSegment::ChapterSummaryHead => format!("{}; {}", hint, summary),
+            _ => format!("{}; {}", summary, hint),
+        }
+    };
+
+    plot_state.current_chapter.summary = updated_summary.clone();
+    if let Some(history_chapter) = plot_state
+        .chapters
+        .iter_mut()
+        .find(|chapter| chapter.index == snapshot.chapter_index)
+    {
+        history_chapter.summary = updated_summary;
+    }
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "manual apply confirmed for chapter={} scope={}",
+            snapshot.chapter_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        manual_apply_outcome_for_scope(request.scope),
+        Some(format!(
+            "manual chapter summary hint applied for focus={}",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:chapter_summary_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        manual_apply_outcome_for_scope(request.scope),
+        Some("manual chapter summary hint applied".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
+fn apply_option_bias_hint(
+    mut trace: NoNameTrace,
+    mut plot_state: PlotState,
+    request: &NoNameReviewedApplyRequest,
+    proposal: &NoNameProposal,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let Some(snapshot) = &request.diagnostics_snapshot else {
+        return Err("option_bias_hint manual apply requires a diagnostics snapshot".to_string());
+    };
+    if plot_state.current_chapter.index != snapshot.chapter_index {
+        return Err(format!(
+            "chapter mismatch: expected {}, current {}",
+            snapshot.chapter_index, plot_state.current_chapter.index
+        ));
+    }
+    if !plot_state.is_waiting_for_input {
+        return Err("option_bias_hint manual apply requires waiting-for-input state".to_string());
+    }
+
+    let current_diagnostics = plot_state
+        .last_generation_diagnostics
+        .clone()
+        .unwrap_or_default();
+    if current_diagnostics != snapshot.expected_generation_diagnostics {
+        return Err("diagnostics snapshot mismatch; refusing stale manual apply".to_string());
+    }
+
+    let hint = build_option_bias_hint(proposal);
+    if current_diagnostics.contains(&hint) {
+        return Err("diagnostics already contains this NoName option bias hint".to_string());
+    }
+
+    plot_state.last_generation_diagnostics = Some(if current_diagnostics.trim().is_empty() {
+        hint.clone()
+    } else {
+        format!("{}; {}", current_diagnostics, hint)
+    });
+
+    let order = next_apply_plan_order(&trace);
+    trace.record_apply_plan(
+        order,
+        request.scope.as_str(),
+        "manual_apply",
+        priority_for_apply_scope(request.scope) + 75,
+        Some(format!(
+            "manual apply confirmed for chapter={} scope={}",
+            snapshot.chapter_index,
+            request.scope.as_str()
+        )),
+    );
+    trace.record_apply_execution(
+        request.scope.as_str(),
+        manual_apply_outcome_for_scope(request.scope),
+        Some(format!(
+            "manual option bias hint applied for focus={}",
+            proposal.focus
+        )),
+    );
+    trace.record_proposal_transition(format!(
+        "{}:manual_apply:option_bias_hint",
+        request.request_id
+    ));
+    trace.set_apply_result(
+        true,
+        manual_apply_outcome_for_scope(request.scope),
+        Some("manual option bias hint applied".to_string()),
+    );
+
+    Ok(NoNameReviewedApplyOutcome { trace, plot_state })
+}
+
+pub fn apply_reviewed_output_to_plot_state(
+    trace: NoNameTrace,
+    request: NoNameReviewedApplyRequest,
+    plot_state: PlotState,
+) -> Result<NoNameReviewedApplyOutcome, String> {
+    let proposal = validate_reviewed_apply_request(&trace, &request)?.clone();
+    match request.scope {
+        NoNameApplyScope::PlotTextHint => {
+            apply_plot_text_hint_to_segment(trace, plot_state, &request, &proposal)
+        }
+        NoNameApplyScope::ChapterSummaryHint => {
+            apply_chapter_summary_hint(trace, plot_state, &request, &proposal)
+        }
+        NoNameApplyScope::OptionBiasHint => {
+            apply_option_bias_hint(trace, plot_state, &request, &proposal)
+        }
+        scope => Err(format!(
+            "manual reviewed apply currently does not support {}",
+            scope.as_str()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::noname_output_interface::{
+        NoNameControlledOutputDecision, NoNameControlledOutputKind, NoNameControlledOutputReview,
+    };
+    use crate::noname_types::{NoNameMode, NoNameProposalKind, NoNameProposalStatus, NoNameRole};
+    use crate::plot_engine::Scene;
+
+    fn make_plot_state(summary: &str) -> PlotState {
+        let scene = Scene {
+            id: "scene-1".to_string(),
+            name: "test scene".to_string(),
+            description: "test description".to_string(),
+            location: "test".to_string(),
+            available_options: Vec::new(),
+        };
+        let mut state = PlotState::new(scene);
+        state.current_chapter.summary = summary.to_string();
+        state
+    }
+
+    fn make_trace_for_summary_apply() -> (NoNameTrace, String) {
+        let proposal_id = "proposal-summary".to_string();
+        let request_id = "controlled-output-proposal-summary-chapter_summary_hint".to_string();
+        let mut trace = NoNameTrace::empty("trace-1", "session-1", "turn-1", NoNameMode::Assisted);
+        trace.record_proposal(NoNameProposal {
+            proposal_id,
+            kind: NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "summary hint".to_string(),
+            summary: "suggest summary hint".to_string(),
+            focus: "sect crisis".to_string(),
+            target_segment: NoNameTargetSegment::ChapterSummaryHead,
+            intended_effect: "prepend chapter summary hint".to_string(),
+            rationale: "keep recap focused".to_string(),
+            suggested_action: Some("manual apply".to_string()),
+            labels: vec!["test".to_string()],
+            apply_scopes: vec![NoNameApplyScope::ChapterSummaryHint],
+            status: NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            NoNameControlledOutputKind::RecapNote,
+            Vec::new(),
+            NoNameControlledOutputReview {
+                request_id: request_id.clone(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "summary hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::RecapNote),
+                safe_apply_scope: Some(NoNameApplyScope::ChapterSummaryHint),
+                requires_human_review: true,
+            },
+        );
+        trace.controlled_output_reviews[0].human_review_decision =
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply);
+        trace.record_apply_execution(
+            NoNameApplyScope::ChapterSummaryHint.as_str(),
+            "second_guardrail_allowed",
+            None,
+        );
+        (trace, request_id)
+    }
+
+    fn make_trace_for_option_bias_apply() -> (NoNameTrace, String) {
+        let proposal_id = "proposal-option-bias".to_string();
+        let request_id = "controlled-output-proposal-option-bias-option_bias_hint".to_string();
+        let mut trace = NoNameTrace::empty("trace-2", "session-1", "turn-2", NoNameMode::Assisted);
+        trace.record_proposal(NoNameProposal {
+            proposal_id,
+            kind: NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "option bias hint".to_string(),
+            summary: "suggest option bias hint".to_string(),
+            focus: "hidden cave".to_string(),
+            target_segment: NoNameTargetSegment::CurrentTurnTail,
+            intended_effect: "bias next player options".to_string(),
+            rationale: "keep choices focused".to_string(),
+            suggested_action: Some("manual apply".to_string()),
+            labels: vec!["test".to_string()],
+            apply_scopes: vec![NoNameApplyScope::OptionBiasHint],
+            status: NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            NoNameControlledOutputKind::IntermediateNarrativeHint,
+            Vec::new(),
+            NoNameControlledOutputReview {
+                request_id: request_id.clone(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "option bias hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::IntermediateNarrativeHint),
+                safe_apply_scope: Some(NoNameApplyScope::OptionBiasHint),
+                requires_human_review: true,
+            },
+        );
+        trace.controlled_output_reviews[0].human_review_decision =
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply);
+        trace.record_apply_execution(
+            NoNameApplyScope::OptionBiasHint.as_str(),
+            "second_guardrail_allowed",
+            None,
+        );
+        (trace, request_id)
+    }
+
+    #[test]
+    fn reviewed_apply_can_write_chapter_summary_hint() {
+        let (trace, request_id) = make_trace_for_summary_apply();
+        let plot_state = make_plot_state("existing summary");
+
+        let outcome = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::ChapterSummaryHint,
+                segment_snapshot: None,
+                summary_snapshot: Some(NoNameApplySummarySnapshot {
+                    chapter_index: 1,
+                    expected_summary: "existing summary".to_string(),
+                }),
+                diagnostics_snapshot: None,
+            },
+            plot_state,
+        )
+        .expect("summary hint should be manually applied");
+
+        assert!(outcome
+            .plot_state
+            .current_chapter
+            .summary
+            .starts_with("NoName summary hint: sect crisis; existing summary"));
+        assert!(outcome.trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "chapter_summary_hint"
+                && entry.outcome == "manual_chapter_summary_hint_applied"
+        }));
+        assert!(outcome
+            .trace
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry.ends_with(":manual_apply:chapter_summary_hint")));
+    }
+
+    #[test]
+    fn reviewed_apply_rejects_stale_chapter_summary_snapshot() {
+        let (trace, request_id) = make_trace_for_summary_apply();
+        let plot_state = make_plot_state("newer summary");
+
+        let error = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::ChapterSummaryHint,
+                segment_snapshot: None,
+                summary_snapshot: Some(NoNameApplySummarySnapshot {
+                    chapter_index: 1,
+                    expected_summary: "older summary".to_string(),
+                }),
+                diagnostics_snapshot: None,
+            },
+            plot_state,
+        )
+        .expect_err("stale summary should be rejected");
+
+        assert!(error.contains("summary snapshot mismatch"));
+    }
+
+    #[test]
+    fn reviewed_apply_can_write_option_bias_hint() {
+        let (trace, request_id) = make_trace_for_option_bias_apply();
+        let mut plot_state = make_plot_state("");
+        plot_state.last_generation_diagnostics = Some("base diagnostics".to_string());
+
+        let outcome = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::OptionBiasHint,
+                segment_snapshot: None,
+                summary_snapshot: None,
+                diagnostics_snapshot: Some(NoNameApplyDiagnosticsSnapshot {
+                    chapter_index: 1,
+                    expected_generation_diagnostics: "base diagnostics".to_string(),
+                }),
+            },
+            plot_state,
+        )
+        .expect("option bias hint should be manually applied");
+
+        assert_eq!(
+            outcome.plot_state.last_generation_diagnostics.as_deref(),
+            Some(
+                "base diagnostics; NoName option bias: next turn should prioritize actions around hidden cave"
+            )
+        );
+        assert!(outcome.trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "option_bias_hint" && entry.outcome == "manual_option_bias_hint_applied"
+        }));
+        assert!(outcome
+            .trace
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry.ends_with(":manual_apply:option_bias_hint")));
+    }
+
+    #[test]
+    fn reviewed_apply_rejects_stale_option_bias_snapshot() {
+        let (trace, request_id) = make_trace_for_option_bias_apply();
+        let mut plot_state = make_plot_state("");
+        plot_state.last_generation_diagnostics = Some("newer diagnostics".to_string());
+
+        let error = apply_reviewed_output_to_plot_state(
+            trace,
+            NoNameReviewedApplyRequest {
+                request_id,
+                scope: NoNameApplyScope::OptionBiasHint,
+                segment_snapshot: None,
+                summary_snapshot: None,
+                diagnostics_snapshot: Some(NoNameApplyDiagnosticsSnapshot {
+                    chapter_index: 1,
+                    expected_generation_diagnostics: "older diagnostics".to_string(),
+                }),
+            },
+            plot_state,
+        )
+        .expect_err("stale diagnostics should be rejected");
+
+        assert!(error.contains("diagnostics snapshot mismatch"));
+    }
+}

--- a/src-tauri/src/noname_context_builder.rs
+++ b/src-tauri/src/noname_context_builder.rs
@@ -2,9 +2,11 @@ use crate::entity_store::{EntityQuery, EntityStore};
 use crate::entity_types::EntityType;
 use crate::noname_context_types::{
     NoNameContextBuildInput, NoNameContextPacket, NoNameContextSourceStat, NoNameRoleContextPacket,
+    NoNameRoleContextSliceStat,
 };
 use crate::noname_memory_manager::NoNameMemoryManager;
 use crate::noname_memory_retrieval::NoNameMemoryQuery;
+use crate::noname_memory_types::{NoNameNarrativeMemoryItem, NoNameNarrativeNoteType};
 use crate::noname_types::NoNameRole;
 
 pub fn build_context_packet(
@@ -38,17 +40,18 @@ pub fn build_context_packet(
         .iter()
         .map(|item| item.summary.clone())
         .collect::<Vec<_>>();
-    let mut narrative_notes = retrieved
-        .narrative
+    let active_notes = role_ranked_active_notes(memory_manager.active_notes(), input.role);
+    let mut narrative_notes = dedupe_ordered_strings(
+        active_notes
+            .iter()
+            .chain(retrieved.narrative.iter())
+            .map(note_line)
+            .collect(),
+    );
+    let mut chapter_summaries = active_notes
         .iter()
-        .map(|item| format!("{}: {}", item.title, item.summary))
-        .collect::<Vec<_>>();
-
-    let mut chapter_summaries = memory_manager
-        .active_notes()
-        .into_iter()
         .take(input.per_section_limit)
-        .map(|note| format!("{}: {}", note.title, note.summary))
+        .map(note_line)
         .collect::<Vec<_>>();
 
     let mut recent_context = input
@@ -154,6 +157,81 @@ pub fn build_context_packet(
     }
 }
 
+fn note_line(note: &NoNameNarrativeMemoryItem) -> String {
+    format!("{}: {}", note.title, note.summary)
+}
+
+fn role_ranked_active_notes(
+    mut notes: Vec<NoNameNarrativeMemoryItem>,
+    role: NoNameRole,
+) -> Vec<NoNameNarrativeMemoryItem> {
+    notes.sort_by(|left, right| {
+        role_note_priority(role, left.note_type)
+            .cmp(&role_note_priority(role, right.note_type))
+            .then_with(|| right.updated_at.cmp(&left.updated_at))
+            .then_with(|| left.note_id.cmp(&right.note_id))
+    });
+    notes
+}
+
+fn role_note_priority(role: NoNameRole, note_type: NoNameNarrativeNoteType) -> u8 {
+    match role {
+        NoNameRole::Director => match note_type {
+            NoNameNarrativeNoteType::Conflict => 0,
+            NoNameNarrativeNoteType::Goal => 1,
+            NoNameNarrativeNoteType::UnresolvedThread => 2,
+            NoNameNarrativeNoteType::Foreshadowing => 3,
+            NoNameNarrativeNoteType::CharacterArc => 4,
+        },
+        NoNameRole::WorldCurator => match note_type {
+            NoNameNarrativeNoteType::Goal => 0,
+            NoNameNarrativeNoteType::Foreshadowing => 1,
+            NoNameNarrativeNoteType::UnresolvedThread => 2,
+            NoNameNarrativeNoteType::Conflict => 3,
+            NoNameNarrativeNoteType::CharacterArc => 4,
+        },
+        NoNameRole::NpcIntent => match note_type {
+            NoNameNarrativeNoteType::CharacterArc => 0,
+            NoNameNarrativeNoteType::Conflict => 1,
+            NoNameNarrativeNoteType::UnresolvedThread => 2,
+            NoNameNarrativeNoteType::Foreshadowing => 3,
+            NoNameNarrativeNoteType::Goal => 4,
+        },
+        NoNameRole::CombatNarrator => match note_type {
+            NoNameNarrativeNoteType::Conflict => 0,
+            NoNameNarrativeNoteType::CharacterArc => 1,
+            NoNameNarrativeNoteType::Goal => 2,
+            NoNameNarrativeNoteType::UnresolvedThread => 3,
+            NoNameNarrativeNoteType::Foreshadowing => 4,
+        },
+        NoNameRole::System => match note_type {
+            NoNameNarrativeNoteType::Goal => 0,
+            NoNameNarrativeNoteType::Conflict => 1,
+            NoNameNarrativeNoteType::Foreshadowing => 2,
+            NoNameNarrativeNoteType::UnresolvedThread => 3,
+            NoNameNarrativeNoteType::CharacterArc => 4,
+        },
+    }
+}
+
+fn build_role_note_hits(notes: &[NoNameNarrativeMemoryItem], limit: usize) -> Vec<String> {
+    notes
+        .iter()
+        .take(limit)
+        .map(|note| format!("{}: {}", note_type_label(note.note_type), note.title))
+        .collect()
+}
+
+fn note_type_label(note_type: NoNameNarrativeNoteType) -> &'static str {
+    match note_type {
+        NoNameNarrativeNoteType::Goal => "goal",
+        NoNameNarrativeNoteType::Conflict => "conflict",
+        NoNameNarrativeNoteType::Foreshadowing => "foreshadowing",
+        NoNameNarrativeNoteType::UnresolvedThread => "unresolvedThread",
+        NoNameNarrativeNoteType::CharacterArc => "characterArc",
+    }
+}
+
 pub fn build_role_context_packet(
     store: &EntityStore,
     memory_manager: &NoNameMemoryManager,
@@ -163,7 +241,10 @@ pub fn build_role_context_packet(
     let mut role_input = input.clone();
     role_input.role = role;
     let packet = build_context_packet(store, memory_manager, &role_input);
-    specialize_context_packet(&packet)
+    let ranked_notes = role_ranked_active_notes(memory_manager.active_notes(), role);
+    let mut role_packet = specialize_context_packet(&packet);
+    role_packet.note_type_hits = build_role_note_hits(&ranked_notes, input.per_section_limit);
+    role_packet
 }
 
 pub fn build_role_context_packets(
@@ -189,7 +270,35 @@ pub fn specialize_context_packet(packet: &NoNameContextPacket) -> NoNameRoleCont
     }
 }
 
+pub fn flatten_role_context_packet(packet: &NoNameRoleContextPacket) -> NoNameContextPacket {
+    NoNameContextPacket {
+        role: packet.role,
+        hard_facts: packet.world_facts.clone(),
+        working_memory: packet.recent_signals.clone(),
+        episodic_memory: packet.recent_signals.clone(),
+        narrative_notes: packet.narrative_priorities.clone(),
+        chapter_summaries: packet.narrative_priorities.clone(),
+        recent_context: packet.recent_signals.clone(),
+        referenced_entities: packet.character_relationships.clone(),
+        compressed_summary: Some(format!(
+            "roleGoal: {}; sceneFocus: {}; noteTypeHits: {}; visibleConstraints: {}; forbiddenScopes: {}",
+            packet.role_goal,
+            packet.scene_focus,
+            packet.note_type_hits.join(" | "),
+            packet.visible_constraints.join(" | "),
+            packet.forbidden_scopes.join(" | ")
+        )),
+        token_budget_used: packet.token_budget_used,
+        source_stats: packet.source_stats.clone(),
+    }
+}
+
 fn director_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
+    let world_facts = take_lines(&packet.hard_facts, 2);
+    let character_relationships = take_lines(&packet.referenced_entities, 4);
+    let narrative_priorities =
+        take_joined(&[&packet.narrative_notes, &packet.chapter_summaries], 6);
+    let recent_signals = take_joined(&[&packet.working_memory, &packet.recent_context], 4);
     NoNameRoleContextPacket {
         role: NoNameRole::Director,
         role_goal: "Select the safest narrative focus for the next beat.".to_string(),
@@ -199,10 +308,11 @@ fn director_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
             &packet.recent_context,
             &packet.hard_facts,
         ]),
-        world_facts: take_lines(&packet.hard_facts, 2),
-        character_relationships: take_lines(&packet.referenced_entities, 4),
-        narrative_priorities: take_joined(&[&packet.narrative_notes, &packet.chapter_summaries], 6),
-        recent_signals: take_joined(&[&packet.working_memory, &packet.recent_context], 4),
+        note_type_hits: Vec::new(),
+        world_facts: world_facts.clone(),
+        character_relationships: character_relationships.clone(),
+        narrative_priorities: narrative_priorities.clone(),
+        recent_signals: recent_signals.clone(),
         visible_constraints: vec![
             "May propose low-risk narrative direction.".to_string(),
             "Should keep unresolved threads visible for later turns.".to_string(),
@@ -211,12 +321,34 @@ fn director_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
             "Must not directly rewrite final plot state.".to_string(),
             "Must not invent hard world canon without WorldCurator support.".to_string(),
         ],
+        context_slice_stats: vec![
+            build_slice_stat("worldFacts", packet.hard_facts.len(), world_facts.len()),
+            build_slice_stat(
+                "characterRelationships",
+                packet.referenced_entities.len(),
+                character_relationships.len(),
+            ),
+            build_slice_stat(
+                "narrativePriorities",
+                packet.narrative_notes.len() + packet.chapter_summaries.len(),
+                narrative_priorities.len(),
+            ),
+            build_slice_stat(
+                "recentSignals",
+                packet.working_memory.len() + packet.recent_context.len(),
+                recent_signals.len(),
+            ),
+        ],
         source_stats: packet.source_stats.clone(),
         token_budget_used: packet.token_budget_used,
     }
 }
 
 fn world_curator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
+    let world_facts = take_joined(&[&packet.hard_facts, &packet.chapter_summaries], 8);
+    let character_relationships = take_lines(&packet.referenced_entities, 3);
+    let narrative_priorities = take_lines(&packet.chapter_summaries, 3);
+    let recent_signals = take_lines(&packet.recent_context, 2);
     NoNameRoleContextPacket {
         role: NoNameRole::WorldCurator,
         role_goal: "Maintain world facts, scene constraints, and canon anchors.".to_string(),
@@ -226,10 +358,11 @@ fn world_curator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacke
             &packet.referenced_entities,
             &packet.recent_context,
         ]),
-        world_facts: take_joined(&[&packet.hard_facts, &packet.chapter_summaries], 8),
-        character_relationships: take_lines(&packet.referenced_entities, 3),
-        narrative_priorities: take_lines(&packet.chapter_summaries, 3),
-        recent_signals: take_lines(&packet.recent_context, 2),
+        note_type_hits: Vec::new(),
+        world_facts: world_facts.clone(),
+        character_relationships: character_relationships.clone(),
+        narrative_priorities: narrative_priorities.clone(),
+        recent_signals: recent_signals.clone(),
         visible_constraints: vec![
             "May clarify setting rules and location constraints.".to_string(),
             "Should preserve established facts over dramatic convenience.".to_string(),
@@ -238,12 +371,39 @@ fn world_curator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacke
             "Must not decide NPC private intent.".to_string(),
             "Must not choose the main plot beat alone.".to_string(),
         ],
+        context_slice_stats: vec![
+            build_slice_stat(
+                "worldFacts",
+                packet.hard_facts.len() + packet.chapter_summaries.len(),
+                world_facts.len(),
+            ),
+            build_slice_stat(
+                "characterRelationships",
+                packet.referenced_entities.len(),
+                character_relationships.len(),
+            ),
+            build_slice_stat(
+                "narrativePriorities",
+                packet.chapter_summaries.len(),
+                narrative_priorities.len(),
+            ),
+            build_slice_stat(
+                "recentSignals",
+                packet.recent_context.len(),
+                recent_signals.len(),
+            ),
+        ],
         source_stats: packet.source_stats.clone(),
         token_budget_used: packet.token_budget_used,
     }
 }
 
 fn npc_intent_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
+    let world_facts = take_lines(&packet.hard_facts, 2);
+    let character_relationships =
+        take_joined(&[&packet.referenced_entities, &packet.narrative_notes], 6);
+    let narrative_priorities = take_lines(&packet.narrative_notes, 4);
+    let recent_signals = take_joined(&[&packet.episodic_memory, &packet.recent_context], 5);
     NoNameRoleContextPacket {
         role: NoNameRole::NpcIntent,
         role_goal: "Infer NPC motivation, stance changes, and relationship pressure.".to_string(),
@@ -253,13 +413,11 @@ fn npc_intent_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
             &packet.narrative_notes,
             &packet.recent_context,
         ]),
-        world_facts: take_lines(&packet.hard_facts, 2),
-        character_relationships: take_joined(
-            &[&packet.referenced_entities, &packet.narrative_notes],
-            6,
-        ),
-        narrative_priorities: take_lines(&packet.narrative_notes, 4),
-        recent_signals: take_joined(&[&packet.episodic_memory, &packet.recent_context], 5),
+        note_type_hits: Vec::new(),
+        world_facts: world_facts.clone(),
+        character_relationships: character_relationships.clone(),
+        narrative_priorities: narrative_priorities.clone(),
+        recent_signals: recent_signals.clone(),
         visible_constraints: vec![
             "May infer motivation only from visible context.".to_string(),
             "Should keep uncertainty explicit when evidence is thin.".to_string(),
@@ -268,12 +426,34 @@ fn npc_intent_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
             "Must not reveal hidden knowledge not present in context.".to_string(),
             "Must not override world facts or combat outcomes.".to_string(),
         ],
+        context_slice_stats: vec![
+            build_slice_stat("worldFacts", packet.hard_facts.len(), world_facts.len()),
+            build_slice_stat(
+                "characterRelationships",
+                packet.referenced_entities.len() + packet.narrative_notes.len(),
+                character_relationships.len(),
+            ),
+            build_slice_stat(
+                "narrativePriorities",
+                packet.narrative_notes.len(),
+                narrative_priorities.len(),
+            ),
+            build_slice_stat(
+                "recentSignals",
+                packet.episodic_memory.len() + packet.recent_context.len(),
+                recent_signals.len(),
+            ),
+        ],
         source_stats: packet.source_stats.clone(),
         token_budget_used: packet.token_budget_used,
     }
 }
 
 fn combat_narrator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
+    let world_facts = take_lines(&packet.hard_facts, 3);
+    let character_relationships = take_lines(&packet.referenced_entities, 3);
+    let narrative_priorities = take_lines(&packet.narrative_notes, 3);
+    let recent_signals = take_joined(&[&packet.recent_context, &packet.episodic_memory], 6);
     NoNameRoleContextPacket {
         role: NoNameRole::CombatNarrator,
         role_goal: "Track conflict rhythm, action feedback, and combat narration anchors."
@@ -284,10 +464,11 @@ fn combat_narrator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPac
             &packet.working_memory,
             &packet.narrative_notes,
         ]),
-        world_facts: take_lines(&packet.hard_facts, 3),
-        character_relationships: take_lines(&packet.referenced_entities, 3),
-        narrative_priorities: take_lines(&packet.narrative_notes, 3),
-        recent_signals: take_joined(&[&packet.recent_context, &packet.episodic_memory], 6),
+        note_type_hits: Vec::new(),
+        world_facts: world_facts.clone(),
+        character_relationships: character_relationships.clone(),
+        narrative_priorities: narrative_priorities.clone(),
+        recent_signals: recent_signals.clone(),
         visible_constraints: vec![
             "May describe action consequences as low-risk narration anchors.".to_string(),
             "Should preserve current combat constraints.".to_string(),
@@ -296,24 +477,61 @@ fn combat_narrator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPac
             "Must not determine final damage or victory state.".to_string(),
             "Must not invent new combat rules.".to_string(),
         ],
+        context_slice_stats: vec![
+            build_slice_stat("worldFacts", packet.hard_facts.len(), world_facts.len()),
+            build_slice_stat(
+                "characterRelationships",
+                packet.referenced_entities.len(),
+                character_relationships.len(),
+            ),
+            build_slice_stat(
+                "narrativePriorities",
+                packet.narrative_notes.len(),
+                narrative_priorities.len(),
+            ),
+            build_slice_stat(
+                "recentSignals",
+                packet.recent_context.len() + packet.episodic_memory.len(),
+                recent_signals.len(),
+            ),
+        ],
         source_stats: packet.source_stats.clone(),
         token_budget_used: packet.token_budget_used,
     }
 }
 
 fn system_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
+    let recent_signals = take_joined(&[&packet.working_memory, &packet.recent_context], 4);
     NoNameRoleContextPacket {
         role: NoNameRole::System,
         role_goal: "Provide diagnostics without narrative authority.".to_string(),
         scene_focus: first_of(&[&packet.recent_context, &packet.working_memory]),
+        note_type_hits: Vec::new(),
         world_facts: Vec::new(),
         character_relationships: Vec::new(),
         narrative_priorities: Vec::new(),
-        recent_signals: take_joined(&[&packet.working_memory, &packet.recent_context], 4),
+        recent_signals: recent_signals.clone(),
         visible_constraints: vec!["May inspect available context shape.".to_string()],
         forbidden_scopes: vec!["Must not author narrative content.".to_string()],
+        context_slice_stats: vec![build_slice_stat(
+            "recentSignals",
+            packet.working_memory.len() + packet.recent_context.len(),
+            recent_signals.len(),
+        )],
         source_stats: packet.source_stats.clone(),
         token_budget_used: packet.token_budget_used,
+    }
+}
+
+fn build_slice_stat(
+    section: &str,
+    source_count: usize,
+    visible_count: usize,
+) -> NoNameRoleContextSliceStat {
+    NoNameRoleContextSliceStat {
+        section: section.to_string(),
+        source_count,
+        visible_count,
     }
 }
 
@@ -379,6 +597,16 @@ fn take_joined(groups: &[&Vec<String>], limit: usize) -> Vec<String> {
         }
     }
     values
+}
+
+fn dedupe_ordered_strings(values: Vec<String>) -> Vec<String> {
+    let mut deduped = Vec::new();
+    for value in values {
+        if !deduped.iter().any(|existing| existing == &value) {
+            deduped.push(value);
+        }
+    }
+    deduped
 }
 
 #[cfg(test)]
@@ -571,6 +799,15 @@ mod tests {
         assert_eq!(packets[2].role, NoNameRole::NpcIntent);
         assert_ne!(packets[0].role_goal, packets[1].role_goal);
         assert_ne!(packets[1].forbidden_scopes, packets[2].forbidden_scopes);
+        assert!(packets[0]
+            .context_slice_stats
+            .iter()
+            .any(|item| item.section == "narrativePriorities"
+                && item.source_count >= item.visible_count));
+        assert!(packets[1]
+            .context_slice_stats
+            .iter()
+            .any(|item| item.section == "worldFacts" && item.source_count >= item.visible_count));
         assert!(packets[1]
             .world_facts
             .iter()
@@ -579,6 +816,57 @@ mod tests {
             .recent_signals
             .iter()
             .any(|item| item.contains("Elder Qinghe")));
+    }
+
+    #[test]
+    fn role_context_prioritizes_structured_note_types_per_role() {
+        let store = EntityStore::new();
+        let mut manager = NoNameMemoryManager::new();
+        manager.upsert_narrative_memory(test_note(
+            "goal-1",
+            crate::noname_memory_types::NoNameNarrativeNoteType::Goal,
+            "Hold Gate",
+            "Keep the mountain gate secure.",
+            1,
+        ));
+        manager.upsert_narrative_memory(test_note(
+            "conflict-1",
+            crate::noname_memory_types::NoNameNarrativeNoteType::Conflict,
+            "Gate Assault",
+            "Enemy cultivators are pressing the ward line.",
+            2,
+        ));
+        manager.upsert_narrative_memory(test_note(
+            "arc-1",
+            crate::noname_memory_types::NoNameNarrativeNoteType::CharacterArc,
+            "Elder Qinghe Doubt",
+            "Elder Qinghe is hesitating under pressure.",
+            3,
+        ));
+
+        let input = NoNameContextBuildInput {
+            role: NoNameRole::Director,
+            world_id: "w1".to_string(),
+            run_id: "r1".to_string(),
+            scene_id: "s1".to_string(),
+            character_ids: vec!["player".to_string()],
+            map_node_id: None,
+            player_intent: None,
+            recent_context_lines: vec!["The ward line flickers.".to_string()],
+            token_budget: 240,
+            per_section_limit: 3,
+        };
+
+        let director = build_role_context_packet(&store, &manager, &input, NoNameRole::Director);
+        let npc = build_role_context_packet(&store, &manager, &input, NoNameRole::NpcIntent);
+        let world = build_role_context_packet(&store, &manager, &input, NoNameRole::WorldCurator);
+
+        assert!(director.narrative_priorities[0].contains("Gate Assault"));
+        assert!(npc.narrative_priorities[0].contains("Elder Qinghe Doubt"));
+        assert!(world.narrative_priorities[0].contains("Hold Gate"));
+        assert_eq!(director.note_type_hits[0], "conflict: Gate Assault");
+        assert_eq!(npc.note_type_hits[0], "characterArc: Elder Qinghe Doubt");
+        assert_eq!(world.note_type_hits[0], "goal: Hold Gate");
     }
 
     #[test]
@@ -615,5 +903,65 @@ mod tests {
             .forbidden_scopes
             .iter()
             .any(|item| item.contains("hidden knowledge")));
+    }
+
+    #[test]
+    fn role_context_can_flatten_back_to_agent_context_packet() {
+        let packet = NoNameContextPacket {
+            role: NoNameRole::NpcIntent,
+            hard_facts: vec!["Gate has a ward".to_string()],
+            working_memory: vec!["Player suspects Elder Qinghe".to_string()],
+            episodic_memory: vec!["Elder Qinghe hesitated".to_string()],
+            narrative_notes: vec!["Broken Ward: saboteur unknown".to_string()],
+            chapter_summaries: vec!["Gate Crisis: ward damaged".to_string()],
+            recent_context: vec!["Ward flickers".to_string()],
+            referenced_entities: vec![
+                "Character:player".to_string(),
+                "Character:ElderQinghe".to_string(),
+            ],
+            compressed_summary: None,
+            token_budget_used: 42,
+            source_stats: vec![NoNameContextSourceStat {
+                source: "test".to_string(),
+                count: 1,
+            }],
+        };
+
+        let role_packet = specialize_context_packet(&packet);
+        let flattened = flatten_role_context_packet(&role_packet);
+
+        assert_eq!(flattened.role, NoNameRole::NpcIntent);
+        assert_eq!(flattened.hard_facts, role_packet.world_facts);
+        assert_eq!(flattened.narrative_notes, role_packet.narrative_priorities);
+        assert_eq!(flattened.recent_context, role_packet.recent_signals);
+        assert!(flattened
+            .referenced_entities
+            .iter()
+            .any(|item| item.contains("ElderQinghe")));
+        assert!(flattened
+            .compressed_summary
+            .as_deref()
+            .unwrap_or_default()
+            .contains("roleGoal"));
+    }
+
+    fn test_note(
+        note_id: &str,
+        note_type: crate::noname_memory_types::NoNameNarrativeNoteType,
+        title: &str,
+        summary: &str,
+        updated_at: u64,
+    ) -> crate::noname_memory_types::NoNameNarrativeMemoryItem {
+        crate::noname_memory_types::NoNameNarrativeMemoryItem {
+            note_id: note_id.to_string(),
+            chapter_index: 1,
+            arc_id: None,
+            note_type,
+            title: title.to_string(),
+            summary: summary.to_string(),
+            status: crate::noname_memory_types::NoNameNarrativeStatus::Active,
+            related_entities: vec![],
+            updated_at,
+        }
     }
 }

--- a/src-tauri/src/noname_context_builder.rs
+++ b/src-tauri/src/noname_context_builder.rs
@@ -1,8 +1,7 @@
 use crate::entity_store::{EntityQuery, EntityStore};
 use crate::entity_types::EntityType;
 use crate::noname_context_types::{
-    NoNameContextBuildInput, NoNameContextPacket, NoNameContextSourceStat,
-    NoNameRoleContextPacket,
+    NoNameContextBuildInput, NoNameContextPacket, NoNameContextSourceStat, NoNameRoleContextPacket,
 };
 use crate::noname_memory_manager::NoNameMemoryManager;
 use crate::noname_memory_retrieval::NoNameMemoryQuery;
@@ -277,7 +276,8 @@ fn npc_intent_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
 fn combat_narrator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
     NoNameRoleContextPacket {
         role: NoNameRole::CombatNarrator,
-        role_goal: "Track conflict rhythm, action feedback, and combat narration anchors.".to_string(),
+        role_goal: "Track conflict rhythm, action feedback, and combat narration anchors."
+            .to_string(),
         scene_focus: first_of(&[
             &packet.recent_context,
             &packet.episodic_memory,
@@ -607,7 +607,10 @@ mod tests {
 
         assert_eq!(world.scene_focus, "Gate has a ward");
         assert_eq!(npc.scene_focus, "Character:ElderQinghe");
-        assert!(world.forbidden_scopes.iter().any(|item| item.contains("NPC")));
+        assert!(world
+            .forbidden_scopes
+            .iter()
+            .any(|item| item.contains("NPC")));
         assert!(npc
             .forbidden_scopes
             .iter()

--- a/src-tauri/src/noname_context_types.rs
+++ b/src-tauri/src/noname_context_types.rs
@@ -10,6 +10,14 @@ pub struct NoNameContextSourceStat {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct NoNameRoleContextSliceStat {
+    pub section: String,
+    pub source_count: usize,
+    pub visible_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NoNameContextPacket {
     pub role: NoNameRole,
     pub hard_facts: Vec<String>,
@@ -30,12 +38,16 @@ pub struct NoNameRoleContextPacket {
     pub role: NoNameRole,
     pub role_goal: String,
     pub scene_focus: String,
+    #[serde(default)]
+    pub note_type_hits: Vec<String>,
     pub world_facts: Vec<String>,
     pub character_relationships: Vec<String>,
     pub narrative_priorities: Vec<String>,
     pub recent_signals: Vec<String>,
     pub visible_constraints: Vec<String>,
     pub forbidden_scopes: Vec<String>,
+    #[serde(default)]
+    pub context_slice_stats: Vec<NoNameRoleContextSliceStat>,
     pub source_stats: Vec<NoNameContextSourceStat>,
     pub token_budget_used: usize,
 }

--- a/src-tauri/src/noname_guardrails.rs
+++ b/src-tauri/src/noname_guardrails.rs
@@ -359,16 +359,18 @@ pub fn validate_director_proposal_for_apply(
     if matches!(
         proposal.target_segment,
         NoNameTargetSegment::ChapterSummaryHead | NoNameTargetSegment::ChapterSummaryTail
-    ) && proposal
-        .apply_scopes
-        .contains(&NoNameApplyScope::PlotTextHint)
-    {
+    ) && proposal.apply_scopes.iter().any(|scope| {
+        matches!(
+            scope,
+            NoNameApplyScope::PlotTextHint | NoNameApplyScope::PlotAugmentationHint
+        )
+    }) {
         return NoNameApplyGuardrailResult::blocked(
             NoNameApplyGuardrailOutcome::FallbackRequired,
             "proposal target_segment 与 apply_scope 不匹配，回退经典链路",
             vec![
                 format!("target_segment={}", proposal.target_segment.as_str()),
-                "apply_scope=plot_text_hint".to_string(),
+                "apply_scope=plot_text_or_augmentation_hint".to_string(),
             ],
         );
     }
@@ -468,6 +470,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         }
     }
 
@@ -516,6 +519,13 @@ mod tests {
             focus: "   ".to_string(),
             rationale: "保持山门线索推进".to_string(),
             prompt_preview: "prompt".to_string(),
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal: make_director_proposal("   ", "保持山门线索推进"),
         };
 
@@ -531,6 +541,13 @@ mod tests {
             focus: "山门危机".repeat(13),
             rationale: "优先观察山门内部的冲突升级与人物反应".to_string(),
             prompt_preview: "prompt".to_string(),
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal: make_director_proposal(
                 &"山门危机".repeat(13),
                 "优先观察山门内部的冲突升级与人物反应",

--- a/src-tauri/src/noname_guardrails.rs
+++ b/src-tauri/src/noname_guardrails.rs
@@ -622,7 +622,9 @@ mod tests {
         proposal.status = crate::noname_types::NoNameProposalStatus::Ready;
         proposal.applyable = true;
         proposal.target_segment = crate::noname_types::NoNameTargetSegment::ChapterSummaryHead;
-        proposal.apply_scopes.push(crate::noname_types::NoNameApplyScope::PlotTextHint);
+        proposal
+            .apply_scopes
+            .push(crate::noname_types::NoNameApplyScope::PlotTextHint);
 
         let result = validate_director_proposal_for_apply(
             NoNameMode::Assisted,

--- a/src-tauri/src/noname_knowledge_retrieval.rs
+++ b/src-tauri/src/noname_knowledge_retrieval.rs
@@ -134,18 +134,13 @@ fn min_score_matches(snippet: &NoNameKnowledgeSnippet, min_score: Option<u32>) -
         .unwrap_or(true)
 }
 
-fn dedupe_snippets(
-    snippets: Vec<NoNameKnowledgeSnippet>,
-) -> (Vec<NoNameKnowledgeSnippet>, usize) {
+fn dedupe_snippets(snippets: Vec<NoNameKnowledgeSnippet>) -> (Vec<NoNameKnowledgeSnippet>, usize) {
     let mut deduped: Vec<NoNameKnowledgeSnippet> = Vec::new();
     let mut duplicate_count = 0;
 
     for snippet in snippets {
         let key = snippet_key(&snippet);
-        if let Some(existing) = deduped
-            .iter_mut()
-            .find(|item| snippet_key(item) == key)
-        {
+        if let Some(existing) = deduped.iter_mut().find(|item| snippet_key(item) == key) {
             duplicate_count += 1;
             if compare_snippets(&snippet, existing).is_lt() {
                 *existing = snippet;

--- a/src-tauri/src/noname_knowledge_store.rs
+++ b/src-tauri/src/noname_knowledge_store.rs
@@ -102,7 +102,11 @@ impl NoNameKnowledgeProvider for InMemoryKnowledgeProvider {
             })
             .collect::<Vec<_>>();
 
-        snippets.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.document_id.cmp(&b.document_id)));
+        snippets.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| a.document_id.cmp(&b.document_id))
+        });
         snippets.truncate(query.limit);
         snippets
     }
@@ -115,10 +119,7 @@ pub struct GraphKnowledgeProvider {
 }
 
 impl GraphKnowledgeProvider {
-    pub fn new(
-        nodes: Vec<NoNameKnowledgeGraphNode>,
-        edges: Vec<NoNameKnowledgeGraphEdge>,
-    ) -> Self {
+    pub fn new(nodes: Vec<NoNameKnowledgeGraphNode>, edges: Vec<NoNameKnowledgeGraphEdge>) -> Self {
         Self { nodes, edges }
     }
 }
@@ -141,7 +142,13 @@ impl NoNameKnowledgeProvider for GraphKnowledgeProvider {
             .iter()
             .filter_map(|node| {
                 let score = score_graph_node(node, keyword.as_deref(), &tag_terms)
-                    + score_graph_edges(node, &self.nodes, &self.edges, keyword.as_deref(), &tag_terms);
+                    + score_graph_edges(
+                        node,
+                        &self.nodes,
+                        &self.edges,
+                        keyword.as_deref(),
+                        &tag_terms,
+                    );
                 if score == 0 {
                     return None;
                 }
@@ -157,7 +164,11 @@ impl NoNameKnowledgeProvider for GraphKnowledgeProvider {
             })
             .collect::<Vec<_>>();
 
-        snippets.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.document_id.cmp(&b.document_id)));
+        snippets.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| a.document_id.cmp(&b.document_id))
+        });
         snippets.truncate(query.limit);
         snippets
     }
@@ -173,11 +184,7 @@ fn score_document(
     if let Some(keyword) = keyword {
         score += contains_text(&document.title, keyword) as u32 * 5;
         score += contains_text(&document.body, keyword) as u32 * 3;
-        score += document
-            .tags
-            .iter()
-            .any(|tag| contains_text(tag, keyword)) as u32
-            * 2;
+        score += document.tags.iter().any(|tag| contains_text(tag, keyword)) as u32 * 2;
     }
 
     for tag in tags {
@@ -203,11 +210,7 @@ fn score_graph_node(
     if let Some(keyword) = keyword {
         score += contains_text(&node.label, keyword) as u32 * 5;
         score += contains_text(&node.body, keyword) as u32 * 3;
-        score += node
-            .tags
-            .iter()
-            .any(|tag| contains_text(tag, keyword)) as u32
-            * 2;
+        score += node.tags.iter().any(|tag| contains_text(tag, keyword)) as u32 * 2;
     }
 
     for tag in tags {
@@ -234,7 +237,11 @@ fn score_graph_edges(
         .iter()
         .filter(|edge| edge.from == node.node_id || edge.to == node.node_id)
         .map(|edge| {
-            let neighbor_id = if edge.from == node.node_id { &edge.to } else { &edge.from };
+            let neighbor_id = if edge.from == node.node_id {
+                &edge.to
+            } else {
+                &edge.from
+            };
             let neighbor = nodes.iter().find(|item| &item.node_id == neighbor_id);
             let relation_score = keyword
                 .map(|term| contains_text(&edge.relation, term) as u32 * 3)
@@ -276,7 +283,11 @@ fn build_graph_excerpt(
         .filter(|edge| edge.from == node.node_id || edge.to == node.node_id)
         .take(3)
         .filter_map(|edge| {
-            let neighbor_id = if edge.from == node.node_id { &edge.to } else { &edge.from };
+            let neighbor_id = if edge.from == node.node_id {
+                &edge.to
+            } else {
+                &edge.from
+            };
             let neighbor = nodes.iter().find(|item| &item.node_id == neighbor_id)?;
             Some(format!("{}:{}", edge.relation, neighbor.label))
         })

--- a/src-tauri/src/noname_memory_compaction.rs
+++ b/src-tauri/src/noname_memory_compaction.rs
@@ -165,10 +165,7 @@ impl NoNameMemoryCompactionService {
         }
     }
 
-    pub fn compact_chapter(
-        &self,
-        input: NoNameChapterCompactionInput,
-    ) -> NoNameCompactionSummary {
+    pub fn compact_chapter(&self, input: NoNameChapterCompactionInput) -> NoNameCompactionSummary {
         let mut source_ids = Vec::new();
         let mut fragments = Vec::new();
         let mut key_entities = Vec::new();
@@ -447,7 +444,12 @@ mod tests {
                 importance: NoNameMemoryImportance::High,
             }],
             notes: vec![
-                note("note-goal", NoNameNarrativeNoteType::Goal, "Hold Gate", "Keep the gate standing"),
+                note(
+                    "note-goal",
+                    NoNameNarrativeNoteType::Goal,
+                    "Hold Gate",
+                    "Keep the gate standing",
+                ),
                 note(
                     "note-conflict",
                     NoNameNarrativeNoteType::Conflict,
@@ -513,7 +515,10 @@ mod tests {
         assert_eq!(summary.kind, NoNameCompactionKind::Trace);
         assert_eq!(summary.source_ids, vec!["trace-1"]);
         assert!(summary.goals.contains(&"gate crisis".to_string()));
-        assert!(summary.diagnostics.iter().any(|item| item.contains("guardrail=reject")));
+        assert!(summary
+            .diagnostics
+            .iter()
+            .any(|item| item.contains("guardrail=reject")));
         assert!(summary
             .diagnostics
             .iter()

--- a/src-tauri/src/noname_memory_manager.rs
+++ b/src-tauri/src/noname_memory_manager.rs
@@ -108,10 +108,7 @@ impl NoNameMemoryManager {
         self.store.retrieve(query)
     }
 
-    pub fn compact_turn_memory(
-        &self,
-        input: NoNameTurnCompactionInput,
-    ) -> NoNameCompactionSummary {
+    pub fn compact_turn_memory(&self, input: NoNameTurnCompactionInput) -> NoNameCompactionSummary {
         NoNameMemoryCompactionService::new().compact_turn(input)
     }
 

--- a/src-tauri/src/noname_memory_retrieval.rs
+++ b/src-tauri/src/noname_memory_retrieval.rs
@@ -192,7 +192,7 @@ where
         })
         .collect::<Vec<_>>();
 
-    ranked.sort_by(|a, b| b.0.cmp(&a.0));
+    ranked.sort_by_key(|item| std::cmp::Reverse(item.0));
     ranked.truncate(query.per_section_limit);
     ranked.into_iter().map(|(_, item)| item).collect()
 }

--- a/src-tauri/src/noname_memory_retrieval.rs
+++ b/src-tauri/src/noname_memory_retrieval.rs
@@ -198,7 +198,11 @@ where
 }
 
 fn working_match_score(query: &NoNameMemoryQuery, item: &NoNameWorkingMemoryItem) -> u32 {
-    let content = [item.summary.as_str(), item.category.as_str(), item.source.as_str()];
+    let content = [
+        item.summary.as_str(),
+        item.category.as_str(),
+        item.source.as_str(),
+    ];
     score_text_fields(query, &content)
 }
 
@@ -211,11 +215,21 @@ fn episodic_match_score(query: &NoNameMemoryQuery, item: &NoNameEpisodicMemoryIt
     let location_score = query
         .location
         .as_deref()
-        .map(|location| item.location_id.as_deref().map(|value| contains_text(value, location)).unwrap_or(false) as u32 * 5)
+        .map(|location| {
+            item.location_id
+                .as_deref()
+                .map(|value| contains_text(value, location))
+                .unwrap_or(false) as u32
+                * 5
+        })
         .unwrap_or_default();
     let text_score = score_text_fields(
         query,
-        &[item.summary.as_str(), item.event_type.as_str(), item.detail_ref.as_deref().unwrap_or("")],
+        &[
+            item.summary.as_str(),
+            item.event_type.as_str(),
+            item.detail_ref.as_deref().unwrap_or(""),
+        ],
     );
 
     actor_score + location_score + text_score
@@ -425,7 +439,14 @@ mod tests {
                 2,
                 NoNameMemoryImportance::High,
             )],
-            &[sample_semantic("fact-1", "青河长老", "山门", 85, 4, vec!["防守"])],
+            &[sample_semantic(
+                "fact-1",
+                "青河长老",
+                "山门",
+                85,
+                4,
+                vec!["防守"],
+            )],
             &[sample_narrative(
                 "note-1",
                 "守住山门",
@@ -446,7 +467,10 @@ mod tests {
     fn retrieval_ranks_by_relevance_then_recency_then_importance() {
         let result = retrieve_memories(
             &NoNameMemoryQuery::by_keyword(NoNameRole::CombatNarrator, "交锋", 200, 2),
-            &[sample_working("敌修与玩家激烈交锋", 3), sample_working("普通巡山记录", 9)],
+            &[
+                sample_working("敌修与玩家激烈交锋", 3),
+                sample_working("普通巡山记录", 9),
+            ],
             &[
                 sample_episodic(
                     "episode-old",
@@ -465,7 +489,14 @@ mod tests {
                     NoNameMemoryImportance::Medium,
                 ),
             ],
-            &[sample_semantic("fact-1", "玩家", "山门", 70, 1, vec!["战斗"])],
+            &[sample_semantic(
+                "fact-1",
+                "玩家",
+                "山门",
+                70,
+                1,
+                vec!["战斗"],
+            )],
             &[sample_narrative(
                 "note-1",
                 "山门交锋",
@@ -503,7 +534,14 @@ mod tests {
                 2,
                 NoNameMemoryImportance::Medium,
             )],
-            &[sample_semantic("fact-1", "玩家", "山门", 80, 3, vec!["地点"])],
+            &[sample_semantic(
+                "fact-1",
+                "玩家",
+                "山门",
+                80,
+                3,
+                vec!["地点"],
+            )],
             &[sample_narrative(
                 "note-1",
                 "山门危机",

--- a/src-tauri/src/noname_note_store.rs
+++ b/src-tauri/src/noname_note_store.rs
@@ -73,10 +73,7 @@ impl NoNameNoteStore {
             .collect()
     }
 
-    pub fn list_by_status(
-        &self,
-        status: NoNameNarrativeStatus,
-    ) -> Vec<NoNameNarrativeMemoryItem> {
+    pub fn list_by_status(&self, status: NoNameNarrativeStatus) -> Vec<NoNameNarrativeMemoryItem> {
         self.notes
             .iter()
             .filter(|item| item.status == status)
@@ -157,18 +154,18 @@ impl NoNameNoteStore {
         review
     }
 
-    pub fn review_chapter(
-        &self,
-        chapter_index: u32,
-        updated_at: u64,
-    ) -> NoNameChapterNoteReview {
+    pub fn review_chapter(&self, chapter_index: u32, updated_at: u64) -> NoNameChapterNoteReview {
         let mut review = NoNameChapterNoteReview {
             chapter_index,
             updated_at,
             ..NoNameChapterNoteReview::default()
         };
 
-        for note in self.notes.iter().filter(|item| item.chapter_index == chapter_index) {
+        for note in self
+            .notes
+            .iter()
+            .filter(|item| item.chapter_index == chapter_index)
+        {
             match note.status {
                 NoNameNarrativeStatus::Active => review.active_note_ids.push(note.note_id.clone()),
                 NoNameNarrativeStatus::Resolved | NoNameNarrativeStatus::Archived => {
@@ -275,7 +272,10 @@ mod tests {
 
         let archived = store.archive("note-1", 12).expect("note should archive");
         assert_eq!(archived.status, NoNameNarrativeStatus::Archived);
-        assert_eq!(store.list_by_status(NoNameNarrativeStatus::Archived).len(), 1);
+        assert_eq!(
+            store.list_by_status(NoNameNarrativeStatus::Archived).len(),
+            1
+        );
     }
 
     #[test]

--- a/src-tauri/src/noname_output_interface.rs
+++ b/src-tauri/src/noname_output_interface.rs
@@ -1,3 +1,4 @@
+use crate::noname_context_types::NoNameRoleContextPacket;
 use crate::noname_types::{NoNameApplyScope, NoNameProposalRef, NoNameRole};
 use serde::{Deserialize, Serialize};
 
@@ -149,7 +150,10 @@ impl NoNameControlledOutputInterface {
             return self.reject(request, "output kind is not allowed by policy");
         }
         if request.content.chars().count() > self.policy.max_content_chars {
-            return self.reject(request, "content exceeds controlled output character budget");
+            return self.reject(
+                request,
+                "content exceeds controlled output character budget",
+            );
         }
 
         let touched_forbidden = request
@@ -178,7 +182,8 @@ impl NoNameControlledOutputInterface {
             return NoNameControlledOutputReview {
                 request_id: request.request_id.clone(),
                 decision: NoNameControlledOutputDecision::NeedsReview,
-                reason: "plot text hint requires human review before higher-layer apply".to_string(),
+                reason: "plot text hint requires human review before higher-layer apply"
+                    .to_string(),
                 normalized_kind: Some(request.kind),
                 safe_apply_scope: Some(request.target_scope),
                 requires_human_review: true,
@@ -212,7 +217,10 @@ impl NoNameControlledOutputInterface {
             title: title.into(),
             content: content.into(),
             touched_forbidden_scopes: Vec::new(),
-            labels: vec!["noname_controlled_output_v1".to_string(), kind_key.to_string()],
+            labels: vec![
+                "noname_controlled_output_v1".to_string(),
+                kind_key.to_string(),
+            ],
         }
     }
 
@@ -229,6 +237,89 @@ impl NoNameControlledOutputInterface {
             safe_apply_scope: None,
             requires_human_review: false,
         }
+    }
+}
+
+pub fn controlled_output_policy_from_role_context(
+    context: &NoNameRoleContextPacket,
+) -> NoNameControlledOutputPolicy {
+    let mut policy = NoNameControlledOutputPolicy::default();
+    let mapped = forbidden_output_scopes_from_role_constraints(&context.forbidden_scopes);
+    if !mapped.is_empty() {
+        policy.forbidden_scopes = mapped;
+    }
+    policy
+}
+
+pub fn forbidden_output_scopes_from_role_constraints(
+    constraints: &[String],
+) -> Vec<NoNameForbiddenOutputScope> {
+    let mut scopes = Vec::new();
+    for constraint in constraints {
+        let text = constraint.to_ascii_lowercase();
+        if contains_any(
+            &text,
+            &[
+                "final plot state",
+                "main plot beat",
+                "author narrative content",
+            ],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::FinalPlotState);
+        }
+        if contains_any(
+            &text,
+            &[
+                "canon",
+                "world fact",
+                "world facts",
+                "hard world",
+                "override world facts",
+            ],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::CanonWorldFact);
+        }
+        if contains_any(
+            &text,
+            &["character stats", "attribute", "realm", "cultivation"],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::CharacterStats);
+        }
+        if contains_any(&text, &["inventory", "resource"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::InventoryOrResource);
+        }
+        if contains_any(&text, &["map topology", "location graph", "route graph"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::MapTopology);
+        }
+        if contains_any(&text, &["chapter lifecycle", "chapter transition"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::ChapterLifecycle);
+        }
+        if contains_any(&text, &["player choice", "choose for player"]) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::PlayerChoice);
+        }
+        if contains_any(
+            &text,
+            &[
+                "combat outcome",
+                "damage",
+                "victory",
+                "combat rules",
+                "final damage",
+            ],
+        ) {
+            push_unique(&mut scopes, NoNameForbiddenOutputScope::CombatOutcome);
+        }
+    }
+    scopes
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn push_unique(scopes: &mut Vec<NoNameForbiddenOutputScope>, scope: NoNameForbiddenOutputScope) {
+    if !scopes.contains(&scope) {
+        scopes.push(scope);
     }
 }
 
@@ -276,7 +367,10 @@ mod tests {
         let review = interface.review(&request);
 
         assert_eq!(review.decision, NoNameControlledOutputDecision::Allow);
-        assert_eq!(review.safe_apply_scope, Some(NoNameApplyScope::ChapterSummaryHint));
+        assert_eq!(
+            review.safe_apply_scope,
+            Some(NoNameApplyScope::ChapterSummaryHint)
+        );
         assert!(!review.requires_human_review);
     }
 
@@ -313,7 +407,39 @@ mod tests {
         let review = interface.review(&request);
 
         assert_eq!(review.decision, NoNameControlledOutputDecision::NeedsReview);
-        assert_eq!(review.safe_apply_scope, Some(NoNameApplyScope::PlotTextHint));
+        assert_eq!(
+            review.safe_apply_scope,
+            Some(NoNameApplyScope::PlotTextHint)
+        );
         assert!(review.requires_human_review);
+    }
+
+    #[test]
+    fn role_context_forbidden_scopes_map_to_output_policy() {
+        let context = NoNameRoleContextPacket {
+            role: NoNameRole::CombatNarrator,
+            role_goal: "Track conflict rhythm".to_string(),
+            scene_focus: "山门冲突".to_string(),
+            world_facts: vec![],
+            character_relationships: vec![],
+            narrative_priorities: vec![],
+            recent_signals: vec![],
+            visible_constraints: vec![],
+            forbidden_scopes: vec![
+                "Must not determine final damage or victory state.".to_string(),
+                "Must not override world facts or combat outcomes.".to_string(),
+            ],
+            source_stats: vec![],
+            token_budget_used: 0,
+        };
+
+        let policy = controlled_output_policy_from_role_context(&context);
+
+        assert!(policy
+            .forbidden_scopes
+            .contains(&NoNameForbiddenOutputScope::CombatOutcome));
+        assert!(policy
+            .forbidden_scopes
+            .contains(&NoNameForbiddenOutputScope::CanonWorldFact));
     }
 }

--- a/src-tauri/src/noname_output_interface.rs
+++ b/src-tauri/src/noname_output_interface.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub enum NoNameControlledOutputKind {
     RecapNote,
     SceneAugmentation,
+    NonFinalPlotAugmentation,
     NarrativeNote,
     IntermediateNarrativeHint,
 }
@@ -16,6 +17,7 @@ impl NoNameControlledOutputKind {
         match self {
             Self::RecapNote => "recap_note",
             Self::SceneAugmentation => "scene_augmentation",
+            Self::NonFinalPlotAugmentation => "non_final_plot_augmentation",
             Self::NarrativeNote => "narrative_note",
             Self::IntermediateNarrativeHint => "intermediate_narrative_hint",
         }
@@ -73,6 +75,7 @@ impl Default for NoNameControlledOutputPolicy {
             allowed_kinds: vec![
                 NoNameControlledOutputKind::RecapNote,
                 NoNameControlledOutputKind::SceneAugmentation,
+                NoNameControlledOutputKind::NonFinalPlotAugmentation,
                 NoNameControlledOutputKind::NarrativeNote,
                 NoNameControlledOutputKind::IntermediateNarrativeHint,
             ],
@@ -176,14 +179,18 @@ impl NoNameControlledOutputInterface {
             );
         }
 
-        if request.target_scope == NoNameApplyScope::PlotTextHint
-            && self.policy.requires_human_review_for_plot_text
+        if matches!(
+            request.target_scope,
+            NoNameApplyScope::PlotTextHint | NoNameApplyScope::PlotAugmentationHint
+        ) && self.policy.requires_human_review_for_plot_text
         {
             return NoNameControlledOutputReview {
                 request_id: request.request_id.clone(),
                 decision: NoNameControlledOutputDecision::NeedsReview,
-                reason: "plot text hint requires human review before higher-layer apply"
-                    .to_string(),
+                reason: format!(
+                    "{} requires human review before higher-layer apply",
+                    request.target_scope.as_str()
+                ),
                 normalized_kind: Some(request.kind),
                 safe_apply_scope: Some(request.target_scope),
                 requires_human_review: true,
@@ -327,6 +334,9 @@ pub fn default_apply_scope_for_kind(kind: NoNameControlledOutputKind) -> NoNameA
     match kind {
         NoNameControlledOutputKind::RecapNote => NoNameApplyScope::ChapterSummaryHint,
         NoNameControlledOutputKind::SceneAugmentation => NoNameApplyScope::PlotTextHint,
+        NoNameControlledOutputKind::NonFinalPlotAugmentation => {
+            NoNameApplyScope::PlotAugmentationHint
+        }
         NoNameControlledOutputKind::NarrativeNote => NoNameApplyScope::Diagnostics,
         NoNameControlledOutputKind::IntermediateNarrativeHint => NoNameApplyScope::OptionBiasHint,
     }
@@ -346,6 +356,9 @@ mod tests {
         assert!(policy
             .allowed_kinds
             .contains(&NoNameControlledOutputKind::IntermediateNarrativeHint));
+        assert!(policy
+            .allowed_kinds
+            .contains(&NoNameControlledOutputKind::NonFinalPlotAugmentation));
         assert!(policy
             .forbidden_scopes
             .contains(&NoNameForbiddenOutputScope::FinalPlotState));
@@ -415,11 +428,32 @@ mod tests {
     }
 
     #[test]
+    fn non_final_plot_augmentation_requires_review_without_final_state() {
+        let interface = NoNameControlledOutputInterface::default();
+        let request = interface.draft_stub(
+            NoNameControlledOutputKind::NonFinalPlotAugmentation,
+            NoNameRole::Director,
+            "Staged scene beat",
+            "Stage a reversible clue for the next turn without rewriting final plot state.",
+        );
+
+        let review = interface.review(&request);
+
+        assert_eq!(review.decision, NoNameControlledOutputDecision::NeedsReview);
+        assert_eq!(
+            review.safe_apply_scope,
+            Some(NoNameApplyScope::PlotAugmentationHint)
+        );
+        assert!(review.requires_human_review);
+    }
+
+    #[test]
     fn role_context_forbidden_scopes_map_to_output_policy() {
         let context = NoNameRoleContextPacket {
             role: NoNameRole::CombatNarrator,
             role_goal: "Track conflict rhythm".to_string(),
             scene_focus: "山门冲突".to_string(),
+            note_type_hits: vec![],
             world_facts: vec![],
             character_relationships: vec![],
             narrative_priorities: vec![],
@@ -429,6 +463,7 @@ mod tests {
                 "Must not determine final damage or victory state.".to_string(),
                 "Must not override world facts or combat outcomes.".to_string(),
             ],
+            context_slice_stats: vec![],
             source_stats: vec![],
             token_budget_used: 0,
         };

--- a/src-tauri/src/noname_prompts.rs
+++ b/src-tauri/src/noname_prompts.rs
@@ -8,11 +8,13 @@ pub const COMBAT_NARRATOR_OBSERVE_PROMPT_ID: &str = "prompt.combat_narrator.obse
 pub fn director_observe_prompt_template() -> NoNamePromptTemplate {
     NoNamePromptTemplate {
         prompt_id: DIRECTOR_OBSERVE_PROMPT_ID.to_string(),
-        template: "你是Nobody的DirectorAgent。当前目标={{goal}}；玩家动作={{action}}；当前场景={{scene}}；请给出下一步最值得推进的冲突或关注点。".to_string(),
+        template: "你是Nobody的DirectorAgent。当前目标={{goal}}；角色目标={{roleGoal}}；玩家动作={{action}}；当前场景={{scene}}；禁止越权={{forbiddenScopes}}；请给出下一步最值得推进的冲突或关注点。".to_string(),
         required_variables: vec![
             "goal".to_string(),
+            "roleGoal".to_string(),
             "action".to_string(),
             "scene".to_string(),
+            "forbiddenScopes".to_string(),
         ],
     }
 }
@@ -20,11 +22,13 @@ pub fn director_observe_prompt_template() -> NoNamePromptTemplate {
 pub fn world_curator_observe_prompt_template() -> NoNamePromptTemplate {
     NoNamePromptTemplate {
         prompt_id: WORLD_CURATOR_OBSERVE_PROMPT_ID.to_string(),
-        template: "你是Nobody的WorldCuratorAgent。当前目标={{goal}}；玩家动作={{action}}；当前场景={{scene}}；请指出最需要补足或校准的世界事实、场景约束或设定缝隙。".to_string(),
+        template: "你是Nobody的WorldCuratorAgent。当前目标={{goal}}；角色目标={{roleGoal}}；玩家动作={{action}}；当前场景={{scene}}；禁止越权={{forbiddenScopes}}；请指出最需要补足或校准的世界事实、场景约束或设定缝隙。".to_string(),
         required_variables: vec![
             "goal".to_string(),
+            "roleGoal".to_string(),
             "action".to_string(),
             "scene".to_string(),
+            "forbiddenScopes".to_string(),
         ],
     }
 }
@@ -32,11 +36,13 @@ pub fn world_curator_observe_prompt_template() -> NoNamePromptTemplate {
 pub fn npc_intent_observe_prompt_template() -> NoNamePromptTemplate {
     NoNamePromptTemplate {
         prompt_id: NPC_INTENT_OBSERVE_PROMPT_ID.to_string(),
-        template: "你是Nobody的NpcIntentAgent。当前目标={{goal}}；玩家动作={{action}}；当前场景={{scene}}；请判断最值得关注的NPC意图、关系变化或反应方向。".to_string(),
+        template: "你是Nobody的NpcIntentAgent。当前目标={{goal}}；角色目标={{roleGoal}}；玩家动作={{action}}；当前场景={{scene}}；禁止越权={{forbiddenScopes}}；请判断最值得关注的NPC意图、关系变化或反应方向。".to_string(),
         required_variables: vec![
             "goal".to_string(),
+            "roleGoal".to_string(),
             "action".to_string(),
             "scene".to_string(),
+            "forbiddenScopes".to_string(),
         ],
     }
 }
@@ -44,11 +50,13 @@ pub fn npc_intent_observe_prompt_template() -> NoNamePromptTemplate {
 pub fn combat_narrator_observe_prompt_template() -> NoNamePromptTemplate {
     NoNamePromptTemplate {
         prompt_id: COMBAT_NARRATOR_OBSERVE_PROMPT_ID.to_string(),
-        template: "你是Nobody的CombatNarratorAgent。当前目标={{goal}}；玩家动作={{action}}；当前场景={{scene}}；请判断当前冲突节奏、战斗风险或动作表现上最值得强化的一点。".to_string(),
+        template: "你是Nobody的CombatNarratorAgent。当前目标={{goal}}；角色目标={{roleGoal}}；玩家动作={{action}}；当前场景={{scene}}；禁止越权={{forbiddenScopes}}；请判断当前冲突节奏、战斗风险或动作表现上最值得强化的一点。".to_string(),
         required_variables: vec![
             "goal".to_string(),
+            "roleGoal".to_string(),
             "action".to_string(),
             "scene".to_string(),
+            "forbiddenScopes".to_string(),
         ],
     }
 }
@@ -61,11 +69,17 @@ mod tests {
     fn director_prompt_contains_required_variables() {
         let template = director_observe_prompt_template();
         assert_eq!(template.prompt_id, DIRECTOR_OBSERVE_PROMPT_ID);
-        assert_eq!(template.required_variables.len(), 3);
+        assert_eq!(template.required_variables.len(), 5);
+        assert!(template
+            .required_variables
+            .contains(&"roleGoal".to_string()));
+        assert!(template
+            .required_variables
+            .contains(&"forbiddenScopes".to_string()));
     }
 
     #[test]
-    fn multi_role_prompts_keep_three_shared_inputs() {
+    fn multi_role_prompts_keep_role_boundary_inputs() {
         let templates = [
             world_curator_observe_prompt_template(),
             npc_intent_observe_prompt_template(),
@@ -73,8 +87,10 @@ mod tests {
         ];
 
         for template in templates {
-            assert_eq!(template.required_variables.len(), 3);
+            assert_eq!(template.required_variables.len(), 5);
             assert!(template.template.contains("当前目标"));
+            assert!(template.template.contains("角色目标"));
+            assert!(template.template.contains("禁止越权"));
         }
     }
 }

--- a/src-tauri/src/noname_protocol_agent.rs
+++ b/src-tauri/src/noname_protocol_agent.rs
@@ -101,7 +101,9 @@ impl NoNameAgentMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::noname_protocol_types::{NoNameTaskLifecycle, NoNameTaskStatus, NoNameTraceWritable};
+    use crate::noname_protocol_types::{
+        NoNameTaskLifecycle, NoNameTaskStatus, NoNameTraceWritable,
+    };
     use crate::noname_types::{NoNameMode, NoNameRole};
     use serde_json::json;
 

--- a/src-tauri/src/noname_protocol_runtime.rs
+++ b/src-tauri/src/noname_protocol_runtime.rs
@@ -40,8 +40,7 @@ impl NoNameProtocolRuntime {
         message: NoNameAgentMessage,
     ) -> Result<NoNameTaskLifecycle, NoNameError> {
         let next = self.resolve_next_lifecycle(&message.lifecycle, message.kind)?;
-        self.task_states
-            .insert(next.task_id.clone(), next.clone());
+        self.task_states.insert(next.task_id.clone(), next.clone());
         self.agent_history.push(message);
         Ok(next)
     }
@@ -251,8 +250,14 @@ mod tests {
             )
             .expect("tool execution should succeed");
 
-        assert_eq!(envelope.kind, crate::noname_protocol_tool::NoNameToolEnvelopeKind::Result);
-        assert_eq!(envelope.result.as_ref().map(|value| value["echo"].as_str()), Some(Some("ok")));
+        assert_eq!(
+            envelope.kind,
+            crate::noname_protocol_tool::NoNameToolEnvelopeKind::Result
+        );
+        assert_eq!(
+            envelope.result.as_ref().map(|value| value["echo"].as_str()),
+            Some(Some("ok"))
+        );
         assert_eq!(
             runtime.task_state("tool-task-1").map(|state| state.status),
             Some(NoNameTaskStatus::Completed)

--- a/src-tauri/src/noname_protocol_types.rs
+++ b/src-tauri/src/noname_protocol_types.rs
@@ -241,7 +241,13 @@ mod tests {
             .cancelled("operator request")
             .expect("cancel");
 
-        assert_eq!(failed.last_error.as_ref().map(|err| err.code.as_str()), Some("noname.tool.failure"));
-        assert_eq!(cancelled.cancellation_reason.as_deref(), Some("operator request"));
+        assert_eq!(
+            failed.last_error.as_ref().map(|err| err.code.as_str()),
+            Some("noname.tool.failure")
+        );
+        assert_eq!(
+            cancelled.cancellation_reason.as_deref(),
+            Some("operator request")
+        );
     }
 }

--- a/src-tauri/src/noname_roles.rs
+++ b/src-tauri/src/noname_roles.rs
@@ -1,5 +1,7 @@
 use crate::noname_capability_registry::NoNameCapabilityRegistry;
-use crate::noname_context_types::NoNameContextPacket;
+use crate::noname_context_types::{
+    NoNameContextPacket, NoNameContextSourceStat, NoNameRoleContextSliceStat,
+};
 use crate::noname_errors::{NoNameError, NoNameErrorKind};
 use crate::noname_prompts::{
     COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID, NPC_INTENT_OBSERVE_PROMPT_ID,
@@ -30,6 +32,20 @@ pub struct NoNameRoleObservation {
     pub focus: String,
     pub rationale: String,
     pub prompt_preview: String,
+    #[serde(default)]
+    pub role_goal: Option<String>,
+    #[serde(default)]
+    pub scene_focus: Option<String>,
+    #[serde(default)]
+    pub forbidden_scopes: Vec<String>,
+    #[serde(default)]
+    pub note_type_hits: Vec<String>,
+    #[serde(default)]
+    pub source_stats: Vec<NoNameContextSourceStat>,
+    #[serde(default)]
+    pub context_token_budget_used: Option<usize>,
+    #[serde(default)]
+    pub context_slice_stats: Vec<NoNameRoleContextSliceStat>,
     pub proposal: NoNameProposal,
 }
 
@@ -103,6 +119,7 @@ impl DirectorAgent {
                 NoNameApplyScope::Diagnostics,
                 NoNameApplyScope::ChapterSummaryHint,
                 NoNameApplyScope::OptionBiasHint,
+                NoNameApplyScope::PlotAugmentationHint,
                 NoNameApplyScope::PlotTextHint,
             ],
             status: NoNameProposalStatus::Observed,
@@ -117,6 +134,13 @@ impl DirectorAgent {
             focus,
             rationale,
             prompt_preview: artifacts.prompt_preview,
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal,
         })
     }
@@ -205,6 +229,13 @@ impl WorldCuratorAgent {
             focus,
             rationale,
             prompt_preview: artifacts.prompt_preview,
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal,
         })
     }
@@ -279,6 +310,7 @@ impl NpcIntentAgent {
             apply_scopes: vec![
                 NoNameApplyScope::Diagnostics,
                 NoNameApplyScope::OptionBiasHint,
+                NoNameApplyScope::PlotAugmentationHint,
                 NoNameApplyScope::PlotTextHint,
             ],
             status: NoNameProposalStatus::Observed,
@@ -293,6 +325,13 @@ impl NpcIntentAgent {
             focus,
             rationale,
             prompt_preview: artifacts.prompt_preview,
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal,
         })
     }
@@ -360,6 +399,7 @@ impl CombatNarratorAgent {
             ],
             apply_scopes: vec![
                 NoNameApplyScope::Diagnostics,
+                NoNameApplyScope::PlotAugmentationHint,
                 NoNameApplyScope::PlotTextHint,
             ],
             status: NoNameProposalStatus::Observed,
@@ -374,6 +414,13 @@ impl CombatNarratorAgent {
             focus,
             rationale,
             prompt_preview: artifacts.prompt_preview,
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal,
         })
     }
@@ -425,8 +472,16 @@ fn run_observe_capability_pipeline(
 
     let mut variables = BTreeMap::new();
     variables.insert("goal".to_string(), goal);
+    variables.insert(
+        "roleGoal".to_string(),
+        role_goal_from_context(context_packet),
+    );
     variables.insert("action".to_string(), action_summary.to_string());
     variables.insert("scene".to_string(), scene_from_context(context_packet));
+    variables.insert(
+        "forbiddenScopes".to_string(),
+        forbidden_scopes_from_context(context_packet),
+    );
 
     let prompt_resolve = NoNamePromptResolve {
         header: header.clone(),
@@ -442,6 +497,8 @@ fn run_observe_capability_pipeline(
         args: json!({
             "actionSummary": action_summary,
             "contextTokenBudgetUsed": context_packet.token_budget_used,
+            "roleGoal": role_goal_from_context(context_packet),
+            "forbiddenScopes": forbidden_scopes_from_context(context_packet),
         }),
     };
     let tool_result = registry.invoke_tool(&tool_call)?;
@@ -459,6 +516,31 @@ fn scene_from_context(context_packet: &NoNameContextPacket) -> String {
         .first()
         .cloned()
         .unwrap_or_else(|| "当前场景".to_string())
+}
+
+fn role_goal_from_context(context_packet: &NoNameContextPacket) -> String {
+    metadata_value_from_context(context_packet, "roleGoal").unwrap_or_else(|| {
+        "Follow the current role responsibility without expanding authority.".to_string()
+    })
+}
+
+fn forbidden_scopes_from_context(context_packet: &NoNameContextPacket) -> String {
+    metadata_value_from_context(context_packet, "forbiddenScopes")
+        .unwrap_or_else(|| "Must not directly mutate final plot state.".to_string())
+}
+
+fn metadata_value_from_context(context_packet: &NoNameContextPacket, key: &str) -> Option<String> {
+    let summary = context_packet.compressed_summary.as_ref()?;
+    let marker = format!("{key}: ");
+    let start = summary.find(&marker)? + marker.len();
+    let tail = &summary[start..];
+    let end = tail.find(';').unwrap_or(tail.len());
+    let value = tail[..end].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
 }
 
 fn read_tool_field<'a>(content: &'a Value, field: &str, fallback: &'a str) -> &'a str {
@@ -496,6 +578,7 @@ pub fn unsupported_role_error(role: NoNameRole) -> NoNameError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::noname_context_builder::{flatten_role_context_packet, specialize_context_packet};
     use crate::noname_context_types::{NoNameContextPacket, NoNameContextSourceStat};
     use crate::noname_tools::{
         build_combat_narrator_registry, build_director_registry, build_npc_intent_registry,
@@ -587,6 +670,28 @@ mod tests {
         assert_eq!(combat.proposal.kind, NoNameProposalKind::CombatNarration);
         assert_eq!(trace.proposals.len(), 3);
         assert_eq!(trace.capability_calls.len(), 9);
+    }
+
+    #[test]
+    fn role_prompt_reads_role_goal_and_forbidden_scopes_from_context() {
+        let mut base_packet = sample_packet(NoNameRole::WorldCurator);
+        base_packet.role = NoNameRole::WorldCurator;
+        let role_packet = specialize_context_packet(&base_packet);
+        let flattened = flatten_role_context_packet(&role_packet);
+        let registry = build_world_curator_registry(&flattened);
+        let mut trace =
+            NoNameTrace::empty("trace-3", "session-3", "turn-3", NoNameMode::ObserveOnly);
+
+        let observation = WorldCuratorAgent::new()
+            .observe_turn(&mut trace, &registry, &flattened, "检查山门法阵")
+            .expect("world curator observe should resolve role prompt");
+
+        assert!(observation.prompt_preview.contains("角色目标"));
+        assert!(observation.prompt_preview.contains(&role_packet.role_goal));
+        assert!(observation.prompt_preview.contains("禁止越权"));
+        assert!(observation
+            .prompt_preview
+            .contains(&role_packet.forbidden_scopes[0]));
     }
 
     #[test]

--- a/src-tauri/src/noname_roles.rs
+++ b/src-tauri/src/noname_roles.rs
@@ -2,8 +2,8 @@ use crate::noname_capability_registry::NoNameCapabilityRegistry;
 use crate::noname_context_types::NoNameContextPacket;
 use crate::noname_errors::{NoNameError, NoNameErrorKind};
 use crate::noname_prompts::{
-    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID,
-    NPC_INTENT_OBSERVE_PROMPT_ID, WORLD_CURATOR_OBSERVE_PROMPT_ID,
+    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID, NPC_INTENT_OBSERVE_PROMPT_ID,
+    WORLD_CURATOR_OBSERVE_PROMPT_ID,
 };
 use crate::noname_protocol_tool::{NoNamePromptResolve, NoNameResourceRead, NoNameToolCall};
 use crate::noname_protocol_types::{NoNameProtocolHeader, NoNameTraceWritable};
@@ -95,7 +95,10 @@ impl DirectorAgent {
             intended_effect: "为下一轮低风险输出提供稳定导向".to_string(),
             rationale: rationale.clone(),
             suggested_action: Some("保持 observe-only，等待后续 assisted 落地".to_string()),
-            labels: vec![NoNameRole::Director.as_str().to_string(), "observe_only".to_string()],
+            labels: vec![
+                NoNameRole::Director.as_str().to_string(),
+                "observe_only".to_string(),
+            ],
             apply_scopes: vec![
                 NoNameApplyScope::Diagnostics,
                 NoNameApplyScope::ChapterSummaryHint,
@@ -355,7 +358,10 @@ impl CombatNarratorAgent {
                 "observe_only".to_string(),
                 "combat".to_string(),
             ],
-            apply_scopes: vec![NoNameApplyScope::Diagnostics, NoNameApplyScope::PlotTextHint],
+            apply_scopes: vec![
+                NoNameApplyScope::Diagnostics,
+                NoNameApplyScope::PlotTextHint,
+            ],
             status: NoNameProposalStatus::Observed,
             applyable: false,
         };
@@ -372,7 +378,11 @@ impl CombatNarratorAgent {
         })
     }
 
-    fn goal_from_context(&self, context_packet: &NoNameContextPacket, action_summary: &str) -> String {
+    fn goal_from_context(
+        &self,
+        context_packet: &NoNameContextPacket,
+        action_summary: &str,
+    ) -> String {
         self.pick_focus(context_packet, action_summary)
     }
 
@@ -466,13 +476,18 @@ fn first_non_player_character(referenced_entities: &[String]) -> Option<String> 
 }
 
 fn contains_combat_signal(text: &str) -> bool {
-    ["战", "斗", "交手", "冲突", "出招", "杀", "攻"].iter().any(|token| text.contains(token))
+    ["战", "斗", "交手", "冲突", "出招", "杀", "攻"]
+        .iter()
+        .any(|token| text.contains(token))
 }
 
 pub fn unsupported_role_error(role: NoNameRole) -> NoNameError {
     NoNameError::new(
         NoNameErrorKind::Config,
-        format!("role {} is not registered for observe dispatch", role.as_str()),
+        format!(
+            "role {} is not registered for observe dispatch",
+            role.as_str()
+        ),
         "noname.agent.unsupported_role",
         true,
     )
@@ -491,9 +506,15 @@ mod tests {
     fn sample_packet(role: NoNameRole) -> NoNameContextPacket {
         NoNameContextPacket {
             role,
-            hard_facts: vec!["玩家 位于 山门".to_string(), "山门受宗门法阵保护".to_string()],
+            hard_facts: vec![
+                "玩家 位于 山门".to_string(),
+                "山门受宗门法阵保护".to_string(),
+            ],
             working_memory: vec!["玩家刚刚选择回到山门".to_string()],
-            episodic_memory: vec!["玩家返回山门".to_string(), "执事长老抬手示意弟子退后".to_string()],
+            episodic_memory: vec![
+                "玩家返回山门".to_string(),
+                "执事长老抬手示意弟子退后".to_string(),
+            ],
             narrative_notes: vec!["山门危机: 强敌逼近".to_string()],
             chapter_summaries: vec!["第一章: 危机渐近".to_string()],
             recent_context: vec!["敌修拔剑逼近，山门弟子列阵应对".to_string()],

--- a/src-tauri/src/noname_runtime.rs
+++ b/src-tauri/src/noname_runtime.rs
@@ -145,6 +145,13 @@ impl NoNameRuntime {
                     action_summary: observation.action_summary.clone(),
                     focus: observation.focus.clone(),
                     rationale: observation.rationale.clone(),
+                    role_goal: observation.role_goal.clone(),
+                    scene_focus: observation.scene_focus.clone(),
+                    forbidden_scopes: observation.forbidden_scopes.clone(),
+                    note_type_hits: observation.note_type_hits.clone(),
+                    source_stats: observation.source_stats.clone(),
+                    context_token_budget_used: observation.context_token_budget_used,
+                    context_slice_stats: observation.context_slice_stats.clone(),
                     proposal: observation.proposal.clone(),
                 })
                 .collect(),
@@ -558,6 +565,10 @@ impl NoNameRuntime {
                 .submit_agent_message(task_request.clone())?;
             task_request.record_on_trace(trace, queued.status.as_str());
 
+            let mut base_context = context_packet.clone();
+            base_context.role = role;
+            let role_context_packet = specialize_context_packet(&base_context);
+
             let delegation = NoNameAgentMessage::new(
                 header.clone(),
                 orchestrator.clone(),
@@ -567,6 +578,9 @@ impl NoNameRuntime {
                 serde_json::json!({
                     "goal": action_summary,
                     "targetRole": role.as_str(),
+                    "roleGoal": &role_context_packet.role_goal,
+                    "sceneFocus": &role_context_packet.scene_focus,
+                    "forbiddenScopes": &role_context_packet.forbidden_scopes,
                 }),
             );
             let running = self
@@ -574,8 +588,6 @@ impl NoNameRuntime {
                 .submit_agent_message(delegation.clone())?;
             delegation.record_on_trace(trace, running.status.as_str());
 
-            let mut role_context = context_packet.clone();
-            role_context.role = role;
             let mut role_trace = NoNameTrace::empty(
                 trace.trace_id.clone(),
                 trace.session_id.clone(),
@@ -583,10 +595,9 @@ impl NoNameRuntime {
                 trace.mode,
             );
 
-            match self.agent_registry.dispatch_observe_turn(
-                role,
+            match self.agent_registry.dispatch_role_context_observe_turn(
                 &mut role_trace,
-                &role_context,
+                &role_context_packet,
                 action_summary,
             ) {
                 Ok(observation) => {
@@ -651,6 +662,9 @@ fn controlled_output_kind_for_scope(scope: NoNameApplyScope) -> NoNameControlled
         NoNameApplyScope::Diagnostics => NoNameControlledOutputKind::NarrativeNote,
         NoNameApplyScope::ChapterSummaryHint => NoNameControlledOutputKind::RecapNote,
         NoNameApplyScope::OptionBiasHint => NoNameControlledOutputKind::IntermediateNarrativeHint,
+        NoNameApplyScope::PlotAugmentationHint => {
+            NoNameControlledOutputKind::NonFinalPlotAugmentation
+        }
         NoNameApplyScope::PlotTextHint => NoNameControlledOutputKind::SceneAugmentation,
     }
 }
@@ -789,6 +803,7 @@ mod tests {
                         last_generation_diagnostics: None,
                         last_option_generation_source: None,
                         last_consistency_risk_score: None,
+                        pending_plot_augmentation_hints: Vec::new(),
                     },
                     action_result: ActionResult {
                         success: true,
@@ -810,6 +825,25 @@ mod tests {
         );
         assert_eq!(result.related_observations.len(), 3);
         assert_eq!(result.trace.related_observations.len(), 3);
+        assert!(result.trace.related_observations.iter().any(|item| {
+            item.role == NoNameRole::WorldCurator
+                && item
+                    .role_goal
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("Maintain world facts")
+                && item
+                    .scene_focus
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("玩家 位于 山门")
+                && item
+                    .forbidden_scopes
+                    .iter()
+                    .any(|scope| scope.contains("NPC private intent"))
+                && item.source_stats.iter().any(|source| source.count > 0)
+                && item.context_token_budget_used.unwrap_or_default() > 0
+        }));
         assert_eq!(result.trace.protocol_events.len(), 9);
         assert_eq!(result.trace.capability_calls.len(), 21);
         assert_eq!(result.trace.proposals.len(), 1);
@@ -891,6 +925,7 @@ mod tests {
                         last_generation_diagnostics: None,
                         last_option_generation_source: None,
                         last_consistency_risk_score: None,
+                        pending_plot_augmentation_hints: Vec::new(),
                     },
                     action_result: ActionResult {
                         success: true,
@@ -926,7 +961,7 @@ mod tests {
                 .map(|item| item.outcome.as_str()),
             Some("applied_diagnostics_note")
         );
-        assert_eq!(result.trace.controlled_output_reviews.len(), 4);
+        assert_eq!(result.trace.controlled_output_reviews.len(), 5);
         assert!(result.trace.controlled_output_reviews.iter().any(|item| {
             item.decision == NoNameControlledOutputDecision::NeedsReview
                 && item.safe_apply_scope == Some(NoNameApplyScope::PlotTextHint)
@@ -1009,6 +1044,7 @@ mod tests {
                         last_generation_diagnostics: None,
                         last_option_generation_source: None,
                         last_consistency_risk_score: None,
+                        pending_plot_augmentation_hints: Vec::new(),
                     },
                     action_result: ActionResult {
                         success: true,

--- a/src-tauri/src/noname_runtime.rs
+++ b/src-tauri/src/noname_runtime.rs
@@ -1,5 +1,6 @@
 use crate::noname_agent_registry::NoNameAgentRegistry;
 use crate::noname_config::NoNameConfig;
+use crate::noname_context_builder::specialize_context_packet;
 use crate::noname_context_types::NoNameContextPacket;
 use crate::noname_errors::{NoNameError, NoNameErrorKind};
 use crate::noname_graph::NoNameGraphExecutor;
@@ -8,7 +9,8 @@ use crate::noname_guardrails::{
     NoNameDirectorGuardrailInput, NoNameGuardrailResult,
 };
 use crate::noname_output_interface::{
-    NoNameControlledOutputDecision, NoNameControlledOutputInterface, NoNameControlledOutputKind,
+    controlled_output_policy_from_role_context, NoNameControlledOutputDecision,
+    NoNameControlledOutputInterface, NoNameControlledOutputKind,
 };
 use crate::noname_protocol_agent::{NoNameAgentMessage, NoNameAgentMessageKind};
 use crate::noname_protocol_runtime::NoNameProtocolRuntime;
@@ -125,7 +127,12 @@ impl NoNameRuntime {
             result
         });
         let proposal = self.finalize_director_proposal(&mut observation, guardrail_result.as_ref());
-        let proposal = self.record_assisted_apply_preflight(&mut trace, proposal, guardrail_input);
+        let proposal = self.record_assisted_apply_preflight(
+            &mut trace,
+            proposal,
+            guardrail_input,
+            context_packet,
+        );
         observation.proposal = proposal.clone();
         trace.replace_last_proposal(proposal.clone());
         let related_observations =
@@ -259,6 +266,7 @@ impl NoNameRuntime {
         trace: &mut NoNameTrace,
         mut proposal: NoNameProposal,
         guardrail_input: Option<&NoNameDirectorGuardrailInput>,
+        context_packet: &NoNameContextPacket,
     ) -> NoNameProposal {
         trace.record_proposal_transition(format!(
             "{}:{}",
@@ -337,7 +345,7 @@ impl NoNameRuntime {
                             ));
                         }
                         let (review_count, needs_review_count) =
-                            self.record_controlled_output_reviews(trace, &proposal);
+                            self.record_controlled_output_reviews(trace, &proposal, context_packet);
                         if review_count > 0 {
                             trace.record_apply_execution(
                                 "runtime.controlled_output_review",
@@ -441,8 +449,13 @@ impl NoNameRuntime {
         &self,
         trace: &mut NoNameTrace,
         proposal: &NoNameProposal,
+        context_packet: &NoNameContextPacket,
     ) -> (usize, usize) {
-        let interface = NoNameControlledOutputInterface::default();
+        let role_context = specialize_context_packet(context_packet);
+        let interface = NoNameControlledOutputInterface::new(
+            controlled_output_policy_from_role_context(&role_context),
+        );
+        let policy_forbidden_scopes = interface.policy().forbidden_scopes.clone();
         let scopes = if proposal.apply_scopes.is_empty() {
             vec![NoNameApplyScope::Diagnostics]
         } else {
@@ -480,7 +493,7 @@ impl NoNameRuntime {
                 scope.as_str(),
                 controlled_output_decision_key(review.decision)
             ));
-            trace.record_controlled_output_review(kind, review);
+            trace.record_controlled_output_review(kind, policy_forbidden_scopes.clone(), review);
             review_count += 1;
         }
 
@@ -653,6 +666,7 @@ fn controlled_output_decision_key(decision: NoNameControlledOutputDecision) -> &
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::noname_output_interface::NoNameForbiddenOutputScope;
     use crate::noname_types::NoNameTraceStage;
 
     #[test]
@@ -916,6 +930,12 @@ mod tests {
         assert!(result.trace.controlled_output_reviews.iter().any(|item| {
             item.decision == NoNameControlledOutputDecision::NeedsReview
                 && item.safe_apply_scope == Some(NoNameApplyScope::PlotTextHint)
+                && item
+                    .policy_forbidden_scopes
+                    .contains(&NoNameForbiddenOutputScope::FinalPlotState)
+                && item
+                    .policy_forbidden_scopes
+                    .contains(&NoNameForbiddenOutputScope::CanonWorldFact)
                 && item.requires_human_review
         }));
         assert!(result

--- a/src-tauri/src/noname_tools.rs
+++ b/src-tauri/src/noname_tools.rs
@@ -4,13 +4,13 @@ use crate::noname_capability_base::{
 };
 use crate::noname_capability_registry::NoNameCapabilityRegistry;
 use crate::noname_context_types::NoNameContextPacket;
+use crate::noname_prompt_catalog::NoNamePromptTemplate;
 use crate::noname_prompts::{
     combat_narrator_observe_prompt_template, director_observe_prompt_template,
     npc_intent_observe_prompt_template, world_curator_observe_prompt_template,
-    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID,
-    NPC_INTENT_OBSERVE_PROMPT_ID, WORLD_CURATOR_OBSERVE_PROMPT_ID,
+    COMBAT_NARRATOR_OBSERVE_PROMPT_ID, DIRECTOR_OBSERVE_PROMPT_ID, NPC_INTENT_OBSERVE_PROMPT_ID,
+    WORLD_CURATOR_OBSERVE_PROMPT_ID,
 };
-use crate::noname_prompt_catalog::NoNamePromptTemplate;
 use crate::noname_resources::NoNameResourceDocument;
 use serde_json::json;
 

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -1,3 +1,4 @@
+use crate::noname_context_types::{NoNameContextSourceStat, NoNameRoleContextSliceStat};
 use crate::noname_output_interface::{
     NoNameControlledOutputDecision, NoNameControlledOutputKind, NoNameControlledOutputReview,
     NoNameForbiddenOutputScope,
@@ -119,6 +120,20 @@ pub struct NoNameRelatedObservationRecord {
     pub action_summary: String,
     pub focus: String,
     pub rationale: String,
+    #[serde(default)]
+    pub role_goal: Option<String>,
+    #[serde(default)]
+    pub scene_focus: Option<String>,
+    #[serde(default)]
+    pub forbidden_scopes: Vec<String>,
+    #[serde(default)]
+    pub note_type_hits: Vec<String>,
+    #[serde(default)]
+    pub source_stats: Vec<NoNameContextSourceStat>,
+    #[serde(default)]
+    pub context_token_budget_used: Option<usize>,
+    #[serde(default)]
+    pub context_slice_stats: Vec<NoNameRoleContextSliceStat>,
     pub proposal: NoNameProposal,
 }
 

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -60,6 +60,56 @@ pub struct NoNameControlledOutputReviewRecord {
     #[serde(default)]
     pub policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
     pub requires_human_review: bool,
+    #[serde(default)]
+    pub human_review_decision: Option<NoNameHumanReviewDecision>,
+    #[serde(default)]
+    pub human_reviewed_at: Option<u64>,
+    #[serde(default)]
+    pub human_review_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NoNameHumanReviewDecision {
+    Pending,
+    ApprovedForHigherApply,
+    RejectedForHigherApply,
+}
+
+impl NoNameHumanReviewDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::ApprovedForHigherApply => "approved_for_higher_apply",
+            Self::RejectedForHigherApply => "rejected_for_higher_apply",
+        }
+    }
+
+    pub fn note(self) -> &'static str {
+        match self {
+            Self::Pending => "人工复核已重置为待确认，未触发高层 apply",
+            Self::ApprovedForHigherApply => "人工确认可进入高层 apply 设计，仍需后端二次 guardrail",
+            Self::RejectedForHigherApply => "人工确认暂不应用，保持当前安全边界",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NoNameSecondGuardrailDecision {
+    Allow,
+    Reject,
+    Fallback,
+}
+
+impl NoNameSecondGuardrailDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Reject => "reject",
+            Self::Fallback => "fallback",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -241,6 +291,9 @@ impl NoNameTrace {
                 safe_apply_scope: review.safe_apply_scope,
                 policy_forbidden_scopes,
                 requires_human_review: review.requires_human_review,
+                human_review_decision: None,
+                human_reviewed_at: None,
+                human_review_note: None,
             });
     }
 

--- a/src-tauri/src/noname_trace.rs
+++ b/src-tauri/src/noname_trace.rs
@@ -1,5 +1,6 @@
 use crate::noname_output_interface::{
     NoNameControlledOutputDecision, NoNameControlledOutputKind, NoNameControlledOutputReview,
+    NoNameForbiddenOutputScope,
 };
 use crate::noname_types::{
     NoNameApplyScope, NoNameMode, NoNameProposal, NoNameRole, NoNameTraceStage,
@@ -56,6 +57,8 @@ pub struct NoNameControlledOutputReviewRecord {
     pub reason: String,
     pub normalized_kind: Option<NoNameControlledOutputKind>,
     pub safe_apply_scope: Option<NoNameApplyScope>,
+    #[serde(default)]
+    pub policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
     pub requires_human_review: bool,
 }
 
@@ -225,6 +228,7 @@ impl NoNameTrace {
     pub fn record_controlled_output_review(
         &mut self,
         requested_kind: NoNameControlledOutputKind,
+        policy_forbidden_scopes: Vec<NoNameForbiddenOutputScope>,
         review: NoNameControlledOutputReview,
     ) {
         self.controlled_output_reviews
@@ -235,6 +239,7 @@ impl NoNameTrace {
                 reason: review.reason,
                 normalized_kind: review.normalized_kind,
                 safe_apply_scope: review.safe_apply_scope,
+                policy_forbidden_scopes,
                 requires_human_review: review.requires_human_review,
             });
     }
@@ -442,6 +447,7 @@ mod tests {
         let mut trace = NoNameTrace::empty("trace-1", "session-1", "turn-1", NoNameMode::Assisted);
         trace.record_controlled_output_review(
             NoNameControlledOutputKind::SceneAugmentation,
+            vec![NoNameForbiddenOutputScope::CombatOutcome],
             NoNameControlledOutputReview {
                 request_id: "review-1".to_string(),
                 decision: NoNameControlledOutputDecision::NeedsReview,
@@ -456,6 +462,10 @@ mod tests {
         assert_eq!(
             trace.controlled_output_reviews[0].decision,
             NoNameControlledOutputDecision::NeedsReview
+        );
+        assert_eq!(
+            trace.controlled_output_reviews[0].policy_forbidden_scopes,
+            vec![NoNameForbiddenOutputScope::CombatOutcome]
         );
         assert!(trace.controlled_output_reviews[0].requires_human_review);
     }

--- a/src-tauri/src/noname_types.rs
+++ b/src-tauri/src/noname_types.rs
@@ -85,6 +85,7 @@ pub enum NoNameApplyScope {
     Diagnostics,
     ChapterSummaryHint,
     OptionBiasHint,
+    PlotAugmentationHint,
     PlotTextHint,
 }
 
@@ -94,6 +95,7 @@ impl NoNameApplyScope {
             Self::Diagnostics => "diagnostics",
             Self::ChapterSummaryHint => "chapter_summary_hint",
             Self::OptionBiasHint => "option_bias_hint",
+            Self::PlotAugmentationHint => "plot_augmentation_hint",
             Self::PlotTextHint => "plot_text_hint",
         }
     }
@@ -325,6 +327,10 @@ mod tests {
         assert_eq!(
             NoNameApplyScope::ChapterSummaryHint.as_str(),
             "chapter_summary_hint"
+        );
+        assert_eq!(
+            NoNameApplyScope::PlotAugmentationHint.as_str(),
+            "plot_augmentation_hint"
         );
     }
 

--- a/src-tauri/src/plot_consistency.rs
+++ b/src-tauri/src/plot_consistency.rs
@@ -593,6 +593,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         }
     }
 

--- a/src-tauri/src/plot_engine.rs
+++ b/src-tauri/src/plot_engine.rs
@@ -152,6 +152,8 @@ pub struct PlotState {
     pub last_option_generation_source: Option<String>,
     #[serde(default)]
     pub last_consistency_risk_score: Option<i32>,
+    #[serde(default)]
+    pub pending_plot_augmentation_hints: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1122,6 +1124,18 @@ impl PlotEngine {
         segment
     }
 
+    fn world_summary_with_pending_plot_augmentation(
+        base: impl Into<String>,
+        current_state: &PlotState,
+    ) -> String {
+        let base = base.into();
+        if let Some(context) = current_state.pending_plot_augmentation_prompt_context() {
+            format!("{base}；{context}")
+        } else {
+            base
+        }
+    }
+
     fn generate_chapter_segment_with_llm(
         &self,
         current_state: &PlotState,
@@ -1153,9 +1167,12 @@ impl PlotEngine {
             actor_realm: None,
             actor_combat_power: None,
             history_events: action_result.events.clone(),
-            world_setting_summary: Some(format!(
-                "小说风格：{}；参考设定文档 78 与补充稿，采用克制、具体、可验证的修仙叙事。请生成一段承接剧情的小说文本。玩家每章需要 2-3 次互动。",
-                settings.novel_style
+            world_setting_summary: Some(Self::world_summary_with_pending_plot_augmentation(
+                format!(
+                    "小说风格：{}；参考设定文档 78 与补充稿，采用克制、具体、可验证的修仙叙事。请生成一段承接剧情的小说文本。玩家每章需要 2-3 次互动。",
+                    settings.novel_style
+                ),
+                current_state,
             )),
         };
 
@@ -1322,9 +1339,12 @@ impl PlotEngine {
             actor_realm: None,
             actor_combat_power: None,
             history_events: action_result.events.clone(),
-            world_setting_summary: Some(format!(
-                "小说风格：{}；请生成一段承接剧情的小说文本。玩家每章需要 2-3 次互动。",
-                settings.novel_style
+            world_setting_summary: Some(Self::world_summary_with_pending_plot_augmentation(
+                format!(
+                    "小说风格：{}；请生成一段承接剧情的小说文本。玩家每章需要 2-3 次互动。",
+                    settings.novel_style
+                ),
+                current_state,
             )),
         };
 
@@ -1566,7 +1586,10 @@ impl PlotEngine {
                 actor_realm: None,
                 actor_combat_power: None,
                 history_events: action_result.events.clone(),
-                world_setting_summary: Some("参考设定文档 78 与补充稿，修仙叙事保持克制、写实、可验证，强调场景、事件与 NPC 反应".to_string()),
+                world_setting_summary: Some(Self::world_summary_with_pending_plot_augmentation(
+                    "参考设定文档 78 与补充稿，修仙叙事保持克制、写实、可验证，强调场景、事件与 NPC 反应",
+                    current_state,
+                )),
             },
             &PromptConstraints {
                 numerical_rules: vec!["必须与行动结果保持一致".to_string()],
@@ -1788,7 +1811,10 @@ impl PlotEngine {
                 actor_realm: None,
                 actor_combat_power: None,
                 history_events: action_result.events.clone(),
-                world_setting_summary: Some("先状态后叙事，输出可验证事实".to_string()),
+                world_setting_summary: Some(Self::world_summary_with_pending_plot_augmentation(
+                    "先状态后叙事，输出可验证事实",
+                    current_state,
+                )),
             },
             &PromptConstraints {
                 numerical_rules: vec!["必须与行动结果保持一致".to_string()],
@@ -1928,7 +1954,10 @@ impl PlotEngine {
                 actor_realm: None,
                 actor_combat_power: None,
                 history_events: action_result.events.clone(),
-                world_setting_summary: Some("轻量降级模式：优先可用与可验证性".to_string()),
+                world_setting_summary: Some(Self::world_summary_with_pending_plot_augmentation(
+                    "轻量降级模式：优先可用与可验证性",
+                    current_state,
+                )),
             },
             &PromptConstraints {
                 numerical_rules: vec!["必须与行动结果保持一致".to_string()],
@@ -2368,9 +2397,10 @@ impl PlotEngine {
                 actor_realm: None,
                 actor_combat_power: None,
                 history_events: action_result.events.clone(),
-                world_setting_summary: Some(
-                    "输出连贯中文小说段落，强调具体行动与因果。".to_string(),
-                ),
+                world_setting_summary: Some(Self::world_summary_with_pending_plot_augmentation(
+                    "输出连贯中文小说段落，强调具体行动与因果。",
+                    current_state,
+                )),
             },
             &PromptConstraints {
                 numerical_rules: vec!["必须与行动结果保持一致".to_string()],
@@ -2967,6 +2997,19 @@ fn fallback_chapter_title(index: u32, summary: &str) -> String {
     }
 }
 
+fn sanitize_pending_plot_augmentation_hint(hint: &str) -> Option<String> {
+    let normalized = hint
+        .replace(['\r', '\n', '\t'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let trimmed = normalized.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.chars().take(160).collect())
+}
+
 impl Scene {
     pub fn new(id: String, name: String, description: String, location: String) -> Self {
         Self {
@@ -3005,6 +3048,7 @@ impl PlotState {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         }
     }
 
@@ -3027,6 +3071,153 @@ impl PlotState {
         self.current_chapter.content.push(text);
         self.segment_count = self.segment_count.saturating_add(1);
         self.current_scene.description = self.current_chapter.content.join("\n\n");
+    }
+
+    pub fn apply_low_risk_chapter_summary_hint(
+        &mut self,
+        chapter_index: u32,
+        expected_summary: &str,
+        hint: &str,
+        prepend: bool,
+    ) -> Result<(), String> {
+        if self.current_chapter.index != chapter_index {
+            return Err(format!(
+                "chapter mismatch: expected {}, current {}",
+                chapter_index, self.current_chapter.index
+            ));
+        }
+        if self.current_chapter.summary != expected_summary {
+            return Err("summary snapshot mismatch; refusing stale low-risk apply".to_string());
+        }
+        let hint = hint.trim();
+        if hint.is_empty() {
+            return Err("chapter summary hint is empty".to_string());
+        }
+        if expected_summary.contains(hint) {
+            return Err("chapter summary already contains this low-risk hint".to_string());
+        }
+
+        let summary = expected_summary.trim();
+        let updated_summary = if summary.is_empty() {
+            hint.to_string()
+        } else if prepend {
+            format!("{}; {}", hint, summary)
+        } else {
+            format!("{}; {}", summary, hint)
+        };
+
+        self.current_chapter.summary = updated_summary.clone();
+        if let Some(history_chapter) = self
+            .chapters
+            .iter_mut()
+            .find(|chapter| chapter.index == chapter_index)
+        {
+            history_chapter.summary = updated_summary;
+        }
+        Ok(())
+    }
+
+    pub fn apply_low_risk_generation_diagnostics_hint(
+        &mut self,
+        chapter_index: u32,
+        expected_generation_diagnostics: &str,
+        hint: &str,
+    ) -> Result<(), String> {
+        if self.current_chapter.index != chapter_index {
+            return Err(format!(
+                "chapter mismatch: expected {}, current {}",
+                chapter_index, self.current_chapter.index
+            ));
+        }
+        if !self.is_waiting_for_input {
+            return Err("diagnostics hint requires waiting-for-input state".to_string());
+        }
+
+        let current_diagnostics = self.last_generation_diagnostics.clone().unwrap_or_default();
+        if current_diagnostics != expected_generation_diagnostics {
+            return Err("diagnostics snapshot mismatch; refusing stale low-risk apply".to_string());
+        }
+
+        let hint = hint.trim();
+        if hint.is_empty() {
+            return Err("generation diagnostics hint is empty".to_string());
+        }
+        if current_diagnostics.contains(hint) {
+            return Err("generation diagnostics already contains this low-risk hint".to_string());
+        }
+
+        self.last_generation_diagnostics = Some(if current_diagnostics.trim().is_empty() {
+            hint.to_string()
+        } else {
+            format!("{}; {}", current_diagnostics, hint)
+        });
+        Ok(())
+    }
+
+    pub fn apply_pending_plot_augmentation_hint(
+        &mut self,
+        chapter_index: u32,
+        expected_hints: &[String],
+        hint: &str,
+    ) -> Result<(), String> {
+        if self.current_chapter.index != chapter_index {
+            return Err(format!(
+                "chapter mismatch: expected {}, current {}",
+                chapter_index, self.current_chapter.index
+            ));
+        }
+        if !self.is_waiting_for_input {
+            return Err("plot augmentation hint requires waiting-for-input state".to_string());
+        }
+        if self.pending_plot_augmentation_hints != expected_hints {
+            return Err(
+                "plot augmentation snapshot mismatch; refusing stale controlled apply".to_string(),
+            );
+        }
+
+        let hint = hint.trim();
+        if hint.is_empty() {
+            return Err("plot augmentation hint is empty".to_string());
+        }
+        if self
+            .pending_plot_augmentation_hints
+            .iter()
+            .any(|existing| existing == hint)
+        {
+            return Err("plot augmentation already contains this controlled hint".to_string());
+        }
+
+        self.pending_plot_augmentation_hints.push(hint.to_string());
+        Ok(())
+    }
+
+    pub fn pending_plot_augmentation_prompt_context(&self) -> Option<String> {
+        let hints = self
+            .pending_plot_augmentation_hints
+            .iter()
+            .filter_map(|hint| sanitize_pending_plot_augmentation_hint(hint))
+            .take(3)
+            .collect::<Vec<_>>();
+        if hints.is_empty() {
+            return None;
+        }
+
+        Some(format!(
+            "NoName pending plot augmentation hints（非最终提示，可忽略）：{}。安全边界：只能作为下一轮叙事灵感；不得直接改写最终剧情状态、数值、背包、地图或章节生命周期；若与玩家行动结果或既有世界事实冲突，必须忽略。",
+            hints.join("；")
+        ))
+    }
+
+    pub fn consume_pending_plot_augmentation_hints(
+        &mut self,
+        expected_hints: &[String],
+    ) -> Result<usize, String> {
+        if self.pending_plot_augmentation_hints != expected_hints {
+            return Err("plot augmentation snapshot mismatch; refusing stale consume".to_string());
+        }
+        let consumed = self.pending_plot_augmentation_hints.len();
+        self.pending_plot_augmentation_hints.clear();
+        Ok(consumed)
     }
 
     pub fn finalize_chapter(&mut self, title: Option<String>, summary: Option<String>) {
@@ -3126,6 +3317,157 @@ mod tests {
         let state = PlotState::new(scene);
         assert!(state.is_waiting_for_input);
         assert!(state.plot_history.is_empty());
+    }
+
+    #[test]
+    fn test_low_risk_chapter_summary_hint_updates_summary() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state.current_chapter.summary = "existing summary".to_string();
+
+        state
+            .apply_low_risk_chapter_summary_hint(
+                1,
+                "existing summary",
+                "NoName summary hint: focus",
+                true,
+            )
+            .expect("summary hint should apply");
+
+        assert_eq!(
+            state.current_chapter.summary,
+            "NoName summary hint: focus; existing summary"
+        );
+    }
+
+    #[test]
+    fn test_low_risk_chapter_summary_hint_rejects_stale_snapshot() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state.current_chapter.summary = "new summary".to_string();
+
+        let error = state
+            .apply_low_risk_chapter_summary_hint(
+                1,
+                "old summary",
+                "NoName summary hint: focus",
+                false,
+            )
+            .expect_err("stale summary should be rejected");
+
+        assert!(error.contains("summary snapshot mismatch"));
+    }
+
+    #[test]
+    fn test_low_risk_generation_diagnostics_hint_updates_diagnostics() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state.last_generation_diagnostics = Some("base diagnostics".to_string());
+
+        state
+            .apply_low_risk_generation_diagnostics_hint(
+                1,
+                "base diagnostics",
+                "NoName option bias: focus",
+            )
+            .expect("diagnostics hint should apply");
+
+        assert_eq!(
+            state.last_generation_diagnostics.as_deref(),
+            Some("base diagnostics; NoName option bias: focus")
+        );
+    }
+
+    #[test]
+    fn test_low_risk_generation_diagnostics_hint_rejects_when_not_waiting() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state.is_waiting_for_input = false;
+
+        let error = state
+            .apply_low_risk_generation_diagnostics_hint(1, "", "NoName option bias: focus")
+            .expect_err("non-waiting state should be rejected");
+
+        assert!(error.contains("waiting-for-input"));
+    }
+
+    #[test]
+    fn test_pending_plot_augmentation_hint_updates_pending_hints() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state
+            .pending_plot_augmentation_hints
+            .push("existing augmentation".to_string());
+
+        state
+            .apply_pending_plot_augmentation_hint(
+                1,
+                &["existing augmentation".to_string()],
+                "NoName plot augmentation: focus",
+            )
+            .expect("plot augmentation hint should apply");
+
+        assert_eq!(
+            state.pending_plot_augmentation_hints,
+            vec![
+                "existing augmentation".to_string(),
+                "NoName plot augmentation: focus".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_pending_plot_augmentation_hint_rejects_stale_snapshot() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state
+            .pending_plot_augmentation_hints
+            .push("new augmentation".to_string());
+
+        let error = state
+            .apply_pending_plot_augmentation_hint(
+                1,
+                &["old augmentation".to_string()],
+                "NoName plot augmentation: focus",
+            )
+            .expect_err("stale plot augmentation snapshot should be rejected");
+
+        assert!(error.contains("plot augmentation snapshot mismatch"));
+    }
+
+    #[test]
+    fn test_pending_plot_augmentation_prompt_context_is_sanitized_and_bounded() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        state
+            .pending_plot_augmentation_hints
+            .push("NoName plot augmentation:\n focus=hidden cave\t| effect=stage beat".to_string());
+        state.pending_plot_augmentation_hints.push("".to_string());
+
+        let context = state
+            .pending_plot_augmentation_prompt_context()
+            .expect("pending hints should produce prompt context");
+
+        assert!(context.contains("非最终提示"));
+        assert!(context.contains("focus=hidden cave | effect=stage beat"));
+        assert!(context.contains("不得直接改写最终剧情状态"));
+        assert!(!context.contains('\n'));
+        assert!(!context.contains('\t'));
+    }
+
+    #[test]
+    fn test_consume_pending_plot_augmentation_hints_clears_matching_snapshot() {
+        let scene = create_test_scene();
+        let mut state = PlotState::new(scene);
+        let expected = vec!["NoName plot augmentation: focus=hidden cave".to_string()];
+        state.pending_plot_augmentation_hints = expected.clone();
+
+        let consumed = state
+            .consume_pending_plot_augmentation_hints(&expected)
+            .expect("matching snapshot should be consumed");
+
+        assert_eq!(consumed, 1);
+        assert!(state.pending_plot_augmentation_hints.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/save_load.rs
+++ b/src-tauri/src/save_load.rs
@@ -611,8 +611,10 @@ mod tests {
         let system = SaveLoadSystem::with_directory(temp_dir.path().to_path_buf());
 
         let game_state = create_test_game_state();
-        let save_data = SaveData::from_game_state(game_state)
-            .with_noname_settings(NoNameSaveSettings { mode: NoNameMode::Assisted });
+        let save_data =
+            SaveData::from_game_state(game_state).with_noname_settings(NoNameSaveSettings {
+                mode: NoNameMode::Assisted,
+            });
         system.save_game(1, &save_data).unwrap();
 
         let saves = system.list_saves().unwrap();

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -14,14 +14,19 @@ use crate::llm_runtime_config::{
 };
 use crate::llm_service::{LLMConfig, LLMRequest, LLMService};
 use crate::memory_layers::{ChapterSummary, MemoryEntry, WorldFact};
+use crate::noname_apply::{
+    apply_reviewed_output_to_plot_state, NoNameApplyDiagnosticsSnapshot,
+    NoNameApplySegmentSnapshot, NoNameApplySummarySnapshot, NoNameReviewedApplyRequest,
+};
 use crate::noname_config::NoNameConfig;
 use crate::noname_context_builder::build_context_packet;
 use crate::noname_context_types::NoNameContextBuildInput;
 use crate::noname_guardrails::{NoNameDirectorGuardrailInput, NoNameGuardrailResult};
 use crate::noname_memory_manager::NoNameMemoryManager;
+use crate::noname_output_interface::NoNameControlledOutputDecision;
 use crate::noname_roles::NoNameDirectorObservation;
 use crate::noname_runtime::{NoNameDirectorRunResult, NoNameRuntime, NoNameTurnInput};
-use crate::noname_trace::NoNameTrace;
+use crate::noname_trace::{NoNameHumanReviewDecision, NoNameSecondGuardrailDecision, NoNameTrace};
 use crate::noname_types::{NoNameApplyScope, NoNameMode, NoNameRole, NoNameTargetSegment};
 use crate::novel_generator::{Novel, NovelGenerator};
 use crate::numerical_system::{Action, Context, StatChange};
@@ -201,6 +206,13 @@ struct NoNameApplyTargetPlan {
     priority: u32,
     order: u32,
     decision: NoNameApplyTargetDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoNameManualPlotTextApplyResult {
+    pub trace: NoNameTrace,
+    pub plot_state: PlotState,
 }
 
 fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
@@ -401,6 +413,400 @@ fn record_noname_apply_plan_and_skip_execution(
     if let NoNameApplyTargetDecision::Skip { outcome, note } = &plan.decision {
         trace.record_apply_execution(plan.target, *outcome, Some(note.clone()));
     }
+}
+
+fn next_noname_apply_plan_order(trace: &NoNameTrace) -> u32 {
+    trace
+        .apply_plan_log
+        .iter()
+        .map(|item| item.order)
+        .max()
+        .unwrap_or_default()
+        + 1
+}
+
+fn find_review_proposal<'a>(
+    trace: &'a NoNameTrace,
+    request_id: &str,
+) -> Option<&'a crate::noname_types::NoNameProposal> {
+    trace
+        .proposals
+        .iter()
+        .rev()
+        .find(|proposal| request_id.contains(&proposal.proposal_id))
+        .or_else(|| trace.proposals.last())
+}
+
+fn record_noname_human_review_apply_intent(
+    trace: &mut NoNameTrace,
+    request_id: &str,
+    decision: NoNameHumanReviewDecision,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) {
+    let target = safe_apply_scope
+        .map(|scope| scope.as_str())
+        .unwrap_or("controlled_output");
+    let order = next_noname_apply_plan_order(trace);
+    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 25;
+
+    match decision {
+        NoNameHumanReviewDecision::Pending => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "review_intent_pending",
+                priority,
+                Some("人工复核已重置为待确认，未进入二次 guardrail".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "human_review_pending",
+                Some("等待人工确认，不触发高层 apply".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:apply_intent:pending", request_id));
+        }
+        NoNameHumanReviewDecision::RejectedForHigherApply => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "reject",
+                priority,
+                Some("人工复核拒绝进入高层 apply，保持安全边界".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "rejected_by_human_review",
+                Some("开发者选择暂不应用，未触发二次 guardrail".to_string()),
+            );
+            trace.record_proposal_transition(format!(
+                "{}:apply_intent:rejected_by_human_review",
+                request_id
+            ));
+        }
+        NoNameHumanReviewDecision::ApprovedForHigherApply => {
+            let rejection_reason = if trace.mode != NoNameMode::Assisted {
+                Some("当前 trace 不是 assisted 模式，拒绝进入高层 apply intent".to_string())
+            } else if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+                Some(format!(
+                    "当前仅允许 plot_text_hint 进入人工确认后的二次 guardrail，实际作用域为 {}",
+                    target
+                ))
+            } else {
+                match find_review_proposal(trace, request_id) {
+                    Some(proposal)
+                        if proposal.status
+                            == crate::noname_types::NoNameProposalStatus::Applied
+                            && proposal.applyable
+                            && target_segment_supports_apply_scope(
+                                proposal.target_segment,
+                                NoNameApplyScope::PlotTextHint,
+                            ) =>
+                    {
+                        None
+                    }
+                    Some(proposal)
+                        if proposal.status
+                            != crate::noname_types::NoNameProposalStatus::Applied
+                            || !proposal.applyable =>
+                    {
+                        Some(format!(
+                            "proposal 状态为 {} / applyable={}，拒绝进入高层 apply intent",
+                            proposal.status.as_str(),
+                            proposal.applyable
+                        ))
+                    }
+                    Some(proposal) => Some(format!(
+                        "target_segment={} 不支持 plot_text_hint 二次 apply",
+                        proposal.target_segment.as_str()
+                    )),
+                    None => {
+                        Some("未找到 review 对应 proposal，拒绝进入高层 apply intent".to_string())
+                    }
+                }
+            };
+
+            if let Some(reason) = rejection_reason {
+                trace.record_apply_plan(
+                    order,
+                    target,
+                    "second_guardrail_reject",
+                    priority,
+                    Some(reason.clone()),
+                );
+                trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason));
+                trace.record_proposal_transition(format!(
+                    "{}:apply_intent:second_guardrail_rejected",
+                    request_id
+                ));
+                return;
+            }
+
+            trace.record_apply_plan(
+                order,
+                target,
+                "review_intent_ready",
+                priority,
+                Some(
+                    "人工确认已通过，已排入二次 guardrail / apply planner，未写入正文".to_string(),
+                ),
+            );
+            trace.record_apply_execution(
+                target,
+                "awaiting_second_guardrail",
+                Some("高层 apply intent 已记录，等待后续二次 guardrail 决策".to_string()),
+            );
+            trace.record_proposal_transition(format!(
+                "{}:apply_intent:awaiting_second_guardrail",
+                request_id
+            ));
+        }
+    }
+}
+
+fn review_is_waiting_for_second_guardrail(trace: &NoNameTrace, request_id: &str) -> bool {
+    let transition = format!("{}:apply_intent:awaiting_second_guardrail", request_id);
+    trace
+        .proposal_transition_log
+        .iter()
+        .any(|entry| entry == &transition)
+        || trace.apply_execution_log.iter().any(|entry| {
+            entry.outcome == "awaiting_second_guardrail"
+                && entry.target == NoNameApplyScope::PlotTextHint.as_str()
+        })
+}
+
+fn second_guardrail_revalidation_reason(
+    trace: &NoNameTrace,
+    request_id: &str,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) -> Option<String> {
+    if trace.mode != NoNameMode::Assisted {
+        return Some("当前 trace 不是 assisted 模式，二次 guardrail 拒绝".to_string());
+    }
+    if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+        return Some("当前二次 guardrail 只允许处理 plot_text_hint".to_string());
+    }
+    if !review_is_waiting_for_second_guardrail(trace, request_id) {
+        return Some("review 尚未进入 awaiting_second_guardrail 队列".to_string());
+    }
+
+    match find_review_proposal(trace, request_id) {
+        Some(proposal)
+            if proposal.status == crate::noname_types::NoNameProposalStatus::Applied
+                && proposal.applyable
+                && target_segment_supports_apply_scope(
+                    proposal.target_segment,
+                    NoNameApplyScope::PlotTextHint,
+                ) =>
+        {
+            None
+        }
+        Some(proposal)
+            if proposal.status != crate::noname_types::NoNameProposalStatus::Applied
+                || !proposal.applyable =>
+        {
+            Some(format!(
+                "proposal 状态为 {} / applyable={}，二次 guardrail 拒绝",
+                proposal.status.as_str(),
+                proposal.applyable
+            ))
+        }
+        Some(proposal) => Some(format!(
+            "target_segment={} 不支持 plot_text_hint 二次 guardrail",
+            proposal.target_segment.as_str()
+        )),
+        None => Some("未找到 review 对应 proposal，二次 guardrail 拒绝".to_string()),
+    }
+}
+
+fn record_noname_second_guardrail_decision(
+    trace: &mut NoNameTrace,
+    request_id: &str,
+    decision: NoNameSecondGuardrailDecision,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) -> Result<(), String> {
+    let target = safe_apply_scope
+        .map(|scope| scope.as_str())
+        .unwrap_or("controlled_output");
+    let order = next_noname_apply_plan_order(trace);
+    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 50;
+    let revalidation_reason =
+        second_guardrail_revalidation_reason(trace, request_id, safe_apply_scope);
+
+    if let Some(reason) = revalidation_reason {
+        trace.record_apply_plan(
+            order,
+            target,
+            "second_guardrail_reject",
+            priority,
+            Some(reason.clone()),
+        );
+        trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason.clone()));
+        trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
+        trace.set_apply_result(true, "second_guardrail_reject", Some(reason));
+        return Ok(());
+    }
+
+    match decision {
+        NoNameSecondGuardrailDecision::Allow => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_allow",
+                priority,
+                Some("二次 guardrail 允许进入后续人工 apply 命令；当前不写正文".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_allowed",
+                Some("已允许进入下一步人工 apply，但未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:allow", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_allow",
+                Some("二次 guardrail 已允许；等待显式人工 apply 命令".to_string()),
+            );
+        }
+        NoNameSecondGuardrailDecision::Reject => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_reject",
+                priority,
+                Some("二次 guardrail 人工拒绝高层 apply".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_rejected",
+                Some("二次 guardrail 决策为拒绝，未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_reject",
+                Some("二次 guardrail 已拒绝高层 apply".to_string()),
+            );
+        }
+        NoNameSecondGuardrailDecision::Fallback => {
+            trace.push_stage(crate::noname_types::NoNameTraceStage::ApplyFallback);
+            trace.fallback_used = true;
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_fallback",
+                priority,
+                Some("二次 guardrail 要求回退经典链路".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_fallback",
+                Some("已记录回退决策，未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:fallback", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_fallback",
+                Some("二次 guardrail 决策为 fallback，继续依赖经典链路".to_string()),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_noname_manual_plot_text_hint_to_plot_state(
+    trace: NoNameTrace,
+    request_id: &str,
+    plot_state: PlotState,
+    chapter_index: u32,
+    segment_index: usize,
+    expected_segment_text: &str,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let outcome = apply_reviewed_output_to_plot_state(
+        trace,
+        NoNameReviewedApplyRequest {
+            request_id: request_id.to_string(),
+            scope: NoNameApplyScope::PlotTextHint,
+            segment_snapshot: Some(NoNameApplySegmentSnapshot {
+                chapter_index,
+                segment_index,
+                expected_segment_text: expected_segment_text.to_string(),
+            }),
+            summary_snapshot: None,
+            diagnostics_snapshot: None,
+        },
+        plot_state,
+    )?;
+    Ok(NoNameManualPlotTextApplyResult {
+        trace: outcome.trace,
+        plot_state: outcome.plot_state,
+    })
+}
+
+fn build_noname_reviewed_apply_request(
+    request_id: String,
+    scope: NoNameApplyScope,
+    chapter_index: Option<u32>,
+    segment_index: Option<usize>,
+    expected_segment_text: Option<String>,
+    expected_summary: Option<String>,
+    expected_generation_diagnostics: Option<String>,
+) -> Result<NoNameReviewedApplyRequest, String> {
+    let segment_snapshot = match scope {
+        NoNameApplyScope::PlotTextHint => Some(NoNameApplySegmentSnapshot {
+            chapter_index: chapter_index
+                .ok_or_else(|| "plot_text_hint manual apply requires chapter_index".to_string())?,
+            segment_index: segment_index
+                .ok_or_else(|| "plot_text_hint manual apply requires segment_index".to_string())?,
+            expected_segment_text: expected_segment_text.ok_or_else(|| {
+                "plot_text_hint manual apply requires expected_segment_text".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+    let summary_snapshot = match scope {
+        NoNameApplyScope::ChapterSummaryHint => Some(NoNameApplySummarySnapshot {
+            chapter_index: chapter_index.ok_or_else(|| {
+                "chapter_summary_hint manual apply requires chapter_index".to_string()
+            })?,
+            expected_summary: expected_summary.ok_or_else(|| {
+                "chapter_summary_hint manual apply requires expected_summary".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+    let diagnostics_snapshot = match scope {
+        NoNameApplyScope::OptionBiasHint => Some(NoNameApplyDiagnosticsSnapshot {
+            chapter_index: chapter_index.ok_or_else(|| {
+                "option_bias_hint manual apply requires chapter_index".to_string()
+            })?,
+            expected_generation_diagnostics: expected_generation_diagnostics.ok_or_else(|| {
+                "option_bias_hint manual apply requires expected_generation_diagnostics".to_string()
+            })?,
+        }),
+        _ => None,
+    };
+
+    Ok(NoNameReviewedApplyRequest {
+        request_id,
+        scope,
+        segment_snapshot,
+        summary_snapshot,
+        diagnostics_snapshot,
+    })
+}
+
+fn apply_noname_reviewed_output_to_plot_state(
+    trace: NoNameTrace,
+    request: NoNameReviewedApplyRequest,
+    plot_state: PlotState,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let outcome = apply_reviewed_output_to_plot_state(trace, request, plot_state)?;
+    Ok(NoNameManualPlotTextApplyResult {
+        trace: outcome.trace,
+        plot_state: outcome.plot_state,
+    })
 }
 
 fn apply_noname_plot_text_hint(
@@ -648,6 +1054,23 @@ fn run_noname_observe_only_for_turn(
         .map_err(|e| e.to_string())?;
 
     Ok(result)
+}
+
+fn maybe_run_noname_for_turn(
+    action_summary: &str,
+    game_state: &GameState,
+    plot_state: &PlotState,
+    timestamp: u64,
+) -> Option<NoNameDirectorRunResult> {
+    let mode = noname_runtime()
+        .lock()
+        .map(|runtime| runtime.mode())
+        .unwrap_or(NoNameMode::Disabled);
+    if !mode.is_enabled() {
+        return None;
+    }
+
+    run_noname_observe_only_for_turn(action_summary, game_state, plot_state, timestamp).ok()
 }
 
 fn build_plot_context_for_generation(
@@ -3668,13 +4091,8 @@ pub async fn execute_player_action(
     plot_state.last_action_result = Some(action_result.clone());
     let plot_text_for_history = plot_update.plot_text.clone();
     let mut plot_text_for_player = plot_update.plot_text.clone();
-    let mut noname_result = run_noname_observe_only_for_turn(
-        &noname_action_summary,
-        &game_state,
-        &plot_state,
-        timestamp,
-    )
-    .ok();
+    let mut noname_result =
+        maybe_run_noname_for_turn(&noname_action_summary, &game_state, &plot_state, timestamp);
     let mut noname_plot_text_applied = false;
     if let Some(result) = noname_result.as_mut() {
         let plans = build_noname_apply_plan_set(
@@ -4006,6 +4424,215 @@ pub async fn clear_noname_recent_traces() -> Result<(), String> {
         .map_err(|_| "NoName runtime lock poisoned".to_string())?;
     runtime.clear_traces();
     Ok(())
+}
+
+#[tauri::command]
+pub async fn mark_noname_controlled_output_review(
+    trace_id: String,
+    request_id: String,
+    decision: NoNameHumanReviewDecision,
+) -> Result<NoNameTrace, String> {
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    let mut trace = runtime
+        .get_recent_traces()
+        .into_iter()
+        .rev()
+        .find(|trace| trace.trace_id == trace_id)
+        .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?;
+
+    let reviewed_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let safe_apply_scope = {
+        let review = trace
+            .controlled_output_reviews
+            .iter_mut()
+            .find(|review| review.request_id == request_id)
+            .ok_or_else(|| format!("NoName controlled output review not found: {}", request_id))?;
+
+        if review.decision != NoNameControlledOutputDecision::NeedsReview
+            || !review.requires_human_review
+        {
+            return Err(format!(
+                "NoName controlled output review does not require human review: {}",
+                request_id
+            ));
+        }
+
+        review.human_review_decision = Some(decision);
+        review.human_reviewed_at = Some(reviewed_at);
+        review.human_review_note = Some(decision.note().to_string());
+        review.safe_apply_scope
+    };
+
+    if safe_apply_scope.is_none() {
+        return Err(format!(
+            "NoName controlled output review has no safe apply scope: {}",
+            request_id
+        ));
+    }
+
+    trace.record_proposal_transition(format!("{}:human_review:{}", request_id, decision.as_str()));
+    record_noname_human_review_apply_intent(&mut trace, &request_id, decision, safe_apply_scope);
+
+    if !runtime.replace_trace(trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(trace)
+}
+
+#[tauri::command]
+pub async fn resolve_noname_second_guardrail(
+    trace_id: String,
+    request_id: String,
+    decision: NoNameSecondGuardrailDecision,
+) -> Result<NoNameTrace, String> {
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    let mut trace = runtime
+        .get_recent_traces()
+        .into_iter()
+        .rev()
+        .find(|trace| trace.trace_id == trace_id)
+        .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?;
+
+    let safe_apply_scope = {
+        let review = trace
+            .controlled_output_reviews
+            .iter()
+            .find(|review| review.request_id == request_id)
+            .ok_or_else(|| format!("NoName controlled output review not found: {}", request_id))?;
+
+        if review.human_review_decision != Some(NoNameHumanReviewDecision::ApprovedForHigherApply) {
+            return Err(format!(
+                "NoName controlled output review is not approved for second guardrail: {}",
+                request_id
+            ));
+        }
+
+        review.safe_apply_scope
+    };
+
+    record_noname_second_guardrail_decision(&mut trace, &request_id, decision, safe_apply_scope)?;
+
+    if !runtime.replace_trace(trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(trace)
+}
+
+#[tauri::command]
+pub async fn apply_noname_manual_plot_text_hint(
+    trace_id: String,
+    request_id: String,
+    chapter_index: u32,
+    segment_index: usize,
+    expected_segment_text: String,
+    engine: State<'_, Mutex<GameEngine>>,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let trace = {
+        let runtime = noname_runtime()
+            .lock()
+            .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+        runtime
+            .get_recent_traces()
+            .into_iter()
+            .rev()
+            .find(|trace| trace.trace_id == trace_id)
+            .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?
+    };
+
+    let result = {
+        let engine = match engine.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
+        let result = apply_noname_manual_plot_text_hint_to_plot_state(
+            trace,
+            &request_id,
+            plot_state,
+            chapter_index,
+            segment_index,
+            &expected_segment_text,
+        )?;
+        engine
+            .update_plot_state(result.plot_state.clone())
+            .map_err(|e| e.to_string())?;
+        result
+    };
+
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    if !runtime.replace_trace(result.trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(result)
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn apply_noname_reviewed_output(
+    trace_id: String,
+    request_id: String,
+    scope: NoNameApplyScope,
+    chapter_index: Option<u32>,
+    segment_index: Option<usize>,
+    expected_segment_text: Option<String>,
+    expected_summary: Option<String>,
+    expected_generation_diagnostics: Option<String>,
+    engine: State<'_, Mutex<GameEngine>>,
+) -> Result<NoNameManualPlotTextApplyResult, String> {
+    let request = build_noname_reviewed_apply_request(
+        request_id,
+        scope,
+        chapter_index,
+        segment_index,
+        expected_segment_text,
+        expected_summary,
+        expected_generation_diagnostics,
+    )?;
+    let trace = {
+        let runtime = noname_runtime()
+            .lock()
+            .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+        runtime
+            .get_recent_traces()
+            .into_iter()
+            .rev()
+            .find(|trace| trace.trace_id == trace_id)
+            .ok_or_else(|| format!("NoName trace not found: {}", trace_id))?
+    };
+
+    let result = {
+        let engine = match engine.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let plot_state = engine.get_plot_state().map_err(|e| e.to_string())?;
+        let result = apply_noname_reviewed_output_to_plot_state(trace, request, plot_state)?;
+        engine
+            .update_plot_state(result.plot_state.clone())
+            .map_err(|e| e.to_string())?;
+        result
+    };
+
+    let mut runtime = noname_runtime()
+        .lock()
+        .map_err(|_| "NoName runtime lock poisoned".to_string())?;
+    if !runtime.replace_trace(result.trace.clone()) {
+        return Err(format!("NoName trace not found: {}", trace_id));
+    }
+
+    Ok(result)
 }
 
 #[tauri::command]
@@ -4710,6 +5337,7 @@ mod tests {
     use crate::event_log::{EventImportance, GameEvent};
     use crate::models::{CultivationRealm, Element, Grade, SpiritualRoot};
     use crate::script::{InitialState, Location, ScriptType, WorldSetting};
+    use std::sync::{Mutex as TestMutex, OnceLock as TestOnceLock};
     use tempfile::tempdir;
 
     fn create_test_script() -> Script {
@@ -4744,6 +5372,35 @@ mod tests {
             world_setting,
             initial_state,
         )
+    }
+
+    fn noname_mode_matrix_lock() -> &'static TestMutex<()> {
+        static LOCK: TestOnceLock<TestMutex<()>> = TestOnceLock::new();
+        LOCK.get_or_init(|| TestMutex::new(()))
+    }
+
+    fn reset_noname_runtime_for_mode_test(mode: NoNameMode) {
+        let mut runtime = noname_runtime()
+            .lock()
+            .expect("noname runtime lock should be available");
+        runtime.set_mode(mode);
+        runtime.clear_traces();
+    }
+
+    fn create_noname_mode_fixture() -> (GameState, PlotState) {
+        let mut engine = GameEngine::new();
+        let script = create_test_script();
+        let game_state = engine
+            .initialize_game(script)
+            .expect("test game should initialize");
+        let plot_state = engine
+            .initialize_plot_with_opening(
+                "山门风声渐紧，灵气沿石阶回荡。".to_string(),
+                Some(vec![make_option(0, "返回山门广场")]),
+            )
+            .expect("test plot should initialize");
+
+        (game_state, plot_state)
     }
 
     #[test]
@@ -6618,6 +7275,301 @@ mod tests {
         assert!(text.contains("applyable=no"));
         assert!(text.contains("guardrail=accept"));
         assert!(text.contains("apply=skipped_observe_only"));
+    }
+
+    #[test]
+    fn test_t7_mode_matrix_disabled_skips_noname_turn() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::Disabled);
+        let (game_state, plot_state) = create_noname_mode_fixture();
+
+        let result =
+            maybe_run_noname_for_turn("自由输入: 观察山门灵气", &game_state, &plot_state, 10);
+
+        assert!(result.is_none());
+        assert!(noname_runtime()
+            .lock()
+            .expect("noname runtime lock should be available")
+            .get_recent_traces()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_t7_mode_matrix_observe_only_records_without_apply() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::ObserveOnly);
+        let (game_state, plot_state) = create_noname_mode_fixture();
+        let mut plot_state_after = plot_state.clone();
+
+        let mut result =
+            maybe_run_noname_for_turn("自由输入: 观察山门灵气", &game_state, &plot_state, 11)
+                .expect("observe-only should produce a NoName observation");
+        apply_noname_low_risk_outputs(&mut plot_state_after, &mut result, false);
+        append_noname_observation_diagnostics(
+            &mut plot_state_after.last_generation_diagnostics,
+            result.trace.mode,
+            &result.observation,
+            result.guardrail_result.as_ref(),
+            &result.trace,
+        );
+
+        assert_eq!(
+            result.proposal.status,
+            crate::noname_types::NoNameProposalStatus::Observed
+        );
+        assert!(!result.proposal.applyable);
+        assert!(result.trace.controlled_output_reviews.is_empty());
+        assert_eq!(
+            result
+                .trace
+                .apply_result
+                .as_ref()
+                .map(|item| item.outcome.as_str()),
+            Some("skipped_observe_only")
+        );
+        assert!(!plot_state_after
+            .current_chapter
+            .summary
+            .contains("NoName提示"));
+        let diagnostics = plot_state_after
+            .last_generation_diagnostics
+            .as_deref()
+            .unwrap_or_default();
+        assert!(diagnostics.contains("NoName.observe_only"));
+        assert!(diagnostics.contains("proposal_status=observed"));
+        assert!(diagnostics.contains("apply=skipped_observe_only"));
+    }
+
+    #[test]
+    fn test_t7_mode_matrix_assisted_records_review_and_low_risk_apply() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::Assisted);
+        let (game_state, plot_state) = create_noname_mode_fixture();
+        let mut plot_state_after = plot_state.clone();
+
+        let mut result =
+            maybe_run_noname_for_turn("自由输入: 观察山门灵气", &game_state, &plot_state, 12)
+                .expect("assisted should produce a NoName observation");
+        apply_noname_low_risk_outputs(&mut plot_state_after, &mut result, false);
+        append_noname_observation_diagnostics(
+            &mut plot_state_after.last_generation_diagnostics,
+            result.trace.mode,
+            &result.observation,
+            result.guardrail_result.as_ref(),
+            &result.trace,
+        );
+
+        assert_eq!(
+            result.proposal.status,
+            crate::noname_types::NoNameProposalStatus::Applied
+        );
+        assert!(result.proposal.applyable);
+        assert_eq!(result.trace.controlled_output_reviews.len(), 4);
+        assert!(result
+            .trace
+            .controlled_output_reviews
+            .iter()
+            .any(|review| review.requires_human_review));
+        assert!(plot_state_after
+            .current_chapter
+            .summary
+            .contains("NoName提示"));
+        let diagnostics = plot_state_after
+            .last_generation_diagnostics
+            .as_deref()
+            .unwrap_or_default();
+        assert!(diagnostics.contains("NoName选项偏置"));
+        assert!(diagnostics.contains("NoName.assisted"));
+        assert!(diagnostics.contains("proposal_status=applied"));
+        assert!(diagnostics.contains("apply=applied_scoped_outputs"));
+        assert!(result
+            .trace
+            .apply_execution_log
+            .iter()
+            .any(|item| item.target == "chapter_summary_hint" && item.outcome == "applied"));
+        assert!(result
+            .trace
+            .apply_execution_log
+            .iter()
+            .any(|item| item.target == "option_bias_hint" && item.outcome == "applied"));
+    }
+
+    #[tokio::test]
+    async fn test_mark_noname_controlled_output_review_records_human_intent() {
+        let _guard = noname_mode_matrix_lock()
+            .lock()
+            .expect("mode matrix lock should be available");
+        reset_noname_runtime_for_mode_test(NoNameMode::Assisted);
+
+        let mut trace = NoNameTrace::empty(
+            "trace-review-1",
+            "session-1",
+            "turn-1",
+            NoNameMode::Assisted,
+        );
+        trace.record_proposal(crate::noname_types::NoNameProposal {
+            proposal_id: "proposal-review".to_string(),
+            kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "Director提案：山门危机".to_string(),
+            summary: "建议优先观察山门危机".to_string(),
+            focus: "山门危机".to_string(),
+            target_segment: crate::noname_types::NoNameTargetSegment::CurrentTurnTail,
+            intended_effect: "为下一轮低风险输出提供导向".to_string(),
+            rationale: "当前章节冲突正在汇聚".to_string(),
+            suggested_action: Some("进入人工确认后的二次 guardrail".to_string()),
+            labels: vec!["director".to_string(), "apply_preflight_ready".to_string()],
+            apply_scopes: vec![crate::noname_types::NoNameApplyScope::PlotTextHint],
+            status: crate::noname_types::NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            crate::noname_output_interface::NoNameControlledOutputKind::SceneAugmentation,
+            vec![crate::noname_output_interface::NoNameForbiddenOutputScope::FinalPlotState],
+            crate::noname_output_interface::NoNameControlledOutputReview {
+                request_id: "controlled-output-proposal-review-plot_text_hint".to_string(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "plot text hint requires human review".to_string(),
+                normalized_kind: Some(
+                    crate::noname_output_interface::NoNameControlledOutputKind::SceneAugmentation,
+                ),
+                safe_apply_scope: Some(crate::noname_types::NoNameApplyScope::PlotTextHint),
+                requires_human_review: true,
+            },
+        );
+
+        noname_runtime()
+            .lock()
+            .expect("noname runtime lock should be available")
+            .store_trace(trace)
+            .expect("trace should be stored");
+
+        let updated = mark_noname_controlled_output_review(
+            "trace-review-1".to_string(),
+            "controlled-output-proposal-review-plot_text_hint".to_string(),
+            NoNameHumanReviewDecision::ApprovedForHigherApply,
+        )
+        .await
+        .expect("review intent should be recorded");
+
+        let review = updated
+            .controlled_output_reviews
+            .iter()
+            .find(|item| item.request_id == "controlled-output-proposal-review-plot_text_hint")
+            .expect("review should exist");
+        assert_eq!(
+            review.human_review_decision,
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply)
+        );
+        assert!(review.human_reviewed_at.is_some());
+        assert!(review
+            .human_review_note
+            .as_ref()
+            .is_some_and(|note| note.contains("二次 guardrail")));
+        assert!(updated
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry
+                == "controlled-output-proposal-review-plot_text_hint:human_review:approved_for_higher_apply"));
+        assert!(updated.apply_plan_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.decision == "review_intent_ready"
+        }));
+        assert!(updated.apply_execution_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.outcome == "awaiting_second_guardrail"
+        }));
+        assert!(updated.proposal_transition_log.iter().any(|entry| entry
+            == "controlled-output-proposal-review-plot_text_hint:apply_intent:awaiting_second_guardrail"));
+        assert_eq!(
+            noname_runtime()
+                .lock()
+                .expect("noname runtime lock should be available")
+                .get_recent_traces()[0]
+                .controlled_output_reviews[0]
+                .human_review_decision,
+            Some(NoNameHumanReviewDecision::ApprovedForHigherApply)
+        );
+
+        let resolved = resolve_noname_second_guardrail(
+            "trace-review-1".to_string(),
+            "controlled-output-proposal-review-plot_text_hint".to_string(),
+            NoNameSecondGuardrailDecision::Allow,
+        )
+        .await
+        .expect("second guardrail should resolve");
+
+        assert!(resolved.apply_plan_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.decision == "second_guardrail_allow"
+        }));
+        assert!(resolved.apply_execution_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.outcome == "second_guardrail_allowed"
+        }));
+        assert!(resolved.proposal_transition_log.iter().any(|entry| {
+            entry == "controlled-output-proposal-review-plot_text_hint:second_guardrail:allow"
+        }));
+        assert_eq!(
+            resolved
+                .apply_result
+                .as_ref()
+                .map(|item| item.outcome.as_str()),
+            Some("second_guardrail_allow")
+        );
+
+        let plot_state = PlotState {
+            current_scene: crate::plot_engine::Scene {
+                id: "scene-1".to_string(),
+                name: "山门".to_string(),
+                description: "你看见山门风声渐紧。".to_string(),
+                location: "sect".to_string(),
+                available_options: vec![make_option(0, "继续观察")],
+            },
+            plot_history: vec!["你看见山门风声渐紧。".to_string()],
+            is_waiting_for_input: true,
+            interaction_state: PlotInteractionState::WaitingForChoice,
+            last_action_result: Some(crate::numerical_system::ActionResult {
+                success: true,
+                description: "你看见山门风声渐紧。".to_string(),
+                stat_changes: vec![],
+                events: vec![],
+            }),
+            settings: PlotSettings::default(),
+            current_chapter: crate::plot_engine::ChapterState {
+                index: 1,
+                title: "第一章".to_string(),
+                content: vec!["你看见山门风声渐紧。".to_string()],
+                summary: String::new(),
+                interaction_count: 1,
+                status: crate::plot_engine::ChapterLifecycle::InProgress,
+            },
+            chapters: vec![],
+            segment_count: 1,
+            last_generation_diagnostics: None,
+            last_option_generation_source: None,
+            last_consistency_risk_score: None,
+        };
+        let applied = apply_noname_manual_plot_text_hint_to_plot_state(
+            resolved,
+            "controlled-output-proposal-review-plot_text_hint",
+            plot_state,
+            1,
+            0,
+            "你看见山门风声渐紧。",
+        )
+        .expect("manual apply should update plot text");
+        assert!(applied.plot_state.current_chapter.content[0].contains("【NoName】重点关注"));
+        assert!(applied
+            .plot_state
+            .plot_history
+            .last()
+            .is_some_and(|item| item.contains("【NoName】重点关注")));
+        assert!(applied.trace.apply_execution_log.iter().any(|item| {
+            item.target == "plot_text_hint" && item.outcome == "manual_plot_text_applied"
+        }));
     }
 
     #[test]

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -16,7 +16,8 @@ use crate::llm_service::{LLMConfig, LLMRequest, LLMService};
 use crate::memory_layers::{ChapterSummary, MemoryEntry, WorldFact};
 use crate::noname_apply::{
     apply_reviewed_output_to_plot_state, NoNameApplyDiagnosticsSnapshot,
-    NoNameApplySegmentSnapshot, NoNameApplySummarySnapshot, NoNameReviewedApplyRequest,
+    NoNameApplyPlotAugmentationSnapshot, NoNameApplySegmentSnapshot, NoNameApplySummarySnapshot,
+    NoNameReviewedApplyRequest,
 };
 use crate::noname_config::NoNameConfig;
 use crate::noname_context_builder::build_context_packet;
@@ -186,7 +187,7 @@ fn target_segment_supports_apply_scope(
     scope: NoNameApplyScope,
 ) -> bool {
     match scope {
-        NoNameApplyScope::PlotTextHint => matches!(
+        NoNameApplyScope::PlotTextHint | NoNameApplyScope::PlotAugmentationHint => matches!(
             target_segment,
             NoNameTargetSegment::CurrentTurnHead | NoNameTargetSegment::CurrentTurnTail
         ),
@@ -218,6 +219,7 @@ pub struct NoNameManualPlotTextApplyResult {
 fn priority_for_apply_scope(scope: NoNameApplyScope) -> u32 {
     match scope {
         NoNameApplyScope::PlotTextHint => 300,
+        NoNameApplyScope::PlotAugmentationHint => 250,
         NoNameApplyScope::ChapterSummaryHint => 200,
         NoNameApplyScope::OptionBiasHint => 100,
         NoNameApplyScope::Diagnostics => 50,
@@ -282,6 +284,53 @@ fn plan_noname_apply_target(
                     decision: NoNameApplyTargetDecision::Skip {
                         outcome: "skipped_duplicate",
                         note: "正文已包含 NoName 标记，跳过重复提示".to_string(),
+                    },
+                };
+            }
+        }
+        NoNameApplyScope::PlotAugmentationHint => {
+            let Some(state) = plot_state else {
+                return NoNameApplyTargetPlan {
+                    target,
+                    priority,
+                    order: 0,
+                    decision: NoNameApplyTargetDecision::Skip {
+                        outcome: "skipped_missing_plot_state",
+                        note: "缺少 plot_state，跳过剧情增强提示".to_string(),
+                    },
+                };
+            };
+            if !state.is_waiting_for_input {
+                return NoNameApplyTargetPlan {
+                    target,
+                    priority,
+                    order: 0,
+                    decision: NoNameApplyTargetDecision::Skip {
+                        outcome: "skipped_not_waiting",
+                        note: "当前不处于等待输入状态，跳过剧情增强提示".to_string(),
+                    },
+                };
+            }
+            let hint = format!(
+                "NoName plot augmentation: focus={} | effect={}",
+                proposal.focus.trim(),
+                proposal.intended_effect.trim()
+            );
+            if state
+                .pending_plot_augmentation_hints
+                .iter()
+                .any(|existing| existing == &hint)
+            {
+                return NoNameApplyTargetPlan {
+                    target,
+                    priority,
+                    order: 0,
+                    decision: NoNameApplyTargetDecision::Skip {
+                        outcome: "skipped_duplicate",
+                        note: format!(
+                            "剧情增强提示已包含“{}”，跳过重复写入",
+                            proposal.focus.trim()
+                        ),
                     },
                 };
             }
@@ -370,6 +419,12 @@ fn build_noname_apply_plan_set(
             NoNameApplyScope::PlotTextHint,
             plot_state,
             plot_text,
+        ),
+        plan_noname_apply_target(
+            proposal,
+            NoNameApplyScope::PlotAugmentationHint,
+            plot_state,
+            None,
         ),
         plan_noname_apply_target(
             proposal,
@@ -486,12 +541,16 @@ fn record_noname_human_review_apply_intent(
         NoNameHumanReviewDecision::ApprovedForHigherApply => {
             let rejection_reason = if trace.mode != NoNameMode::Assisted {
                 Some("当前 trace 不是 assisted 模式，拒绝进入高层 apply intent".to_string())
-            } else if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+            } else if !matches!(
+                safe_apply_scope,
+                Some(NoNameApplyScope::PlotTextHint | NoNameApplyScope::PlotAugmentationHint)
+            ) {
                 Some(format!(
-                    "当前仅允许 plot_text_hint 进入人工确认后的二次 guardrail，实际作用域为 {}",
+                    "当前仅允许 plot_text_hint / plot_augmentation_hint 进入人工确认后的二次 guardrail，实际作用域为 {}",
                     target
                 ))
             } else {
+                let scope = safe_apply_scope.unwrap_or(NoNameApplyScope::PlotTextHint);
                 match find_review_proposal(trace, request_id) {
                     Some(proposal)
                         if proposal.status
@@ -499,7 +558,7 @@ fn record_noname_human_review_apply_intent(
                             && proposal.applyable
                             && target_segment_supports_apply_scope(
                                 proposal.target_segment,
-                                NoNameApplyScope::PlotTextHint,
+                                scope,
                             ) =>
                     {
                         None
@@ -516,8 +575,9 @@ fn record_noname_human_review_apply_intent(
                         ))
                     }
                     Some(proposal) => Some(format!(
-                        "target_segment={} 不支持 plot_text_hint 二次 apply",
-                        proposal.target_segment.as_str()
+                        "target_segment={} 不支持 {} 二次 apply",
+                        proposal.target_segment.as_str(),
+                        scope.as_str()
                     )),
                     None => {
                         Some("未找到 review 对应 proposal，拒绝进入高层 apply intent".to_string())
@@ -569,10 +629,10 @@ fn review_is_waiting_for_second_guardrail(trace: &NoNameTrace, request_id: &str)
         .proposal_transition_log
         .iter()
         .any(|entry| entry == &transition)
-        || trace.apply_execution_log.iter().any(|entry| {
-            entry.outcome == "awaiting_second_guardrail"
-                && entry.target == NoNameApplyScope::PlotTextHint.as_str()
-        })
+        || trace
+            .apply_execution_log
+            .iter()
+            .any(|entry| entry.outcome == "awaiting_second_guardrail")
 }
 
 fn second_guardrail_revalidation_reason(
@@ -583,8 +643,16 @@ fn second_guardrail_revalidation_reason(
     if trace.mode != NoNameMode::Assisted {
         return Some("当前 trace 不是 assisted 模式，二次 guardrail 拒绝".to_string());
     }
-    if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
-        return Some("当前二次 guardrail 只允许处理 plot_text_hint".to_string());
+    let Some(scope) = safe_apply_scope else {
+        return Some("二次 guardrail 缺少 safe_apply_scope".to_string());
+    };
+    if !matches!(
+        scope,
+        NoNameApplyScope::PlotTextHint | NoNameApplyScope::PlotAugmentationHint
+    ) {
+        return Some(
+            "当前二次 guardrail 只允许处理 plot_text_hint / plot_augmentation_hint".to_string(),
+        );
     }
     if !review_is_waiting_for_second_guardrail(trace, request_id) {
         return Some("review 尚未进入 awaiting_second_guardrail 队列".to_string());
@@ -594,10 +662,7 @@ fn second_guardrail_revalidation_reason(
         Some(proposal)
             if proposal.status == crate::noname_types::NoNameProposalStatus::Applied
                 && proposal.applyable
-                && target_segment_supports_apply_scope(
-                    proposal.target_segment,
-                    NoNameApplyScope::PlotTextHint,
-                ) =>
+                && target_segment_supports_apply_scope(proposal.target_segment, scope) =>
         {
             None
         }
@@ -612,8 +677,9 @@ fn second_guardrail_revalidation_reason(
             ))
         }
         Some(proposal) => Some(format!(
-            "target_segment={} 不支持 plot_text_hint 二次 guardrail",
-            proposal.target_segment.as_str()
+            "target_segment={} 不支持 {} 二次 guardrail",
+            proposal.target_segment.as_str(),
+            scope.as_str()
         )),
         None => Some("未找到 review 对应 proposal，二次 guardrail 拒绝".to_string()),
     }
@@ -735,6 +801,7 @@ fn apply_noname_manual_plot_text_hint_to_plot_state(
             }),
             summary_snapshot: None,
             diagnostics_snapshot: None,
+            plot_augmentation_snapshot: None,
         },
         plot_state,
     )?;
@@ -744,7 +811,7 @@ fn apply_noname_manual_plot_text_hint_to_plot_state(
     })
 }
 
-fn build_noname_reviewed_apply_request(
+struct NoNameReviewedApplyCommandInput {
     request_id: String,
     scope: NoNameApplyScope,
     chapter_index: Option<u32>,
@@ -752,48 +819,73 @@ fn build_noname_reviewed_apply_request(
     expected_segment_text: Option<String>,
     expected_summary: Option<String>,
     expected_generation_diagnostics: Option<String>,
+    expected_plot_augmentation_hints: Option<Vec<String>>,
+}
+
+fn build_noname_reviewed_apply_request(
+    input: NoNameReviewedApplyCommandInput,
 ) -> Result<NoNameReviewedApplyRequest, String> {
-    let segment_snapshot = match scope {
+    let segment_snapshot = match input.scope {
         NoNameApplyScope::PlotTextHint => Some(NoNameApplySegmentSnapshot {
-            chapter_index: chapter_index
+            chapter_index: input
+                .chapter_index
                 .ok_or_else(|| "plot_text_hint manual apply requires chapter_index".to_string())?,
-            segment_index: segment_index
+            segment_index: input
+                .segment_index
                 .ok_or_else(|| "plot_text_hint manual apply requires segment_index".to_string())?,
-            expected_segment_text: expected_segment_text.ok_or_else(|| {
+            expected_segment_text: input.expected_segment_text.ok_or_else(|| {
                 "plot_text_hint manual apply requires expected_segment_text".to_string()
             })?,
         }),
         _ => None,
     };
-    let summary_snapshot = match scope {
+    let summary_snapshot = match input.scope {
         NoNameApplyScope::ChapterSummaryHint => Some(NoNameApplySummarySnapshot {
-            chapter_index: chapter_index.ok_or_else(|| {
+            chapter_index: input.chapter_index.ok_or_else(|| {
                 "chapter_summary_hint manual apply requires chapter_index".to_string()
             })?,
-            expected_summary: expected_summary.ok_or_else(|| {
+            expected_summary: input.expected_summary.ok_or_else(|| {
                 "chapter_summary_hint manual apply requires expected_summary".to_string()
             })?,
         }),
         _ => None,
     };
-    let diagnostics_snapshot = match scope {
+    let diagnostics_snapshot = match input.scope {
         NoNameApplyScope::OptionBiasHint => Some(NoNameApplyDiagnosticsSnapshot {
-            chapter_index: chapter_index.ok_or_else(|| {
+            chapter_index: input.chapter_index.ok_or_else(|| {
                 "option_bias_hint manual apply requires chapter_index".to_string()
             })?,
-            expected_generation_diagnostics: expected_generation_diagnostics.ok_or_else(|| {
-                "option_bias_hint manual apply requires expected_generation_diagnostics".to_string()
+            expected_generation_diagnostics: input.expected_generation_diagnostics.ok_or_else(
+                || {
+                    "option_bias_hint manual apply requires expected_generation_diagnostics"
+                        .to_string()
+                },
+            )?,
+        }),
+        _ => None,
+    };
+    let plot_augmentation_snapshot = match input.scope {
+        NoNameApplyScope::PlotAugmentationHint => Some(NoNameApplyPlotAugmentationSnapshot {
+            chapter_index: input.chapter_index.ok_or_else(|| {
+                "plot_augmentation_hint manual apply requires chapter_index".to_string()
             })?,
+            expected_plot_augmentation_hints: input.expected_plot_augmentation_hints.ok_or_else(
+                || {
+                    "plot_augmentation_hint manual apply requires expected_plot_augmentation_hints"
+                        .to_string()
+                },
+            )?,
         }),
         _ => None,
     };
 
     Ok(NoNameReviewedApplyRequest {
-        request_id,
-        scope,
+        request_id: input.request_id,
+        scope: input.scope,
         segment_snapshot,
         summary_snapshot,
         diagnostics_snapshot,
+        plot_augmentation_snapshot,
     })
 }
 
@@ -1145,6 +1237,19 @@ fn diagnostics_used_preset_fallback(diag: Option<&str>) -> bool {
         return false;
     };
     text.contains("已使用预设文本")
+}
+
+fn append_generation_diagnostic(existing: &mut Option<String>, note: impl Into<String>) {
+    let note = note.into();
+    match existing {
+        Some(diag) => {
+            diag.push('；');
+            diag.push_str(&note);
+        }
+        None => {
+            *existing = Some(note);
+        }
+    }
 }
 
 fn effective_consistency_report_after_option_resolution(
@@ -3627,6 +3732,7 @@ pub async fn execute_player_action(
     } else {
         build_plot_context_for_generation(&game_state, &plot_state, &action)
     };
+    let pending_plot_augmentation_snapshot = plot_state.pending_plot_augmentation_hints.clone();
     let mut plot_state_for_generation = plot_state.clone();
     let narrative_hint =
         narrative_density_and_pacing_hint(plot_state.current_chapter.interaction_count);
@@ -3644,7 +3750,7 @@ pub async fn execute_player_action(
         }
     }
 
-    let cache_key = if quick_mode {
+    let cache_key = if quick_mode || !pending_plot_augmentation_snapshot.is_empty() {
         None
     } else {
         Some(build_action_plot_cache_key(
@@ -3899,6 +4005,7 @@ pub async fn execute_player_action(
     }
 
     // Phase 2: 双通道（state_patch + narrative）优先，失败则保留现有 plot_engine 结果。
+    let mut plot_update_overridden_by_turn_update = false;
     if !quick_mode {
         if let Some(mut registry) = world_registry.clone() {
             let turn_update_started = Instant::now();
@@ -3979,6 +4086,7 @@ pub async fn execute_player_action(
                         if entity_ref_ok {
                             if !narrative.is_empty() {
                                 plot_update.plot_text = narrative;
+                                plot_update_overridden_by_turn_update = true;
                             }
                             if !turn_result.choices.is_empty() {
                                 plot_update.available_options =
@@ -4127,6 +4235,68 @@ pub async fn execute_player_action(
     }
 
     plot_state.last_generation_diagnostics = plot_update.generation_diagnostics.clone();
+    let mut pending_plot_augmentation_trace: Option<(String, String)> = None;
+    if !pending_plot_augmentation_snapshot.is_empty() {
+        let should_consume_pending_plot_augmentation = !quick_mode
+            && !plot_update_overridden_by_turn_update
+            && !diagnostics_used_preset_fallback(plot_state.last_generation_diagnostics.as_deref());
+        if should_consume_pending_plot_augmentation {
+            match plot_state
+                .consume_pending_plot_augmentation_hints(&pending_plot_augmentation_snapshot)
+            {
+                Ok(consumed) => {
+                    let note = format!(
+                        "pending plot augmentation consumed after plot_engine generation; count={}",
+                        consumed
+                    );
+                    append_generation_diagnostic(
+                        &mut plot_state.last_generation_diagnostics,
+                        format!("NoName pending plot augmentation consumed={}", consumed),
+                    );
+                    pending_plot_augmentation_trace =
+                        Some(("pending_plot_augmentation_consumed".to_string(), note));
+                }
+                Err(err) => {
+                    let note = format!(
+                        "pending plot augmentation retained because snapshot changed: {}",
+                        err
+                    );
+                    append_generation_diagnostic(
+                        &mut plot_state.last_generation_diagnostics,
+                        format!("NoName pending plot augmentation retained({})", err),
+                    );
+                    pending_plot_augmentation_trace =
+                        Some(("pending_plot_augmentation_retained".to_string(), note));
+                }
+            }
+        } else {
+            let retain_reason = if quick_mode {
+                "quick_mode"
+            } else if plot_update_overridden_by_turn_update {
+                "turn_update_override"
+            } else if diagnostics_used_preset_fallback(
+                plot_state.last_generation_diagnostics.as_deref(),
+            ) {
+                "preset_fallback"
+            } else {
+                "no_llm_consumption"
+            };
+            let note = format!(
+                "pending plot augmentation retained because {}; count={}",
+                retain_reason,
+                pending_plot_augmentation_snapshot.len()
+            );
+            append_generation_diagnostic(
+                &mut plot_state.last_generation_diagnostics,
+                format!(
+                    "NoName pending plot augmentation retained({})",
+                    retain_reason
+                ),
+            );
+            pending_plot_augmentation_trace =
+                Some(("pending_plot_augmentation_retained".to_string(), note));
+        }
+    }
 
     // 用最新段落更新场景描述，避免选项生成长期绑定旧描述导致“选项不变”。
     if !plot_text_for_history.trim().is_empty() {
@@ -4381,6 +4551,17 @@ pub async fn execute_player_action(
     }
 
     if let Some(mut noname_result) = noname_result {
+        if let Some((outcome, note)) = pending_plot_augmentation_trace.take() {
+            noname_result.trace.record_apply_execution(
+                NoNameApplyScope::PlotAugmentationHint.as_str(),
+                outcome.as_str(),
+                Some(note),
+            );
+            noname_result.trace.record_proposal_transition(format!(
+                "{}:pending_plot_augmentation:{}",
+                noname_result.proposal.proposal_id, outcome
+            ));
+        }
         apply_noname_low_risk_outputs(
             &mut plot_state,
             &mut noname_result,
@@ -4589,9 +4770,10 @@ pub async fn apply_noname_reviewed_output(
     expected_segment_text: Option<String>,
     expected_summary: Option<String>,
     expected_generation_diagnostics: Option<String>,
+    expected_plot_augmentation_hints: Option<Vec<String>>,
     engine: State<'_, Mutex<GameEngine>>,
 ) -> Result<NoNameManualPlotTextApplyResult, String> {
-    let request = build_noname_reviewed_apply_request(
+    let request = build_noname_reviewed_apply_request(NoNameReviewedApplyCommandInput {
         request_id,
         scope,
         chapter_index,
@@ -4599,7 +4781,8 @@ pub async fn apply_noname_reviewed_output(
         expected_segment_text,
         expected_summary,
         expected_generation_diagnostics,
-    )?;
+        expected_plot_augmentation_hints,
+    })?;
     let trace = {
         let runtime = noname_runtime()
             .lock()
@@ -7202,6 +7385,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
 
         let summary = build_noname_action_summary(&action, &plot_state);
@@ -7217,6 +7401,13 @@ mod tests {
             focus: "山门危机".to_string(),
             rationale: "应优先观察山门危机".to_string(),
             prompt_preview: "prompt".to_string(),
+            role_goal: None,
+            scene_focus: None,
+            forbidden_scopes: Vec::new(),
+            note_type_hits: Vec::new(),
+            source_stats: Vec::new(),
+            context_token_budget_used: None,
+            context_slice_stats: Vec::new(),
             proposal: crate::noname_types::NoNameProposal {
                 proposal_id: "proposal-1".to_string(),
                 kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -7370,12 +7561,17 @@ mod tests {
             crate::noname_types::NoNameProposalStatus::Applied
         );
         assert!(result.proposal.applyable);
-        assert_eq!(result.trace.controlled_output_reviews.len(), 4);
+        assert_eq!(result.trace.controlled_output_reviews.len(), 5);
         assert!(result
             .trace
             .controlled_output_reviews
             .iter()
             .any(|review| review.requires_human_review));
+        assert!(result.trace.controlled_output_reviews.iter().any(|review| {
+            review.safe_apply_scope
+                == Some(crate::noname_types::NoNameApplyScope::PlotAugmentationHint)
+                && review.requires_human_review
+        }));
         assert!(plot_state_after
             .current_chapter
             .summary
@@ -7551,6 +7747,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
         let applied = apply_noname_manual_plot_text_hint_to_plot_state(
             resolved,
@@ -7593,6 +7790,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
         let mut result = NoNameDirectorRunResult {
             trace: NoNameTrace {
@@ -7620,6 +7818,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-1".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -7735,6 +7940,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-plot-text".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -7817,6 +8029,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-plot-text-head".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -7883,6 +8102,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
         let mut result = NoNameDirectorRunResult {
             trace: NoNameTrace {
@@ -7910,6 +8130,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-scope".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -7995,6 +8222,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
         let mut result = NoNameDirectorRunResult {
             trace: NoNameTrace {
@@ -8022,6 +8250,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-summary-head".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -8095,6 +8330,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-plot-text-mismatch".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -8170,6 +8412,7 @@ mod tests {
             last_generation_diagnostics: None,
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
         let mut result = NoNameDirectorRunResult {
             trace: NoNameTrace {
@@ -8197,6 +8440,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-summary-duplicate".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,
@@ -8271,6 +8521,7 @@ mod tests {
             last_generation_diagnostics: Some(existing_hint.to_string()),
             last_option_generation_source: None,
             last_consistency_risk_score: None,
+            pending_plot_augmentation_hints: Vec::new(),
         };
         let mut result = NoNameDirectorRunResult {
             trace: NoNameTrace {
@@ -8298,6 +8549,13 @@ mod tests {
                 focus: "山门危机".to_string(),
                 rationale: "应优先观察山门危机".to_string(),
                 prompt_preview: "prompt".to_string(),
+                role_goal: None,
+                scene_focus: None,
+                forbidden_scopes: Vec::new(),
+                note_type_hits: Vec::new(),
+                source_stats: Vec::new(),
+                context_token_budget_used: None,
+                context_slice_stats: Vec::new(),
                 proposal: crate::noname_types::NoNameProposal {
                     proposal_id: "proposal-option-duplicate".to_string(),
                     kind: crate::noname_types::NoNameProposalKind::PlotCandidate,

--- a/src-tauri/src/world_registry.rs
+++ b/src-tauri/src/world_registry.rs
@@ -704,10 +704,7 @@ fn extract_unmarked_named_entities(text: &str) -> Vec<String> {
             .collect::<String>()
             .trim()
             .to_string();
-        loop {
-            let Some(first) = candidate.chars().next() else {
-                break;
-            };
+        while let Some(first) = candidate.chars().next() {
             let is_prefix = matches!(
                 first,
                 '在' | '于'

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -87,6 +87,28 @@
 
       <section class="agent-trace-card">
         <p class="agent-trace-card-title">
+          应用生命周期
+        </p>
+        <ul class="agent-trace-lifecycle">
+          <li
+            v-for="step in applyLifecycleSteps"
+            :key="step.key"
+            class="agent-trace-lifecycle-step"
+            :class="`is-${step.tone}`"
+          >
+            <div class="agent-trace-lifecycle-head">
+              <span class="agent-trace-main-line">{{ step.label }}</span>
+              <span class="agent-trace-lifecycle-state">{{ step.state }}</span>
+            </div>
+            <p class="agent-trace-muted">
+              {{ step.detail }}
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section class="agent-trace-card">
+        <p class="agent-trace-card-title">
           状态迁移
         </p>
         <p
@@ -210,6 +232,109 @@
             >
               策略禁区：{{ review.policyForbiddenScopes.join(' / ') }}
             </p>
+            <p
+              v-if="review.requiresHumanReview"
+              class="agent-trace-review-state"
+            >
+              {{ humanReviewDecisionLabel(review.requestId) }}
+            </p>
+            <div
+              v-if="review.requiresHumanReview"
+              class="agent-trace-review-actions"
+            >
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                :class="{ 'is-active': humanReviewDecision(review.requestId) === 'approvedForHigherApply' }"
+                @click="markHumanReview(review.requestId, 'approvedForHigherApply')"
+              >
+                标记可进入高层 apply 设计
+              </button>
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                :class="{ 'is-active': humanReviewDecision(review.requestId) === 'rejectedForHigherApply' }"
+                @click="markHumanReview(review.requestId, 'rejectedForHigherApply')"
+              >
+                暂不应用
+              </button>
+              <button
+                v-if="humanReviewDecision(review.requestId) !== 'pending'"
+                type="button"
+                class="agent-trace-review-btn agent-trace-review-btn-ghost"
+                @click="markHumanReview(review.requestId, 'pending')"
+              >
+                重置待复核
+              </button>
+            </div>
+            <div
+              v-if="humanReviewDecision(review.requestId) === 'approvedForHigherApply'"
+              class="agent-trace-review-actions"
+            >
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                @click="resolveSecondGuardrail(review.requestId, 'allow')"
+              >
+                二次护栏允许
+              </button>
+              <button
+                type="button"
+                class="agent-trace-review-btn"
+                @click="resolveSecondGuardrail(review.requestId, 'reject')"
+              >
+                二次护栏拒绝
+              </button>
+              <button
+                type="button"
+                class="agent-trace-review-btn agent-trace-review-btn-ghost"
+                @click="resolveSecondGuardrail(review.requestId, 'fallback')"
+              >
+                回退经典链路
+              </button>
+            </div>
+            <div
+              v-if="hasSecondGuardrailAllow(review.requestId)"
+              class="agent-trace-manual-preview"
+              :class="manualApplyPreview(review.requestId).toneClass"
+            >
+              <p class="agent-trace-main-line">
+                人工写入预览：{{ manualApplyPreview(review.requestId).statusLabel }}
+              </p>
+              <p class="agent-trace-muted">
+                {{ manualApplyPreview(review.requestId).statusText }}
+              </p>
+              <div
+                v-if="manualApplyPreview(review.requestId).before && manualApplyPreview(review.requestId).after"
+                class="agent-trace-manual-preview-grid"
+              >
+                <div>
+                  <p class="agent-trace-preview-label">
+                    写入前
+                  </p>
+                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review.requestId).before }}</pre>
+                </div>
+                <div>
+                  <p class="agent-trace-preview-label">
+                    写入后
+                  </p>
+                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review.requestId).after }}</pre>
+                </div>
+              </div>
+            </div>
+            <div
+              v-if="hasSecondGuardrailAllow(review.requestId)"
+              class="agent-trace-review-actions"
+            >
+              <button
+                type="button"
+                class="agent-trace-review-btn is-active"
+                :disabled="!manualApplyPreview(review.requestId).canApply"
+                @click="applyManualPlotTextHint(review.requestId)"
+              >
+                显式人工写入正文提示
+              </button>
+            </div>
           </li>
         </ul>
       </section>
@@ -311,18 +436,38 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { NoNameTrace } from '../types/game';
+import type {
+  NoNameHumanReviewDecision,
+  NoNameHumanReviewMarkPayload,
+  NoNameManualApplySegmentSnapshot,
+  NoNameManualPlotTextApplyPayload,
+  NoNameProposal,
+  NoNameSecondGuardrailDecision,
+  NoNameSecondGuardrailResolvePayload,
+  NoNameTrace,
+} from '../types/game';
+import { buildNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
   trace: NoNameTrace | null;
   selectedIndex?: number;
   totalCount?: number;
   activeMode?: string;
+  reviewDecisions?: Record<string, NoNameHumanReviewDecision>;
+  manualApplySegment?: NoNameManualApplySegmentSnapshot | null;
 }>(), {
   selectedIndex: 0,
   totalCount: 0,
   activeMode: '',
+  reviewDecisions: () => ({}),
+  manualApplySegment: null,
 });
+
+const emit = defineEmits<{
+  (event: 'mark-controlled-output-review', payload: NoNameHumanReviewMarkPayload): void;
+  (event: 'resolve-second-guardrail', payload: NoNameSecondGuardrailResolvePayload): void;
+  (event: 'apply-manual-plot-text-hint', payload: NoNameManualPlotTextApplyPayload): void;
+}>();
 
 const latestProposal = computed(() => {
   if (!props.trace || props.trace.proposals.length === 0) {
@@ -334,6 +479,9 @@ const latestProposal = computed(() => {
 const relatedObservations = computed(() => props.trace?.relatedObservations ?? []);
 const protocolEvents = computed(() => props.trace?.protocolEvents ?? []);
 const controlledOutputReviews = computed(() => props.trace?.controlledOutputReviews ?? []);
+const applyLifecycleSteps = computed(() => (
+  props.trace ? buildNoNameApplyLifecycle(props.trace, props.reviewDecisions) : []
+));
 
 const guardrailLabel = computed(() => {
   const result = props.trace?.guardrailResult;
@@ -350,6 +498,145 @@ const applyResultLabel = computed(() => {
   }
   return result.reason ? `${result.outcome} (${result.reason})` : result.outcome;
 });
+
+function humanReviewDecision(requestId: string): NoNameHumanReviewDecision {
+  return props.reviewDecisions[requestId] ?? 'pending';
+}
+
+function humanReviewDecisionLabel(requestId: string) {
+  const decision = humanReviewDecision(requestId);
+  if (decision === 'approvedForHigherApply') {
+    return '人工结论：可进入下一阶段 apply 设计；当前不会自动写入剧情正文。';
+  }
+  if (decision === 'rejectedForHigherApply') {
+    return '人工结论：暂不应用；保持当前安全边界。';
+  }
+  return '等待开发者确认：当前只记录，不会自动写入剧情正文。';
+}
+
+function markHumanReview(requestId: string, decision: NoNameHumanReviewDecision) {
+  if (!props.trace) {
+    return;
+  }
+  emit('mark-controlled-output-review', {
+    traceId: props.trace.traceId,
+    requestId,
+    decision,
+  });
+}
+
+function resolveSecondGuardrail(requestId: string, decision: NoNameSecondGuardrailDecision) {
+  if (!props.trace) {
+    return;
+  }
+  emit('resolve-second-guardrail', {
+    traceId: props.trace.traceId,
+    requestId,
+    decision,
+  });
+}
+
+function hasSecondGuardrailAllow(requestId: string) {
+  const transition = `${requestId}:second_guardrail:allow`;
+  return Boolean(props.trace?.proposalTransitionLog?.includes(transition))
+    || Boolean(props.trace?.applyExecutionLog?.some((item) => (
+      (item.target === 'plot_text_hint' || item.target === 'plotTextHint')
+      && item.outcome === 'second_guardrail_allowed'
+    )));
+}
+
+function hasManualPlotTextApplied(requestId: string) {
+  return Boolean(props.trace?.proposalTransitionLog?.includes(`${requestId}:manual_apply:plot_text_hint`))
+    || Boolean(props.trace?.applyExecutionLog?.some((item) => (
+      (item.target === 'plot_text_hint' || item.target === 'plotTextHint')
+      && item.outcome === 'manual_plot_text_applied'
+    )));
+}
+
+function findProposalForReview(requestId: string): NoNameProposal | null {
+  const proposals = props.trace?.proposals ?? [];
+  return [...proposals].reverse().find((proposal) => requestId.includes(proposal.proposalId))
+    ?? proposals[proposals.length - 1]
+    ?? null;
+}
+
+function buildManualPlotText(proposal: NoNameProposal, segmentText: string) {
+  const hint = `【NoName】重点关注：${proposal.focus}`;
+  if (proposal.targetSegment === 'current_turn_head') {
+    return `${hint}\n\n${segmentText.trim()}`;
+  }
+  return `${segmentText.trim()}\n\n${hint}`;
+}
+
+function manualApplyPreview(requestId: string) {
+  if (hasManualPlotTextApplied(requestId)) {
+    return {
+      canApply: false,
+      toneClass: 'is-safe',
+      statusLabel: '已写入',
+      statusText: '这条 review 已记录 manual_plot_text_applied，避免重复写入同一条正文提示。',
+      before: '',
+      after: '',
+    };
+  }
+
+  const segment = props.manualApplySegment;
+  if (!segment || !segment.text.trim()) {
+    return {
+      canApply: false,
+      toneClass: 'is-warn',
+      statusLabel: '缺少当前段落快照',
+      statusText: '当前剧情段落为空，无法执行显式人工写入。',
+      before: '',
+      after: '',
+    };
+  }
+
+  if (segment.text.includes('【NoName】') || segment.text.includes('NoName提示')) {
+    return {
+      canApply: false,
+      toneClass: 'is-warn',
+      statusLabel: '疑似已包含 NoName 标记',
+      statusText: '当前段落已经包含 NoName 标记，为避免重复写入，按钮已禁用。',
+      before: segment.text,
+      after: '',
+    };
+  }
+
+  const proposal = findProposalForReview(requestId);
+  if (!proposal) {
+    return {
+      canApply: false,
+      toneClass: 'is-warn',
+      statusLabel: '找不到关联提案',
+      statusText: '无法从 requestId 反查 proposal，暂不允许写入。',
+      before: segment.text,
+      after: '',
+    };
+  }
+
+  return {
+    canApply: true,
+    toneClass: 'is-ready',
+    statusLabel: `将写入第 ${segment.chapterIndex} 章第 ${segment.segmentIndex + 1} 段`,
+    statusText: '请确认下方差异预览无误；后端还会再次校验章节、段落和正文快照。',
+    before: segment.text,
+    after: buildManualPlotText(proposal, segment.text),
+  };
+}
+
+function applyManualPlotTextHint(requestId: string) {
+  if (!props.trace) {
+    return;
+  }
+  if (!manualApplyPreview(requestId).canApply) {
+    return;
+  }
+  emit('apply-manual-plot-text-hint', {
+    traceId: props.trace.traceId,
+    requestId,
+  });
+}
 </script>
 
 <style scoped>
@@ -456,6 +743,51 @@ const applyResultLabel = computed(() => {
   gap: 8px;
 }
 
+.agent-trace-lifecycle {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.agent-trace-lifecycle-step {
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 72%, transparent);
+  background: color-mix(in srgb, var(--ink-card-bg) 90%, transparent);
+  padding: 10px 12px;
+}
+
+.agent-trace-lifecycle-step.is-done {
+  border-color: color-mix(in srgb, #2f6b4b 46%, var(--ink-border-soft));
+}
+
+.agent-trace-lifecycle-step.is-pending {
+  border-color: color-mix(in srgb, var(--ink-accent-main) 54%, var(--ink-border-soft));
+}
+
+.agent-trace-lifecycle-step.is-blocked,
+.agent-trace-lifecycle-step.is-fallback {
+  border-color: color-mix(in srgb, #9b4d2e 54%, var(--ink-border-soft));
+}
+
+.agent-trace-lifecycle-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+
+.agent-trace-lifecycle-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-accent) 72%, transparent);
+  padding: 3px 8px;
+  color: var(--ink-text-muted);
+  font-size: 12px;
+}
+
 .agent-trace-row {
   display: grid;
   gap: 4px;
@@ -465,8 +797,111 @@ const applyResultLabel = computed(() => {
   padding: 10px 12px;
 }
 
+.agent-trace-review-state {
+  margin: 8px 0 0;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-accent) 72%, transparent);
+  background: color-mix(in srgb, var(--ink-accent-main) 10%, var(--ink-card-bg));
+  color: var(--ink-text-primary);
+  padding: 8px 10px;
+  line-height: 1.5;
+}
+
+.agent-trace-review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.agent-trace-manual-preview {
+  margin-top: 10px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 72%, transparent);
+  background: color-mix(in srgb, var(--ink-card-bg) 90%, transparent);
+  padding: 10px 12px;
+}
+
+.agent-trace-manual-preview.is-ready {
+  border-color: color-mix(in srgb, #2f6b4b 44%, var(--ink-border-soft));
+}
+
+.agent-trace-manual-preview.is-warn {
+  border-color: color-mix(in srgb, #9b4d2e 54%, var(--ink-border-soft));
+}
+
+.agent-trace-manual-preview.is-safe {
+  border-color: color-mix(in srgb, var(--ink-accent-main) 48%, var(--ink-border-soft));
+}
+
+.agent-trace-manual-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.agent-trace-preview-label {
+  margin: 0 0 6px;
+  color: var(--ink-text-muted);
+  font-size: 12px;
+}
+
+.agent-trace-preview-text {
+  margin: 0;
+  max-height: 170px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--ink-border-soft) 70%, transparent);
+  background: color-mix(in srgb, var(--ink-card-bg-soft) 88%, transparent);
+  padding: 8px;
+  color: var(--ink-text-primary);
+  font-family: "LXGW WenKai", "Noto Serif SC", serif;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.agent-trace-review-btn {
+  border: 1px solid color-mix(in srgb, var(--ink-border-accent) 78%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink-card-bg) 92%, transparent);
+  color: var(--ink-text-primary);
+  cursor: pointer;
+  padding: 7px 10px;
+  transition: background-color 180ms ease, border-color 180ms ease, transform 120ms ease;
+}
+
+.agent-trace-review-btn:hover {
+  transform: translateY(-1px);
+}
+
+.agent-trace-review-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+}
+
+.agent-trace-review-btn.is-active {
+  border-color: var(--ink-accent-main);
+  background: color-mix(in srgb, var(--ink-accent-main) 20%, var(--ink-card-bg));
+}
+
+.agent-trace-review-btn-ghost {
+  color: var(--ink-text-muted);
+}
+
 @media (max-width: 900px) {
   .agent-trace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-trace-lifecycle {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-trace-manual-preview-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -40,6 +40,7 @@
             <li>elapsedMs：{{ trace.elapsedMs }} ms</li>
             <li>guardrail：{{ guardrailLabel }}</li>
             <li>applyResult：{{ applyResultLabel }}</li>
+            <li>剧情增强提示：{{ pendingPlotAugmentationSummary }}</li>
           </ul>
         </section>
 
@@ -155,6 +156,36 @@
             </p>
             <p class="agent-trace-muted">
               焦点：{{ item.focus }} · 目标段：{{ item.proposal.targetSegment }}
+            </p>
+            <p
+              v-if="item.roleGoal || item.sceneFocus"
+              class="agent-trace-muted"
+            >
+              角色上下文：{{ item.roleGoal || '无角色目标' }} · {{ item.sceneFocus || '无场景焦点' }}
+            </p>
+            <p
+              v-if="item.forbiddenScopes?.length"
+              class="agent-trace-muted"
+            >
+              角色禁区：{{ item.forbiddenScopes.join(' / ') }}
+            </p>
+            <p
+              v-if="item.noteTypeHits?.length"
+              class="agent-trace-muted"
+            >
+              笔记命中：{{ item.noteTypeHits.join(' / ') }}
+            </p>
+            <p
+              v-if="item.sourceStats?.length || item.contextTokenBudgetUsed"
+              class="agent-trace-muted"
+            >
+              上下文来源：{{ formatSourceStats(item.sourceStats) }} · token={{ item.contextTokenBudgetUsed ?? 0 }}
+            </p>
+            <p
+              v-if="item.contextSliceStats?.length"
+              class="agent-trace-muted"
+            >
+              裁剪差异：{{ formatContextSliceStats(item.contextSliceStats) }}
             </p>
             <p class="agent-trace-muted">
               状态：{{ item.proposal.status || (item.proposal.applyable ? 'ready' : 'observed') }}
@@ -294,45 +325,45 @@
               </button>
             </div>
             <div
-              v-if="hasSecondGuardrailAllow(review.requestId)"
+              v-if="hasSecondGuardrailAllow(review.requestId, review.safeApplyScope)"
               class="agent-trace-manual-preview"
-              :class="manualApplyPreview(review.requestId).toneClass"
+              :class="manualApplyPreview(review).toneClass"
             >
               <p class="agent-trace-main-line">
                 人工写入预览：{{ manualApplyPreview(review.requestId).statusLabel }}
               </p>
               <p class="agent-trace-muted">
-                {{ manualApplyPreview(review.requestId).statusText }}
+                {{ manualApplyPreview(review).statusText }}
               </p>
               <div
-                v-if="manualApplyPreview(review.requestId).before && manualApplyPreview(review.requestId).after"
+                v-if="manualApplyPreview(review).before !== undefined && manualApplyPreview(review).after !== undefined"
                 class="agent-trace-manual-preview-grid"
               >
                 <div>
                   <p class="agent-trace-preview-label">
                     写入前
                   </p>
-                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review.requestId).before }}</pre>
+                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review).before }}</pre>
                 </div>
                 <div>
                   <p class="agent-trace-preview-label">
                     写入后
                   </p>
-                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review.requestId).after }}</pre>
+                  <pre class="agent-trace-preview-text">{{ manualApplyPreview(review).after }}</pre>
                 </div>
               </div>
             </div>
             <div
-              v-if="hasSecondGuardrailAllow(review.requestId)"
+              v-if="hasSecondGuardrailAllow(review.requestId, review.safeApplyScope)"
               class="agent-trace-review-actions"
             >
               <button
                 type="button"
                 class="agent-trace-review-btn is-active"
-                :disabled="!manualApplyPreview(review.requestId).canApply"
-                @click="applyManualPlotTextHint(review.requestId)"
+                :disabled="!manualApplyPreview(review).canApply"
+                @click="applyManualReviewedOutput(review)"
               >
-                显式人工写入正文提示
+                {{ manualApplyButtonLabel(review) }}
               </button>
             </div>
           </li>
@@ -392,7 +423,13 @@
               class="agent-trace-row"
             >
               <p class="agent-trace-main-line">
-                {{ execution.target }} · {{ execution.outcome }}
+                {{ applyExecutionDisplay(execution).targetLabel }} · {{ applyExecutionDisplay(execution).outcomeLabel }}
+              </p>
+              <p
+                v-if="applyExecutionDisplay(execution).targetLabel !== execution.target || applyExecutionDisplay(execution).outcomeLabel !== execution.outcome"
+                class="agent-trace-muted"
+              >
+                原始记录：{{ execution.target }} / {{ execution.outcome }}
               </p>
               <p
                 v-if="execution.note"
@@ -437,16 +474,31 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type {
+  NoNameApplyExecutionRecord,
+  NoNameContextSourceStat,
   NoNameHumanReviewDecision,
   NoNameHumanReviewMarkPayload,
+  NoNameManualApplyDiagnosticsSnapshot,
+  NoNameManualApplyPlotAugmentationSnapshot,
   NoNameManualApplySegmentSnapshot,
+  NoNameManualApplySummarySnapshot,
+  NoNameManualChapterSummaryHintApplyPayload,
+  NoNameManualOptionBiasHintApplyPayload,
+  NoNameManualPlotAugmentationHintApplyPayload,
   NoNameManualPlotTextApplyPayload,
+  NoNameApplyScope,
+  NoNameControlledOutputReviewRecord,
   NoNameProposal,
+  NoNameRoleContextSliceStat,
   NoNameSecondGuardrailDecision,
   NoNameSecondGuardrailResolvePayload,
   NoNameTrace,
 } from '../types/game';
-import { buildNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
+import {
+  buildNoNameApplyLifecycle,
+  formatNoNameApplyExecutionRecord,
+  summarizeNoNamePendingPlotAugmentation,
+} from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
   trace: NoNameTrace | null;
@@ -455,18 +507,27 @@ const props = withDefaults(defineProps<{
   activeMode?: string;
   reviewDecisions?: Record<string, NoNameHumanReviewDecision>;
   manualApplySegment?: NoNameManualApplySegmentSnapshot | null;
+  manualApplySummary?: NoNameManualApplySummarySnapshot | null;
+  manualApplyDiagnostics?: NoNameManualApplyDiagnosticsSnapshot | null;
+  manualApplyPlotAugmentations?: NoNameManualApplyPlotAugmentationSnapshot | null;
 }>(), {
   selectedIndex: 0,
   totalCount: 0,
   activeMode: '',
   reviewDecisions: () => ({}),
   manualApplySegment: null,
+  manualApplySummary: null,
+  manualApplyDiagnostics: null,
+  manualApplyPlotAugmentations: null,
 });
 
 const emit = defineEmits<{
   (event: 'mark-controlled-output-review', payload: NoNameHumanReviewMarkPayload): void;
   (event: 'resolve-second-guardrail', payload: NoNameSecondGuardrailResolvePayload): void;
   (event: 'apply-manual-plot-text-hint', payload: NoNameManualPlotTextApplyPayload): void;
+  (event: 'apply-manual-chapter-summary-hint', payload: NoNameManualChapterSummaryHintApplyPayload): void;
+  (event: 'apply-manual-option-bias-hint', payload: NoNameManualOptionBiasHintApplyPayload): void;
+  (event: 'apply-manual-plot-augmentation-hint', payload: NoNameManualPlotAugmentationHintApplyPayload): void;
 }>();
 
 const latestProposal = computed(() => {
@@ -482,6 +543,27 @@ const controlledOutputReviews = computed(() => props.trace?.controlledOutputRevi
 const applyLifecycleSteps = computed(() => (
   props.trace ? buildNoNameApplyLifecycle(props.trace, props.reviewDecisions) : []
 ));
+const pendingPlotAugmentationSummary = computed(() => (
+  props.trace ? summarizeNoNamePendingPlotAugmentation(props.trace) : '无'
+));
+
+function applyExecutionDisplay(execution: NoNameApplyExecutionRecord) {
+  return formatNoNameApplyExecutionRecord(execution);
+}
+
+function formatSourceStats(sourceStats: NoNameContextSourceStat[] | undefined) {
+  if (!sourceStats || sourceStats.length === 0) {
+    return '无';
+  }
+  return sourceStats.map((item) => `${item.source}:${item.count}`).join(' / ');
+}
+
+function formatContextSliceStats(sliceStats: NoNameRoleContextSliceStat[] | undefined) {
+  if (!sliceStats || sliceStats.length === 0) {
+    return '无';
+  }
+  return sliceStats.map((item) => `${item.section}:${item.sourceCount}->${item.visibleCount}`).join(' / ');
+}
 
 const guardrailLabel = computed(() => {
   const result = props.trace?.guardrailResult;
@@ -536,21 +618,59 @@ function resolveSecondGuardrail(requestId: string, decision: NoNameSecondGuardra
   });
 }
 
-function hasSecondGuardrailAllow(requestId: string) {
+function normalizeApplyScope(value: string | null | undefined) {
+  return (value ?? '').replace(/_/g, '').toLowerCase();
+}
+
+function scopeToTransitionSuffix(scope: NoNameApplyScope | null | undefined) {
+  if (scope === 'chapterSummaryHint') {
+    return 'chapter_summary_hint';
+  }
+  if (scope === 'optionBiasHint') {
+    return 'option_bias_hint';
+  }
+  if (scope === 'plotAugmentationHint') {
+    return 'plot_augmentation_hint';
+  }
+  if (scope === 'plotTextHint') {
+    return 'plot_text_hint';
+  }
+  return normalizeApplyScope(scope);
+}
+
+function manualApplyOutcome(scope: NoNameApplyScope | null | undefined) {
+  if (scope === 'chapterSummaryHint') {
+    return 'manual_chapter_summary_hint_applied';
+  }
+  if (scope === 'optionBiasHint') {
+    return 'manual_option_bias_hint_applied';
+  }
+  if (scope === 'plotAugmentationHint') {
+    return 'manual_plot_augmentation_hint_applied';
+  }
+  return 'manual_plot_text_applied';
+}
+
+function hasSecondGuardrailAllow(requestId: string, scope: NoNameApplyScope | null | undefined = 'plotTextHint') {
   const transition = `${requestId}:second_guardrail:allow`;
+  const target = normalizeApplyScope(scope);
   return Boolean(props.trace?.proposalTransitionLog?.includes(transition))
     || Boolean(props.trace?.applyExecutionLog?.some((item) => (
-      (item.target === 'plot_text_hint' || item.target === 'plotTextHint')
+      normalizeApplyScope(item.target) === target
       && item.outcome === 'second_guardrail_allowed'
     )));
 }
 
-function hasManualPlotTextApplied(requestId: string) {
-  return Boolean(props.trace?.proposalTransitionLog?.includes(`${requestId}:manual_apply:plot_text_hint`))
+function hasManualReviewedApplyApplied(requestId: string, scope: NoNameApplyScope | null | undefined = 'plotTextHint') {
+  return Boolean(props.trace?.proposalTransitionLog?.includes(`${requestId}:manual_apply:${scopeToTransitionSuffix(scope)}`))
     || Boolean(props.trace?.applyExecutionLog?.some((item) => (
-      (item.target === 'plot_text_hint' || item.target === 'plotTextHint')
-      && item.outcome === 'manual_plot_text_applied'
+      normalizeApplyScope(item.target) === normalizeApplyScope(scope)
+      && item.outcome === manualApplyOutcome(scope)
     )));
+}
+
+function hasManualPlotTextApplied(requestId: string) {
+  return hasManualReviewedApplyApplied(requestId, 'plotTextHint');
 }
 
 function findProposalForReview(requestId: string): NoNameProposal | null {
@@ -568,7 +688,149 @@ function buildManualPlotText(proposal: NoNameProposal, segmentText: string) {
   return `${segmentText.trim()}\n\n${hint}`;
 }
 
-function manualApplyPreview(requestId: string) {
+function manualApplyPreview(input: string | NoNameControlledOutputReviewRecord) {
+  const requestId = typeof input === 'string' ? input : input.requestId;
+  const scope: NoNameApplyScope | null | undefined = typeof input === 'string'
+    ? 'plotTextHint'
+    : input.safeApplyScope;
+  if (scope === 'chapterSummaryHint') {
+    const proposal = findProposalForReview(requestId);
+    const snapshot = props.manualApplySummary;
+    if (hasManualReviewedApplyApplied(requestId, scope)) {
+      return {
+        canApply: false,
+        toneClass: 'is-safe',
+        statusLabel: '已写入章节摘要提示',
+        statusText: '这条 review 已记录 manual_chapter_summary_hint_applied，避免重复写入。',
+        before: undefined,
+        after: undefined,
+      };
+    }
+    if (!proposal || !snapshot) {
+      return {
+        canApply: false,
+        toneClass: 'is-warn',
+        statusLabel: '缺少章节摘要快照',
+        statusText: '当前章节摘要或关联 proposal 不可用，无法执行显式写入。',
+        before: undefined,
+        after: undefined,
+      };
+    }
+    const hint = `NoName summary hint: ${proposal.focus.trim()}`;
+    const before = snapshot.summary;
+    if (before.includes(hint) || (proposal.focus.trim() && before.includes(proposal.focus.trim()))) {
+      return {
+        canApply: false,
+        toneClass: 'is-warn',
+        statusLabel: '摘要疑似已包含提示',
+        statusText: '当前章节摘要已经包含这条 NoName 提示或焦点，避免重复写入。',
+        before,
+        after: undefined,
+      };
+    }
+    const after = before.trim()
+      ? proposal.targetSegment === 'chapter_summary_head'
+        ? `${hint}; ${before.trim()}`
+        : `${before.trim()}; ${hint}`
+      : hint;
+    return {
+      canApply: true,
+      toneClass: 'is-ready',
+      statusLabel: `将写入第 ${snapshot.chapterIndex} 章摘要`,
+      statusText: '后端会再次校验章节和摘要快照，避免陈旧写入。',
+      before,
+      after,
+    };
+  }
+  if (scope === 'optionBiasHint') {
+    const proposal = findProposalForReview(requestId);
+    const snapshot = props.manualApplyDiagnostics;
+    if (hasManualReviewedApplyApplied(requestId, scope)) {
+      return {
+        canApply: false,
+        toneClass: 'is-safe',
+        statusLabel: '已写入选项偏置提示',
+        statusText: '这条 review 已记录 manual_option_bias_hint_applied，避免重复写入。',
+        before: undefined,
+        after: undefined,
+      };
+    }
+    if (!proposal || !snapshot) {
+      return {
+        canApply: false,
+        toneClass: 'is-warn',
+        statusLabel: '缺少诊断提示快照',
+        statusText: '当前 diagnostics 或关联 proposal 不可用，无法执行显式写入。',
+        before: undefined,
+        after: undefined,
+      };
+    }
+    const hint = `NoName option bias: next turn should prioritize actions around ${proposal.focus.trim()}`;
+    const before = snapshot.diagnostics;
+    if (before.includes(hint)) {
+      return {
+        canApply: false,
+        toneClass: 'is-warn',
+        statusLabel: '诊断提示已包含该偏置',
+        statusText: '当前 generation diagnostics 已包含这条 NoName 选项偏置提示，避免重复写入。',
+        before,
+        after: undefined,
+      };
+    }
+    return {
+      canApply: true,
+      toneClass: 'is-ready',
+      statusLabel: `将写入第 ${snapshot.chapterIndex} 章诊断提示`,
+      statusText: '后端会再次校验章节和 diagnostics 快照，避免陈旧写入。',
+      before,
+      after: before.trim() ? `${before}; ${hint}` : hint,
+    };
+  }
+  if (scope === 'plotAugmentationHint') {
+    const proposal = findProposalForReview(requestId);
+    const snapshot = props.manualApplyPlotAugmentations;
+    if (hasManualReviewedApplyApplied(requestId, scope)) {
+      return {
+        canApply: false,
+        toneClass: 'is-safe',
+        statusLabel: '已暂存剧情增强提示',
+        statusText: '这条 review 已记录 manual_plot_augmentation_hint_applied，避免重复写入。',
+        before: undefined,
+        after: undefined,
+      };
+    }
+    if (!proposal || !snapshot) {
+      return {
+        canApply: false,
+        toneClass: 'is-warn',
+        statusLabel: '缺少剧情增强快照',
+        statusText: '当前 pending augmentation 列表或关联 proposal 不可用，无法执行显式写入。',
+        before: undefined,
+        after: undefined,
+      };
+    }
+    const hint = `NoName plot augmentation: focus=${proposal.focus.trim()} | effect=${proposal.intendedEffect.trim()}`;
+    const beforeItems = snapshot.hints;
+    const before = beforeItems.length > 0 ? beforeItems.join('\n') : '（暂无暂存剧情增强提示）';
+    if (beforeItems.includes(hint)) {
+      return {
+        canApply: false,
+        toneClass: 'is-warn',
+        statusLabel: '剧情增强提示已存在',
+        statusText: '当前 pending augmentation 列表已包含这条 NoName 提示，避免重复写入。',
+        before,
+        after: undefined,
+      };
+    }
+    return {
+      canApply: true,
+      toneClass: 'is-ready',
+      statusLabel: `将暂存第 ${snapshot.chapterIndex} 章剧情增强提示`,
+      statusText: '这只进入 pending augmentation 列表，不直接改写最终正文或剧情状态机。',
+      before,
+      after: [...beforeItems, hint].join('\n'),
+    };
+  }
   if (hasManualPlotTextApplied(requestId)) {
     return {
       canApply: false,
@@ -625,17 +887,43 @@ function manualApplyPreview(requestId: string) {
   };
 }
 
-function applyManualPlotTextHint(requestId: string) {
+function manualApplyButtonLabel(review: NoNameControlledOutputReviewRecord) {
+  if (review.safeApplyScope === 'chapterSummaryHint') {
+    return '显式人工写入章节摘要提示';
+  }
+  if (review.safeApplyScope === 'optionBiasHint') {
+    return '显式人工写入选项偏置提示';
+  }
+  if (review.safeApplyScope === 'plotAugmentationHint') {
+    return '显式人工暂存剧情增强提示';
+  }
+  return '显式人工写入正文提示';
+}
+
+function applyManualReviewedOutput(review: NoNameControlledOutputReviewRecord) {
   if (!props.trace) {
     return;
   }
-  if (!manualApplyPreview(requestId).canApply) {
+  if (!manualApplyPreview(review).canApply) {
     return;
   }
-  emit('apply-manual-plot-text-hint', {
+  const payload = {
     traceId: props.trace.traceId,
-    requestId,
-  });
+    requestId: review.requestId,
+  };
+  if (review.safeApplyScope === 'chapterSummaryHint') {
+    emit('apply-manual-chapter-summary-hint', payload);
+    return;
+  }
+  if (review.safeApplyScope === 'optionBiasHint') {
+    emit('apply-manual-option-bias-hint', payload);
+    return;
+  }
+  if (review.safeApplyScope === 'plotAugmentationHint') {
+    emit('apply-manual-plot-augmentation-hint', payload);
+    return;
+  }
+  emit('apply-manual-plot-text-hint', payload);
 }
 </script>
 

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -204,6 +204,12 @@
             <p class="agent-trace-muted">
               {{ review.requiresHumanReview ? '需要人工复核' : '可自动通过' }} · {{ review.reason }}
             </p>
+            <p
+              v-if="review.policyForbiddenScopes?.length"
+              class="agent-trace-muted"
+            >
+              策略禁区：{{ review.policyForbiddenScopes.join(' / ') }}
+            </p>
           </li>
         </ul>
       </section>

--- a/src/components/GameRuntimeView.vue
+++ b/src/components/GameRuntimeView.vue
@@ -124,9 +124,13 @@
       :traces="gameStore.noNameTraces ?? []"
       :no-name-mode="noNameMode"
       :is-dev-mode="isDevMode"
+      :manual-apply-segment="manualApplySegment"
       @close="showNoNameDebugConsole = false"
       @clear-traces="gameStore.clearNoNameTraces()"
       @set-no-name-mode="setNoNameMode"
+      @mark-controlled-output-review="gameStore.markNoNameControlledOutputReview"
+      @resolve-second-guardrail="gameStore.resolveNoNameSecondGuardrail"
+      @apply-manual-plot-text-hint="gameStore.applyNoNameManualPlotTextHint"
     />
     <NotificationCenter
       v-if="runtimeNotifications.length > 0"
@@ -153,7 +157,7 @@ import NotificationCenter from './NotificationCenter.vue';
 import NoNameDebugConsole from './NoNameDebugConsole.vue';
 import RuntimeQuickPanelsDialog from './RuntimeQuickPanelsDialog.vue';
 import StoryViewport from './StoryViewport.vue';
-import type { ConsistencyPolicy, NoNameMode } from '../types/game';
+import type { ConsistencyPolicy, NoNameManualApplySegmentSnapshot, NoNameMode } from '../types/game';
 import { invokeRuntime } from '../utils/tauriInvoke';
 import {
   createFreeTextAction,
@@ -224,6 +228,18 @@ const hasNoNameTraceHistory = computed(() => (gameStore.noNameTraces?.length ?? 
 const noNameDebugText = computed(() => {
   const getter = (gameStore as { getNoNameTraceDebugText?: () => string }).getNoNameTraceDebugText;
   return typeof getter === 'function' ? getter.call(gameStore) : '暂无 NoName Agent Trace。';
+});
+const manualApplySegment = computed<NoNameManualApplySegmentSnapshot | null>(() => {
+  const chapter = gameStore.plotState?.current_chapter;
+  if (!chapter || chapter.content.length === 0) {
+    return null;
+  }
+  const segmentIndex = chapter.content.length - 1;
+  return {
+    chapterIndex: chapter.index,
+    segmentIndex,
+    text: chapter.content[segmentIndex] ?? '',
+  };
 });
 
 const refreshNoNameMode = async () => {

--- a/src/components/GameRuntimeView.vue
+++ b/src/components/GameRuntimeView.vue
@@ -125,12 +125,18 @@
       :no-name-mode="noNameMode"
       :is-dev-mode="isDevMode"
       :manual-apply-segment="manualApplySegment"
+      :manual-apply-summary="manualApplySummary"
+      :manual-apply-diagnostics="manualApplyDiagnostics"
+      :manual-apply-plot-augmentations="manualApplyPlotAugmentations"
       @close="showNoNameDebugConsole = false"
       @clear-traces="gameStore.clearNoNameTraces()"
       @set-no-name-mode="setNoNameMode"
       @mark-controlled-output-review="gameStore.markNoNameControlledOutputReview"
       @resolve-second-guardrail="gameStore.resolveNoNameSecondGuardrail"
       @apply-manual-plot-text-hint="gameStore.applyNoNameManualPlotTextHint"
+      @apply-manual-chapter-summary-hint="gameStore.applyNoNameManualChapterSummaryHint"
+      @apply-manual-option-bias-hint="gameStore.applyNoNameManualOptionBiasHint"
+      @apply-manual-plot-augmentation-hint="gameStore.applyNoNameManualPlotAugmentationHint"
     />
     <NotificationCenter
       v-if="runtimeNotifications.length > 0"
@@ -157,7 +163,14 @@ import NotificationCenter from './NotificationCenter.vue';
 import NoNameDebugConsole from './NoNameDebugConsole.vue';
 import RuntimeQuickPanelsDialog from './RuntimeQuickPanelsDialog.vue';
 import StoryViewport from './StoryViewport.vue';
-import type { ConsistencyPolicy, NoNameManualApplySegmentSnapshot, NoNameMode } from '../types/game';
+import type {
+  ConsistencyPolicy,
+  NoNameManualApplyDiagnosticsSnapshot,
+  NoNameManualApplyPlotAugmentationSnapshot,
+  NoNameManualApplySegmentSnapshot,
+  NoNameManualApplySummarySnapshot,
+  NoNameMode,
+} from '../types/game';
 import { invokeRuntime } from '../utils/tauriInvoke';
 import {
   createFreeTextAction,
@@ -239,6 +252,36 @@ const manualApplySegment = computed<NoNameManualApplySegmentSnapshot | null>(() 
     chapterIndex: chapter.index,
     segmentIndex,
     text: chapter.content[segmentIndex] ?? '',
+  };
+});
+const manualApplySummary = computed<NoNameManualApplySummarySnapshot | null>(() => {
+  const chapter = gameStore.plotState?.current_chapter;
+  if (!chapter) {
+    return null;
+  }
+  return {
+    chapterIndex: chapter.index,
+    summary: chapter.summary ?? '',
+  };
+});
+const manualApplyDiagnostics = computed<NoNameManualApplyDiagnosticsSnapshot | null>(() => {
+  const chapter = gameStore.plotState?.current_chapter;
+  if (!chapter) {
+    return null;
+  }
+  return {
+    chapterIndex: chapter.index,
+    diagnostics: gameStore.plotState?.last_generation_diagnostics ?? '',
+  };
+});
+const manualApplyPlotAugmentations = computed<NoNameManualApplyPlotAugmentationSnapshot | null>(() => {
+  const chapter = gameStore.plotState?.current_chapter;
+  if (!chapter) {
+    return null;
+  }
+  return {
+    chapterIndex: chapter.index,
+    hints: [...(gameStore.plotState?.pending_plot_augmentation_hints ?? [])],
   };
 });
 

--- a/src/components/InfoTabsDialog.vue
+++ b/src/components/InfoTabsDialog.vue
@@ -418,7 +418,13 @@
                   class="rounded border px-2 py-1"
                 >
                   <p class="info-text-body">
-                    {{ item.target }} · {{ item.outcome }}
+                    {{ applyExecutionDisplay(item).targetLabel }} · {{ applyExecutionDisplay(item).outcomeLabel }}
+                  </p>
+                  <p
+                    v-if="applyExecutionDisplay(item).targetLabel !== item.target || applyExecutionDisplay(item).outcomeLabel !== item.outcome"
+                    class="info-text-muted mt-1 whitespace-pre-wrap"
+                  >
+                    原始记录：{{ item.target }} / {{ item.outcome }}
                   </p>
                   <p
                     v-if="item.note"
@@ -475,6 +481,7 @@ import UiButton from '../shared/ui/UiButton.vue';
 import NovelExporter from './NovelExporter.vue';
 import StatusBanner from './StatusBanner.vue';
 import { formatLocationLabel } from '../shared/locationLabel';
+import { formatNoNameApplyExecutionRecord } from '../utils/noNameApplyLifecycle';
 
 type TabId = 'character' | 'progress' | 'map' | 'review' | 'export' | 'debug' | 'system';
 type RootElementKey = 'Fire' | 'Water' | 'Wood' | 'Metal' | 'Earth';
@@ -695,6 +702,10 @@ const debugNoNameTransitions = computed(() => props.debugNoNameTransitions ?? []
 const debugNoNamePlans = computed(() => props.debugNoNamePlans ?? []);
 const debugNoNameExecutions = computed(() => props.debugNoNameExecutions ?? []);
 const debugNoNameScopes = computed(() => props.debugNoNameScopes ?? []);
+
+function applyExecutionDisplay(item: NoNameExecutionView) {
+  return formatNoNameApplyExecutionRecord(item);
+}
 </script>
 
 <style scoped>

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -114,9 +114,15 @@
             :active-mode="noNameMode"
             :review-decisions="selectedReviewDecisions"
             :manual-apply-segment="manualApplySegment"
+            :manual-apply-summary="manualApplySummary"
+            :manual-apply-diagnostics="manualApplyDiagnostics"
+            :manual-apply-plot-augmentations="manualApplyPlotAugmentations"
             @mark-controlled-output-review="markControlledOutputReview"
             @resolve-second-guardrail="resolveSecondGuardrail"
             @apply-manual-plot-text-hint="applyManualPlotTextHint"
+            @apply-manual-chapter-summary-hint="applyManualChapterSummaryHint"
+            @apply-manual-option-bias-hint="applyManualOptionBiasHint"
+            @apply-manual-plot-augmentation-hint="applyManualPlotAugmentationHint"
           />
         </main>
       </div>
@@ -130,13 +136,23 @@ import AgentTracePanel from './AgentTracePanel.vue';
 import type {
   NoNameHumanReviewDecision,
   NoNameHumanReviewMarkPayload,
+  NoNameManualApplyDiagnosticsSnapshot,
+  NoNameManualApplyPlotAugmentationSnapshot,
   NoNameManualApplySegmentSnapshot,
+  NoNameManualApplySummarySnapshot,
+  NoNameManualChapterSummaryHintApplyPayload,
+  NoNameManualOptionBiasHintApplyPayload,
+  NoNameManualPlotAugmentationHintApplyPayload,
   NoNameManualPlotTextApplyPayload,
   NoNameMode,
   NoNameSecondGuardrailResolvePayload,
   NoNameTrace,
 } from '../types/game';
-import { summarizeNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
+import {
+  summarizeNoNameApplyExecutions,
+  summarizeNoNameApplyLifecycle,
+  summarizeNoNamePendingPlotAugmentation,
+} from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
   isOpen: boolean;
@@ -144,9 +160,15 @@ const props = withDefaults(defineProps<{
   noNameMode: NoNameMode;
   isDevMode?: boolean;
   manualApplySegment?: NoNameManualApplySegmentSnapshot | null;
+  manualApplySummary?: NoNameManualApplySummarySnapshot | null;
+  manualApplyDiagnostics?: NoNameManualApplyDiagnosticsSnapshot | null;
+  manualApplyPlotAugmentations?: NoNameManualApplyPlotAugmentationSnapshot | null;
 }>(), {
   isDevMode: false,
   manualApplySegment: null,
+  manualApplySummary: null,
+  manualApplyDiagnostics: null,
+  manualApplyPlotAugmentations: null,
 });
 
 const emit = defineEmits<{
@@ -156,6 +178,9 @@ const emit = defineEmits<{
   (event: 'mark-controlled-output-review', payload: NoNameHumanReviewMarkPayload): void;
   (event: 'resolve-second-guardrail', payload: NoNameSecondGuardrailResolvePayload): void;
   (event: 'apply-manual-plot-text-hint', payload: NoNameManualPlotTextApplyPayload): void;
+  (event: 'apply-manual-chapter-summary-hint', payload: NoNameManualChapterSummaryHintApplyPayload): void;
+  (event: 'apply-manual-option-bias-hint', payload: NoNameManualOptionBiasHintApplyPayload): void;
+  (event: 'apply-manual-plot-augmentation-hint', payload: NoNameManualPlotAugmentationHintApplyPayload): void;
 }>();
 
 const modeOptions: Array<{ value: NoNameMode; label: string }> = [
@@ -253,6 +278,18 @@ function applyManualPlotTextHint(payload: NoNameManualPlotTextApplyPayload) {
   emit('apply-manual-plot-text-hint', payload);
 }
 
+function applyManualChapterSummaryHint(payload: NoNameManualChapterSummaryHintApplyPayload) {
+  emit('apply-manual-chapter-summary-hint', payload);
+}
+
+function applyManualOptionBiasHint(payload: NoNameManualOptionBiasHintApplyPayload) {
+  emit('apply-manual-option-bias-hint', payload);
+}
+
+function applyManualPlotAugmentationHint(payload: NoNameManualPlotAugmentationHintApplyPayload) {
+  emit('apply-manual-plot-augmentation-hint', payload);
+}
+
 function humanReviewDecisionKey(traceId: string, requestId: string) {
   return `${traceId}::${requestId}`;
 }
@@ -285,6 +322,28 @@ function buildTraceReport(
     } satisfies Record<NoNameHumanReviewDecision, number>,
   );
   const relatedObservations = trace.relatedObservations ?? [];
+  const roleContextSummary = relatedObservations.length > 0
+    ? relatedObservations
+      .map((item) => {
+        const roleGoal = item.roleGoal ?? 'no-role-goal';
+        const sceneFocus = item.sceneFocus ?? 'no-scene-focus';
+        const forbiddenScopes = item.forbiddenScopes?.length
+          ? item.forbiddenScopes.join('/')
+          : 'none';
+        const noteTypeHits = item.noteTypeHits?.length
+          ? item.noteTypeHits.join('/')
+          : 'none';
+        const sourceStats = item.sourceStats?.length
+          ? item.sourceStats.map((source) => `${source.source}:${source.count}`).join('/')
+          : 'none';
+        const tokenBudgetUsed = item.contextTokenBudgetUsed ?? 0;
+        const contextSliceStats = item.contextSliceStats?.length
+          ? item.contextSliceStats.map((stat) => `${stat.section}:${stat.sourceCount}->${stat.visibleCount}`).join('/')
+          : 'none';
+        return `${item.role}:${roleGoal}:${sceneFocus}[forbidden=${forbiddenScopes}][notes=${noteTypeHits}][sources=${sourceStats}][tokens=${tokenBudgetUsed}][slice=${contextSliceStats}]`;
+      })
+      .join(', ')
+    : 'none';
   const guardrail = trace.guardrailResult
     ? `${trace.guardrailResult.outcome}${trace.guardrailResult.reason ? ` (${trace.guardrailResult.reason})` : ''}`
     : '无';
@@ -292,6 +351,12 @@ function buildTraceReport(
     ? `${trace.applyResult.outcome}${trace.applyResult.reason ? ` (${trace.applyResult.reason})` : ''}`
     : '无';
   const lifecycle = summarizeNoNameApplyLifecycle(trace, reviewDecisions);
+  const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(trace);
+  const applyExecutions = summarizeNoNameApplyExecutions(trace, {
+    emptyLabel: 'none',
+    rawPrefix: ' [raw=',
+    notePrefix: ' (',
+  });
   return [
     `Trace: ${trace.traceId}`,
     `Mode: ${trace.mode}`,
@@ -300,12 +365,15 @@ function buildTraceReport(
     `Proposals: ${readyCount}/${trace.proposals.length} applyable`,
     `Latest Proposal: ${latestProposal ? `${latestProposal.producerRole}:${latestProposal.kind}:${latestProposal.focus}` : '无'}`,
     `Related Observations: ${relatedObservations.length}`,
+    `Role Contexts: ${roleContextSummary}`,
     `Protocol Events: ${protocolEvents.length}`,
     `Controlled Reviews: ${controlledReviews.length} (${humanReviewCount} needs human review)`,
     `Human Review Decisions: ${reviewDecisionCounts.approvedForHigherApply} approved / ${reviewDecisionCounts.rejectedForHigherApply} rejected / ${reviewDecisionCounts.pending} pending`,
     `Guardrail: ${guardrail}`,
     `Apply Result: ${applyResult}`,
     `Apply Lifecycle: ${lifecycle}`,
+    `Apply Executions: ${applyExecutions}`,
+    `Plot Augmentation: ${pendingPlotAugmentation}`,
     `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,
     `Elapsed: ${trace.elapsedMs} ms`,
   ].join('\n');

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -112,6 +112,11 @@
             :selected-index="selectedIndex"
             :total-count="traces.length"
             :active-mode="noNameMode"
+            :review-decisions="selectedReviewDecisions"
+            :manual-apply-segment="manualApplySegment"
+            @mark-controlled-output-review="markControlledOutputReview"
+            @resolve-second-guardrail="resolveSecondGuardrail"
+            @apply-manual-plot-text-hint="applyManualPlotTextHint"
           />
         </main>
       </div>
@@ -122,21 +127,35 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import AgentTracePanel from './AgentTracePanel.vue';
-import type { NoNameMode, NoNameTrace } from '../types/game';
+import type {
+  NoNameHumanReviewDecision,
+  NoNameHumanReviewMarkPayload,
+  NoNameManualApplySegmentSnapshot,
+  NoNameManualPlotTextApplyPayload,
+  NoNameMode,
+  NoNameSecondGuardrailResolvePayload,
+  NoNameTrace,
+} from '../types/game';
+import { summarizeNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
   isOpen: boolean;
   traces: NoNameTrace[];
   noNameMode: NoNameMode;
   isDevMode?: boolean;
+  manualApplySegment?: NoNameManualApplySegmentSnapshot | null;
 }>(), {
   isDevMode: false,
+  manualApplySegment: null,
 });
 
-defineEmits<{
+const emit = defineEmits<{
   (event: 'close'): void;
   (event: 'clear-traces'): void;
   (event: 'set-no-name-mode', mode: NoNameMode): void;
+  (event: 'mark-controlled-output-review', payload: NoNameHumanReviewMarkPayload): void;
+  (event: 'resolve-second-guardrail', payload: NoNameSecondGuardrailResolvePayload): void;
+  (event: 'apply-manual-plot-text-hint', payload: NoNameManualPlotTextApplyPayload): void;
 }>();
 
 const modeOptions: Array<{ value: NoNameMode; label: string }> = [
@@ -183,8 +202,27 @@ const selectedTrace = computed(() => {
 });
 
 const copyStatus = ref('');
+const humanReviewDecisions = ref<Record<string, NoNameHumanReviewDecision>>({});
 
-const selectedTraceReport = computed(() => buildTraceReport(selectedTrace.value));
+const selectedReviewDecisions = computed<Record<string, NoNameHumanReviewDecision>>(() => {
+  const trace = selectedTrace.value;
+  if (!trace) {
+    return {};
+  }
+  return Object.fromEntries(
+    (trace.controlledOutputReviews ?? []).map((review) => [
+      review.requestId,
+      humanReviewDecisions.value[humanReviewDecisionKey(trace.traceId, review.requestId)]
+        ?? review.humanReviewDecision
+        ?? 'pending',
+    ]),
+  );
+});
+
+const selectedTraceReport = computed(() => buildTraceReport(
+  selectedTrace.value,
+  selectedReviewDecisions.value,
+));
 
 async function copySelectedTraceReport() {
   const report = selectedTraceReport.value;
@@ -199,7 +237,30 @@ async function copySelectedTraceReport() {
   }
 }
 
-function buildTraceReport(trace: NoNameTrace | null) {
+function markControlledOutputReview(payload: NoNameHumanReviewMarkPayload) {
+  humanReviewDecisions.value = {
+    ...humanReviewDecisions.value,
+    [humanReviewDecisionKey(payload.traceId, payload.requestId)]: payload.decision,
+  };
+  emit('mark-controlled-output-review', payload);
+}
+
+function resolveSecondGuardrail(payload: NoNameSecondGuardrailResolvePayload) {
+  emit('resolve-second-guardrail', payload);
+}
+
+function applyManualPlotTextHint(payload: NoNameManualPlotTextApplyPayload) {
+  emit('apply-manual-plot-text-hint', payload);
+}
+
+function humanReviewDecisionKey(traceId: string, requestId: string) {
+  return `${traceId}::${requestId}`;
+}
+
+function buildTraceReport(
+  trace: NoNameTrace | null,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+) {
   if (!trace) {
     return '';
   }
@@ -211,6 +272,18 @@ function buildTraceReport(trace: NoNameTrace | null) {
   const protocolEvents = trace.protocolEvents ?? [];
   const controlledReviews = trace.controlledOutputReviews ?? [];
   const humanReviewCount = controlledReviews.filter((review) => review.requiresHumanReview).length;
+  const reviewDecisionCounts = controlledReviews.reduce(
+    (counts, review) => {
+      const decision = reviewDecisions[review.requestId] ?? 'pending';
+      counts[decision] += 1;
+      return counts;
+    },
+    {
+      pending: 0,
+      approvedForHigherApply: 0,
+      rejectedForHigherApply: 0,
+    } satisfies Record<NoNameHumanReviewDecision, number>,
+  );
   const relatedObservations = trace.relatedObservations ?? [];
   const guardrail = trace.guardrailResult
     ? `${trace.guardrailResult.outcome}${trace.guardrailResult.reason ? ` (${trace.guardrailResult.reason})` : ''}`
@@ -218,6 +291,7 @@ function buildTraceReport(trace: NoNameTrace | null) {
   const applyResult = trace.applyResult
     ? `${trace.applyResult.outcome}${trace.applyResult.reason ? ` (${trace.applyResult.reason})` : ''}`
     : '无';
+  const lifecycle = summarizeNoNameApplyLifecycle(trace, reviewDecisions);
   return [
     `Trace: ${trace.traceId}`,
     `Mode: ${trace.mode}`,
@@ -228,8 +302,10 @@ function buildTraceReport(trace: NoNameTrace | null) {
     `Related Observations: ${relatedObservations.length}`,
     `Protocol Events: ${protocolEvents.length}`,
     `Controlled Reviews: ${controlledReviews.length} (${humanReviewCount} needs human review)`,
+    `Human Review Decisions: ${reviewDecisionCounts.approvedForHigherApply} approved / ${reviewDecisionCounts.rejectedForHigherApply} rejected / ${reviewDecisionCounts.pending} pending`,
     `Guardrail: ${guardrail}`,
     `Apply Result: ${applyResult}`,
+    `Apply Lifecycle: ${lifecycle}`,
     `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,
     `Elapsed: ${trace.elapsedMs} ms`,
   ].join('\n');

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -46,6 +46,13 @@ const trace: NoNameTrace = {
     actionSummary: '玩家返回山门',
     focus: '山门法阵',
     rationale: '需要补齐世界设定锚点',
+    roleGoal: 'Maintain world facts, scene constraints, and canon anchors.',
+    sceneFocus: '山门法阵',
+    forbiddenScopes: ['Must not decide NPC private intent.', 'Must not choose the main plot beat alone.'],
+    noteTypeHits: ['goal: Hold Gate', 'foreshadowing: Broken Ward'],
+    sourceStats: [{ source: 'hard_facts', count: 2 }, { source: 'chapter_summaries', count: 1 }],
+    contextTokenBudgetUsed: 42,
+    contextSliceStats: [{ section: 'worldFacts', sourceCount: 4, visibleCount: 3 }],
     proposal: {
       proposalId: 'proposal-world-1',
       kind: 'worldPatchProposal',
@@ -117,6 +124,17 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('低风险输出');
     expect(wrapper.text()).toContain('协作观察');
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
+    expect(wrapper.text()).toContain('角色上下文');
+    expect(wrapper.text()).toContain('Maintain world facts');
+    expect(wrapper.text()).toContain('角色禁区');
+    expect(wrapper.text()).toContain('Must not decide NPC private intent.');
+    expect(wrapper.text()).toContain('笔记命中');
+    expect(wrapper.text()).toContain('goal: Hold Gate');
+    expect(wrapper.text()).toContain('上下文来源');
+    expect(wrapper.text()).toContain('hard_facts:2');
+    expect(wrapper.text()).toContain('token=42');
+    expect(wrapper.text()).toContain('裁剪差异');
+    expect(wrapper.text()).toContain('worldFacts:4->3');
     expect(wrapper.text()).toContain('协议事件');
     expect(wrapper.text()).toContain('agent · delegation · running');
     expect(wrapper.text()).toContain('受控输出复核');
@@ -124,6 +142,33 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('需要人工复核');
     expect(wrapper.text()).toContain('策略禁区：finalPlotState / canonWorldFact');
     expect(wrapper.text()).toContain('等待开发者确认');
+  });
+
+  it('shows pending plot augmentation summary in the overview', () => {
+    const wrapper = mount(AgentTracePanel, {
+      props: {
+        trace: {
+          ...trace,
+          proposals: [{
+            ...trace.proposals[0],
+            applyScopes: ['diagnostics', 'plotAugmentationHint'],
+          }],
+          applyExecutionLog: [
+            ...(trace.applyExecutionLog ?? []),
+            {
+              target: 'plot_augmentation_hint',
+              outcome: 'pending_plot_augmentation_consumed',
+              note: 'pending plot augmentation consumed after plot_engine generation; count=1',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('剧情增强提示');
+    expect(wrapper.text()).toContain('已消费');
+    expect(wrapper.text()).toContain('count=1');
+    expect(wrapper.text()).toContain('原始记录：plot_augmentation_hint / pending_plot_augmentation_consumed');
   });
 
   it('emits a human review decision without applying plot text', async () => {
@@ -197,7 +242,7 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('【NoName】重点关注：山门危机');
     await wrapper
       .findAll('.agent-trace-review-btn')
-      .find((button) => button.text() === '显式人工写入正文提示')
+      .find((button) => button.text().includes('显式人工写入正文提示'))
       ?.trigger('click');
     expect(wrapper.emitted('apply-manual-plot-text-hint')?.[0]).toEqual([{
       traceId: 'trace-2',
@@ -226,11 +271,99 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('疑似已包含 NoName 标记');
     const button = wrapper
       .findAll('.agent-trace-review-btn')
-      .find((item) => item.text() === '显式人工写入正文提示');
+      .find((item) => item.text().includes('显式人工写入正文提示'));
     expect(button?.attributes('disabled')).toBeDefined();
 
     await button?.trigger('click');
     expect(wrapper.emitted('apply-manual-plot-text-hint')).toBeUndefined();
+  });
+
+  it('emits manual chapter summary and option bias apply events after second guardrail allow', async () => {
+    const chapterSummaryTrace: NoNameTrace = {
+      ...trace,
+      proposals: [{
+        ...trace.proposals[0],
+        proposalId: 'proposal-summary',
+        focus: '山门危机',
+        targetSegment: 'chapter_summary_tail',
+        applyScopes: ['chapterSummaryHint'],
+      }],
+      controlledOutputReviews: [{
+        requestId: 'controlled-output-proposal-summary-chapter_summary_hint',
+        requestedKind: 'recapNote',
+        decision: 'needsReview',
+        reason: 'summary hint requires review',
+        normalizedKind: 'recapNote',
+        safeApplyScope: 'chapterSummaryHint',
+        policyForbiddenScopes: ['finalPlotState'],
+        requiresHumanReview: true,
+      }],
+      proposalTransitionLog: [
+        'controlled-output-proposal-summary-chapter_summary_hint:second_guardrail:allow',
+      ],
+      applyExecutionLog: [{
+        target: 'chapterSummaryHint',
+        outcome: 'second_guardrail_allowed',
+        note: 'allowed',
+      }],
+    };
+    const wrapper = mount(AgentTracePanel, {
+      props: {
+        trace: chapterSummaryTrace,
+        manualApplySummary: {
+          chapterIndex: 1,
+          summary: '已有摘要',
+        },
+      },
+    });
+
+    const summaryButtons = wrapper.findAll('.agent-trace-review-btn');
+    await summaryButtons[summaryButtons.length - 1]?.trigger('click');
+    expect(wrapper.emitted('apply-manual-chapter-summary-hint')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-summary-chapter_summary_hint',
+    }]);
+
+    await wrapper.setProps({
+      trace: {
+        ...chapterSummaryTrace,
+        proposals: [{
+          ...chapterSummaryTrace.proposals[0],
+          proposalId: 'proposal-option',
+          focus: '暗洞',
+          targetSegment: 'current_turn_tail',
+          applyScopes: ['optionBiasHint'],
+        }],
+        controlledOutputReviews: [{
+          requestId: 'controlled-output-proposal-option-option_bias_hint',
+          requestedKind: 'intermediateNarrativeHint',
+          decision: 'needsReview',
+          reason: 'option bias requires review',
+          normalizedKind: 'intermediateNarrativeHint',
+          safeApplyScope: 'optionBiasHint',
+          policyForbiddenScopes: ['finalPlotState'],
+          requiresHumanReview: true,
+        }],
+        proposalTransitionLog: [
+          'controlled-output-proposal-option-option_bias_hint:second_guardrail:allow',
+        ],
+        applyExecutionLog: [{
+          target: 'optionBiasHint',
+          outcome: 'second_guardrail_allowed',
+          note: 'allowed',
+        }],
+      },
+      manualApplyDiagnostics: {
+        chapterIndex: 1,
+        diagnostics: 'base diagnostics',
+      },
+    });
+    const optionButtons = wrapper.findAll('.agent-trace-review-btn');
+    await optionButtons[optionButtons.length - 1]?.trigger('click');
+    expect(wrapper.emitted('apply-manual-option-bias-hint')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-option-option_bias_hint',
+    }]);
   });
 
   it('shows empty state when trace is missing', () => {

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -112,6 +112,9 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('preflight_ready');
     expect(wrapper.text()).toContain('未回退');
     expect(wrapper.text()).toContain('ApplyProposal');
+    expect(wrapper.text()).toContain('应用生命周期');
+    expect(wrapper.text()).toContain('提案阶段');
+    expect(wrapper.text()).toContain('低风险输出');
     expect(wrapper.text()).toContain('协作观察');
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('协议事件');
@@ -120,6 +123,114 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('sceneAugmentation · plotTextHint · needsReview');
     expect(wrapper.text()).toContain('需要人工复核');
     expect(wrapper.text()).toContain('策略禁区：finalPlotState / canonWorldFact');
+    expect(wrapper.text()).toContain('等待开发者确认');
+  });
+
+  it('emits a human review decision without applying plot text', async () => {
+    const wrapper = mount(AgentTracePanel, {
+      props: {
+        trace,
+        reviewDecisions: {
+          'controlled-output-proposal-2-plot_text_hint': 'pending',
+        },
+      },
+    });
+
+    const buttons = wrapper.findAll('.agent-trace-review-btn');
+    expect(buttons.map((button) => button.text())).toContain('标记可进入高层 apply 设计');
+
+    await buttons.find((button) => button.text() === '标记可进入高层 apply 设计')?.trigger('click');
+
+    expect(wrapper.emitted('mark-controlled-output-review')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      decision: 'approvedForHigherApply',
+    }]);
+
+    await wrapper.setProps({
+      reviewDecisions: {
+        'controlled-output-proposal-2-plot_text_hint': 'approvedForHigherApply',
+      },
+    });
+    expect(wrapper.text()).toContain('人工结论：可进入下一阶段 apply 设计');
+    expect(wrapper.text()).toContain('重置待复核');
+    expect(wrapper.text()).toContain('二次护栏允许');
+
+    await wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((button) => button.text() === '二次护栏允许')
+      ?.trigger('click');
+    expect(wrapper.emitted('resolve-second-guardrail')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      decision: 'allow',
+    }]);
+
+    await wrapper.setProps({
+      trace: {
+        ...trace,
+        proposalTransitionLog: [
+          ...(trace.proposalTransitionLog ?? []),
+          'controlled-output-proposal-2-plot_text_hint:second_guardrail:allow',
+        ],
+        applyExecutionLog: [
+          ...(trace.applyExecutionLog ?? []),
+          {
+            target: 'plot_text_hint',
+            outcome: 'second_guardrail_allowed',
+            note: '允许进入显式人工 apply',
+          },
+        ],
+      },
+      manualApplySegment: {
+        chapterIndex: 1,
+        segmentIndex: 0,
+        text: '你看见山门风声渐紧。',
+      },
+    });
+    expect(wrapper.text()).toContain('显式人工写入正文提示');
+    expect(wrapper.text()).toContain('人工写入');
+    expect(wrapper.text()).toContain('等待显式命令');
+    expect(wrapper.text()).toContain('人工写入预览');
+    expect(wrapper.text()).toContain('写入前');
+    expect(wrapper.text()).toContain('写入后');
+    expect(wrapper.text()).toContain('【NoName】重点关注：山门危机');
+    await wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((button) => button.text() === '显式人工写入正文提示')
+      ?.trigger('click');
+    expect(wrapper.emitted('apply-manual-plot-text-hint')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+    }]);
+  });
+
+  it('disables manual plot text apply when the current segment already has a NoName marker', async () => {
+    const wrapper = mount(AgentTracePanel, {
+      props: {
+        trace: {
+          ...trace,
+          proposalTransitionLog: [
+            ...(trace.proposalTransitionLog ?? []),
+            'controlled-output-proposal-2-plot_text_hint:second_guardrail:allow',
+          ],
+        },
+        manualApplySegment: {
+          chapterIndex: 1,
+          segmentIndex: 0,
+          text: '【NoName】重点关注：山门危机\n\n你看见山门风声渐紧。',
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('疑似已包含 NoName 标记');
+    const button = wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((item) => item.text() === '显式人工写入正文提示');
+    expect(button?.attributes('disabled')).toBeDefined();
+
+    await button?.trigger('click');
+    expect(wrapper.emitted('apply-manual-plot-text-hint')).toBeUndefined();
   });
 
   it('shows empty state when trace is missing', () => {

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -78,6 +78,7 @@ const trace: NoNameTrace = {
     reason: 'plot text hint requires human review before higher-layer apply',
     normalizedKind: 'sceneAugmentation',
     safeApplyScope: 'plotTextHint',
+    policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
     requiresHumanReview: true,
   }],
   guardrailResult: {
@@ -118,6 +119,7 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('受控输出复核');
     expect(wrapper.text()).toContain('sceneAugmentation · plotTextHint · needsReview');
     expect(wrapper.text()).toContain('需要人工复核');
+    expect(wrapper.text()).toContain('策略禁区：finalPlotState / canonWorldFact');
   });
 
   it('shows empty state when trace is missing', () => {

--- a/src/components/__tests__/InfoTabsDialog.test.ts
+++ b/src/components/__tests__/InfoTabsDialog.test.ts
@@ -87,6 +87,11 @@ describe('InfoTabsDialog', () => {
           { order: 1, target: 'plot_text_hint', decision: 'apply', priority: 300, note: '允许执行 plot_text_hint' },
         ],
         debugNoNameExecutions: [
+          {
+            target: 'plot_augmentation_hint',
+            outcome: 'pending_plot_augmentation_consumed',
+            note: 'pending plot augmentation consumed after plot_engine generation; count=1',
+          },
           { target: 'plot_text_hint', outcome: 'applied', note: '已将提案提示插入正文' },
         ],
         systemError: null,
@@ -109,5 +114,8 @@ describe('InfoTabsDialog', () => {
     expect(wrapper.text()).toContain('P300');
     expect(wrapper.text()).toContain('允许执行 plot_text_hint');
     expect(wrapper.text()).toContain('plot_text_hint');
+    expect(wrapper.text()).toContain('剧情增强提示');
+    expect(wrapper.text()).toContain('已消费');
+    expect(wrapper.text()).toContain('原始记录：plot_augmentation_hint / pending_plot_augmentation_consumed');
   });
 });

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -52,7 +52,7 @@ const traces: NoNameTrace[] = [
       intendedEffect: '补足世界事实',
       rationale: '山门设定需要锚点',
       labels: ['world_curator'],
-      applyScopes: ['diagnostics', 'chapterSummaryHint'],
+      applyScopes: ['diagnostics', 'chapterSummaryHint', 'plotAugmentationHint'],
       status: 'ready',
       applyable: true,
     }],
@@ -68,6 +68,10 @@ const traces: NoNameTrace[] = [
       target: 'chapter_summary_hint',
       outcome: 'applied',
       note: '已完成写入',
+    }, {
+      target: 'plot_augmentation_hint',
+      outcome: 'pending_plot_augmentation_consumed',
+      note: 'pending plot augmentation consumed after plot_engine generation; count=1',
     }],
     guardrailResult: { outcome: 'accept', reason: null },
     applyResult: { attempted: true, outcome: 'preflight_ready', reason: '允许应用' },
@@ -79,6 +83,34 @@ const traces: NoNameTrace[] = [
       taskId: 'task-1',
       status: 'queued',
       detail: 'fan-out',
+    }],
+    relatedObservations: [{
+      role: 'worldCurator',
+      actionSummary: '玩家返回山门',
+      focus: '山门法阵',
+      rationale: '需要补齐世界设定锚点',
+      roleGoal: 'Maintain world facts, scene constraints, and canon anchors.',
+      sceneFocus: '山门法阵',
+      forbiddenScopes: ['Must not decide NPC private intent.'],
+      noteTypeHits: ['goal: Hold Gate'],
+      sourceStats: [{ source: 'hard_facts', count: 2 }],
+      contextTokenBudgetUsed: 42,
+      contextSliceStats: [{ section: 'worldFacts', sourceCount: 4, visibleCount: 3 }],
+      proposal: {
+        proposalId: 'proposal-world-1',
+        kind: 'worldPatchProposal',
+        producerRole: 'worldCurator',
+        title: 'WorldCurator提案：山门法阵',
+        summary: '补齐法阵约束',
+        focus: '山门法阵',
+        targetSegment: 'chapter_summary_tail',
+        intendedEffect: '补足世界事实',
+        rationale: '设定缺口明显',
+        labels: ['worldCurator'],
+        applyScopes: ['diagnostics', 'chapterSummaryHint'],
+        status: 'observed',
+        applyable: false,
+      },
     }],
     controlledOutputReviews: [{
       requestId: 'controlled-output-proposal-2-plot_text_hint',
@@ -109,9 +141,15 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('当前模式：assisted');
     expect(wrapper.text()).toContain('Protocol Events: 1');
+    expect(wrapper.text()).toContain('Role Contexts: worldCurator:Maintain world facts, scene constraints, and canon anchors.:山门法阵');
+    expect(wrapper.text()).toContain('[notes=goal: Hold Gate]');
+    expect(wrapper.text()).toContain('[sources=hard_facts:2]');
+    expect(wrapper.text()).toContain('[tokens=42]');
+    expect(wrapper.text()).toContain('[slice=worldFacts:4->3]');
     expect(wrapper.text()).toContain('Controlled Reviews: 1 (1 needs human review)');
     expect(wrapper.text()).toContain('Human Review Decisions: 0 approved / 0 rejected / 1 pending');
     expect(wrapper.text()).toContain('Apply Lifecycle:');
+    expect(wrapper.text()).toContain('Plot Augmentation: 已消费');
     expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
     const traceButtons = wrapper.findAll('.noname-debug-console-trace-btn');
@@ -193,6 +231,10 @@ describe('NoNameDebugConsole', () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Protocol Events: 1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Controlled Reviews: 1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Executions:'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('剧情增强提示:已消费'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Plot Augmentation: 已消费'));
     expect(wrapper.text()).toContain('摘要已复制');
   });
 });

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -87,6 +87,7 @@ const traces: NoNameTrace[] = [
       reason: 'plot text hint requires human review before higher-layer apply',
       normalizedKind: 'sceneAugmentation',
       safeApplyScope: 'plotTextHint',
+      policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
       requiresHumanReview: true,
     }],
     fallbackUsed: false,

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -110,6 +110,8 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('当前模式：assisted');
     expect(wrapper.text()).toContain('Protocol Events: 1');
     expect(wrapper.text()).toContain('Controlled Reviews: 1 (1 needs human review)');
+    expect(wrapper.text()).toContain('Human Review Decisions: 0 approved / 0 rejected / 1 pending');
+    expect(wrapper.text()).toContain('Apply Lifecycle:');
     expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
     const traceButtons = wrapper.findAll('.noname-debug-console-trace-btn');
@@ -117,6 +119,37 @@ describe('NoNameDebugConsole', () => {
 
     await traceButtons[0].trigger('click');
     expect(wrapper.text()).toContain('Director提案：初始观察');
+  });
+
+  it('tracks local human review decisions for NeedsReview outputs', async () => {
+    const wrapper = mount(NoNameDebugConsole, {
+      props: {
+        isOpen: true,
+        traces,
+        noNameMode: 'assisted',
+        isDevMode: true,
+      },
+    });
+
+    expect(wrapper.text()).toContain('等待开发者确认');
+
+    const reviewButtons = wrapper.findAll('.agent-trace-review-btn');
+    await reviewButtons
+      .find((button) => button.text() === '标记可进入高层 apply 设计')
+      ?.trigger('click');
+
+    expect(wrapper.text()).toContain('人工结论：可进入下一阶段 apply 设计');
+    expect(wrapper.text()).toContain('Human Review Decisions: 1 approved / 0 rejected / 0 pending');
+
+    await wrapper
+      .findAll('.agent-trace-review-btn')
+      .find((button) => button.text() === '二次护栏允许')
+      ?.trigger('click');
+    expect(wrapper.emitted('resolve-second-guardrail')?.[0]).toEqual([{
+      traceId: 'trace-2',
+      requestId: 'controlled-output-proposal-2-plot_text_hint',
+      decision: 'allow',
+    }]);
   });
 
   it('emits close, clear and mode change events', async () => {
@@ -159,6 +192,7 @@ describe('NoNameDebugConsole', () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace: trace-2'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Protocol Events: 1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Controlled Reviews: 1'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));
     expect(wrapper.text()).toContain('摘要已复制');
   });
 });

--- a/src/platform/webRuntime.test.ts
+++ b/src/platform/webRuntime.test.ts
@@ -142,8 +142,15 @@ describe('webRuntime', () => {
     const expectedSegmentText = beforeContent[segmentIndex];
     const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
     const latestTrace = traces[traces.length - 1];
-    const review = latestTrace.controlledOutputReviews?.find((item) => item.requiresHumanReview);
+    const review = latestTrace.controlledOutputReviews?.find((item) => (
+      item.safeApplyScope === 'plotTextHint' && item.requiresHumanReview
+    ));
     expect(review?.decision).toBe('needsReview');
+    expect(latestTrace.controlledOutputReviews?.some((item) => (
+      item.safeApplyScope === 'plotAugmentationHint'
+      && item.requestedKind === 'nonFinalPlotAugmentation'
+      && item.requiresHumanReview
+    ))).toBe(true);
 
     const updatedTrace = await invokeWebRuntime<NoNameTrace>('mark_noname_controlled_output_review', {
       traceId: latestTrace.traceId,
@@ -153,7 +160,9 @@ describe('webRuntime', () => {
 
     const afterPlotState = await invokeWebRuntime<PlotState>('get_plot_state');
     expect(afterPlotState.current_chapter.content).toEqual(beforeContent);
-    expect(updatedTrace.controlledOutputReviews?.[3]?.humanReviewDecision).toBe('approvedForHigherApply');
+    expect(updatedTrace.controlledOutputReviews?.find((item) => (
+      item.safeApplyScope === 'plotTextHint'
+    ))?.humanReviewDecision).toBe('approvedForHigherApply');
     expect(updatedTrace.applyPlanLog?.some((item) => (
       item.target === 'plotTextHint' && item.decision === 'review_intent_ready'
     ))).toBe(true);
@@ -186,6 +195,70 @@ describe('webRuntime', () => {
     expect(applied.plotState.current_chapter.content[segmentIndex]).toContain('【NoName】重点关注：观察灵脉回响');
     expect(applied.trace.applyExecutionLog?.some((item) => (
       item.target === 'plotTextHint' && item.outcome === 'manual_plot_text_applied'
+    ))).toBe(true);
+  });
+
+  it('consumes reviewed plot augmentation hints on the next assisted generation', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+    await invokeWebRuntime('set_noname_mode', { mode: 'assisted' });
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '追踪洞府残响',
+        selected_option_id: null,
+      },
+    });
+
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const firstTrace = traces[traces.length - 1];
+    const review = firstTrace.controlledOutputReviews?.find((item) => (
+      item.safeApplyScope === 'plotAugmentationHint' && item.requiresHumanReview
+    ));
+    expect(review?.decision).toBe('needsReview');
+
+    await invokeWebRuntime<NoNameTrace>('mark_noname_controlled_output_review', {
+      traceId: firstTrace.traceId,
+      requestId: review?.requestId,
+      decision: 'approvedForHigherApply',
+    });
+    await invokeWebRuntime<NoNameTrace>('resolve_noname_second_guardrail', {
+      traceId: firstTrace.traceId,
+      requestId: review?.requestId,
+      decision: 'allow',
+    });
+
+    const beforeApply = await invokeWebRuntime<PlotState>('get_plot_state');
+    const applied = await invokeWebRuntime<{ trace: NoNameTrace; plotState: PlotState }>('apply_noname_reviewed_output', {
+      traceId: firstTrace.traceId,
+      requestId: review?.requestId,
+      scope: 'plotAugmentationHint',
+      chapterIndex: beforeApply.current_chapter.index,
+      expectedPlotAugmentationHints: beforeApply.pending_plot_augmentation_hints ?? [],
+    });
+    expect(applied.plotState.pending_plot_augmentation_hints).toHaveLength(1);
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '沿着残响前进',
+        selected_option_id: null,
+      },
+      quickMode: false,
+    });
+
+    const afterConsume = await invokeWebRuntime<PlotState>('get_plot_state');
+    const afterTraces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestTrace = afterTraces[afterTraces.length - 1];
+
+    expect(afterConsume.pending_plot_augmentation_hints).toHaveLength(0);
+    expect(afterConsume.last_generation_diagnostics).toContain('NoName pending plot augmentation consumed=1');
+    expect(latestTrace.applyExecutionLog?.some((item) => (
+      item.target === 'plotAugmentationHint'
+      && item.outcome === 'pending_plot_augmentation_consumed'
+      && item.note?.includes('count=1')
     ))).toBe(true);
   });
 

--- a/src/platform/webRuntime.test.ts
+++ b/src/platform/webRuntime.test.ts
@@ -38,7 +38,56 @@ describe('webRuntime', () => {
     expect(loaded).toBeTruthy();
   });
 
-  it('applies NoName plot hint to current turn head in assisted mode for free text actions', async () => {
+  it('skips NoName traces and diagnostics in disabled mode', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+    await invokeWebRuntime('set_noname_mode', { mode: 'disabled' });
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '观察山门灵气',
+        selected_option_id: null,
+      },
+    });
+
+    const plotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestParagraph = plotState.current_chapter.content[plotState.current_chapter.content.length - 1] ?? '';
+    expect(traces).toHaveLength(0);
+    expect(latestParagraph.includes('【NoName】重点关注')).toBe(false);
+    expect(plotState.last_generation_diagnostics ?? '').not.toContain('NoName.');
+  });
+
+  it('records observe-only trace without applying NoName outputs', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '观察山门灵气',
+        selected_option_id: null,
+      },
+    });
+
+    const plotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestTrace = traces[traces.length - 1];
+    const latestParagraph = plotState.current_chapter.content[plotState.current_chapter.content.length - 1] ?? '';
+    expect(latestTrace?.mode).toBe('observeOnly');
+    expect(latestTrace?.proposals[0]?.status).toBe('observed');
+    expect(latestTrace?.proposals[0]?.applyable).toBe(false);
+    expect(latestTrace?.applyResult?.outcome).toBe('skipped_observe_only');
+    expect(latestTrace?.applyExecutionLog).toHaveLength(0);
+    expect(latestParagraph.includes('【NoName】重点关注')).toBe(false);
+    expect(plotState.current_chapter.summary).not.toContain('NoName提示');
+    expect(plotState.last_generation_diagnostics).toContain('NoName.observeOnly');
+  });
+
+  it('queues NoName plot hint for review while applying low-risk hints in assisted mode', async () => {
     const script = await invokeWebRuntime<Script>('generate_random_script');
     await invokeWebRuntime('initialize_game', { script });
     await invokeWebRuntime('initialize_plot');
@@ -54,7 +103,7 @@ describe('webRuntime', () => {
 
     const plotState = await invokeWebRuntime<PlotState>('get_plot_state');
     const latestParagraph = plotState.current_chapter.content[plotState.current_chapter.content.length - 1] ?? '';
-    expect(latestParagraph.startsWith('【NoName】重点关注：观察灵脉回响')).toBe(true);
+    expect(latestParagraph.includes('【NoName】重点关注：观察灵脉回响')).toBe(false);
     expect(plotState.current_chapter.summary).toContain('NoName提示：后续重点关注观察灵脉回响');
     expect(plotState.last_generation_diagnostics).toContain('target_segment=current_turn_head');
 
@@ -63,9 +112,81 @@ describe('webRuntime', () => {
     expect(latestTrace?.applyPlanLog?.[0]?.order).toBe(1);
     expect(latestTrace?.proposals[0]?.targetSegment).toBe('current_turn_head');
     expect(latestTrace?.proposals[0]?.applyScopes).toContain('plotTextHint');
-    expect(latestTrace?.applyPlanLog?.[0]?.decision).toBe('apply');
+    expect(latestTrace?.applyPlanLog?.[0]?.decision).toBe('needs_review');
     expect(latestTrace?.applyPlanLog?.[0]?.priority).toBe(300);
+    expect(latestTrace?.controlledOutputReviews?.some((item) => (
+      item.safeApplyScope === 'plotTextHint' && item.decision === 'needsReview'
+    ))).toBe(true);
+    expect(latestTrace?.applyResult?.outcome).toBe('applied_summary_and_option_bias');
+    expect(latestTrace?.applyResult?.reason).toContain('plotTextHint 等待人工复核');
     expect(latestTrace?.applyResult?.reason).toContain('target=current_turn_head');
+  });
+
+  it('records human review apply intent without mutating plot text in web mode', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+    await invokeWebRuntime('set_noname_mode', { mode: 'assisted' });
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '观察灵脉回响',
+        selected_option_id: null,
+      },
+    });
+
+    const beforePlotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    const beforeContent = [...beforePlotState.current_chapter.content];
+    const segmentIndex = beforeContent.length - 1;
+    const expectedSegmentText = beforeContent[segmentIndex];
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestTrace = traces[traces.length - 1];
+    const review = latestTrace.controlledOutputReviews?.find((item) => item.requiresHumanReview);
+    expect(review?.decision).toBe('needsReview');
+
+    const updatedTrace = await invokeWebRuntime<NoNameTrace>('mark_noname_controlled_output_review', {
+      traceId: latestTrace.traceId,
+      requestId: review?.requestId,
+      decision: 'approvedForHigherApply',
+    });
+
+    const afterPlotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    expect(afterPlotState.current_chapter.content).toEqual(beforeContent);
+    expect(updatedTrace.controlledOutputReviews?.[3]?.humanReviewDecision).toBe('approvedForHigherApply');
+    expect(updatedTrace.applyPlanLog?.some((item) => (
+      item.target === 'plotTextHint' && item.decision === 'review_intent_ready'
+    ))).toBe(true);
+    expect(updatedTrace.applyExecutionLog?.some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'awaiting_second_guardrail'
+    ))).toBe(true);
+
+    const resolvedTrace = await invokeWebRuntime<NoNameTrace>('resolve_noname_second_guardrail', {
+      traceId: latestTrace.traceId,
+      requestId: review?.requestId,
+      decision: 'allow',
+    });
+    const finalPlotState = await invokeWebRuntime<PlotState>('get_plot_state');
+    expect(finalPlotState.current_chapter.content).toEqual(beforeContent);
+    expect(resolvedTrace.applyPlanLog?.some((item) => (
+      item.target === 'plotTextHint' && item.decision === 'second_guardrail_allow'
+    ))).toBe(true);
+    expect(resolvedTrace.applyExecutionLog?.some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'second_guardrail_allowed'
+    ))).toBe(true);
+    expect(resolvedTrace.applyResult?.outcome).toBe('second_guardrail_allow');
+
+    const applied = await invokeWebRuntime<{ trace: NoNameTrace; plotState: PlotState }>('apply_noname_manual_plot_text_hint', {
+      traceId: latestTrace.traceId,
+      requestId: review?.requestId,
+      chapterIndex: beforePlotState.current_chapter.index,
+      segmentIndex,
+      expectedSegmentText,
+    });
+    expect(applied.plotState.current_chapter.content[segmentIndex]).toContain('【NoName】重点关注：观察灵脉回响');
+    expect(applied.trace.applyExecutionLog?.some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'manual_plot_text_applied'
+    ))).toBe(true);
   });
 
   it('applies NoName summary hint to chapter summary head for even option actions in assisted mode', async () => {

--- a/src/platform/webRuntime.ts
+++ b/src/platform/webRuntime.ts
@@ -9,7 +9,9 @@ import {
   type GameState,
   type MapLocationOverview,
   type NoNameApplyScope,
+  type NoNameHumanReviewMarkPayload,
   type NoNameMode,
+  type NoNameSecondGuardrailResolvePayload,
   type NoNameTargetSegment,
   type NoNameTrace,
   type PlayerAction,
@@ -328,14 +330,6 @@ function deriveWebNoNameApplyScopes(targetSegment: NoNameTargetSegment): NoNameA
   return baseScopes;
 }
 
-function applyWebNoNamePlotHint(paragraph: string, focus: string, targetSegment: NoNameTargetSegment): string {
-  const hint = `【NoName】重点关注：${focus}`;
-  if (targetSegment === 'current_turn_head') {
-    return `${hint}\n\n${paragraph}`;
-  }
-  return `${paragraph}\n\n${hint}`;
-}
-
 function applyWebNoNameSummaryHint(summary: string, focus: string, targetSegment: NoNameTargetSegment): string {
   const hint = `NoName提示：后续重点关注${focus}`;
   if (!summary.trim()) {
@@ -399,35 +393,64 @@ function appendWebNoNameTrace(
       proposalTransitionLog: [
         `${proposalId}:ready`,
         `${proposalId}:apply_preflight:ready`,
-        ...applyScopes.map((scope) => `${proposalId}:applied:${scope}`),
+        ...applyScopes
+          .filter((scope) => scope !== 'plotTextHint')
+          .map((scope) => `${proposalId}:applied:${scope}`),
+        ...(applyScopes.includes('plotTextHint')
+          ? [`${proposalId}:controlled_output:plot_text_hint:needs_review`]
+          : []),
       ],
       applyPlanLog: applyScopes
         .map((scope) => ({
         target: scope,
-        decision: 'apply',
+        decision: scope === 'plotTextHint' ? 'needs_review' : 'apply',
         priority: scope === 'plotTextHint' ? 300 : scope === 'chapterSummaryHint' ? 200 : scope === 'optionBiasHint' ? 100 : 50,
-        note: `web mock 允许执行 ${scope}`,
+        note: scope === 'plotTextHint'
+          ? 'web mock plotTextHint 需要人工复核'
+          : `web mock 允许执行 ${scope}`,
       }))
         .sort((left, right) => right.priority - left.priority)
         .map((item, index) => ({ ...item, order: index + 1 })),
-      applyExecutionLog: applyScopes.map((scope) => ({
+      applyExecutionLog: applyScopes
+        .filter((scope) => scope !== 'plotTextHint')
+        .map((scope) => ({
         target: scope,
         outcome: 'applied',
-        note: scope === 'plotTextHint'
-          ? `已将提案提示写入正文，聚焦“${text}”`
-          : scope === 'chapterSummaryHint'
+        note: scope === 'chapterSummaryHint'
             ? `已补充章节摘要提示，聚焦“${text}”`
             : scope === 'optionBiasHint'
               ? `已补充下轮选项偏置提示，聚焦“${text}”`
               : `已补充诊断提示，聚焦“${text}”`,
       })),
+      controlledOutputReviews: applyScopes.map((scope) => ({
+        requestId: `controlled-output-${proposalId}-${scope === 'plotTextHint' ? 'plot_text_hint' : scope}`,
+        requestedKind: scope === 'plotTextHint'
+          ? 'sceneAugmentation'
+          : scope === 'chapterSummaryHint'
+            ? 'recapNote'
+            : scope === 'optionBiasHint'
+              ? 'intermediateNarrativeHint'
+              : 'narrativeNote',
+        decision: scope === 'plotTextHint' ? 'needsReview' : 'allow',
+        reason: scope === 'plotTextHint'
+          ? 'plot text hint requires human review before higher-layer apply'
+          : 'controlled output stays within allowed boundary',
+        normalizedKind: scope === 'plotTextHint'
+          ? 'sceneAugmentation'
+          : scope === 'chapterSummaryHint'
+            ? 'recapNote'
+            : scope === 'optionBiasHint'
+              ? 'intermediateNarrativeHint'
+              : 'narrativeNote',
+        safeApplyScope: scope,
+        policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
+        requiresHumanReview: scope === 'plotTextHint',
+      })),
       guardrailResult: { outcome: 'accept' },
       applyResult: {
         attempted: true,
-        outcome: applyScopes.includes('plotTextHint')
-          ? 'applied_summary_option_bias_and_plot_text'
-          : 'applied_summary_and_option_bias',
-        reason: `web mock 已将提案应用到低风险输出层，target=${targetSegment}，scopes=${applyScopes.join(',')}，正文为：${paragraph}`,
+        outcome: 'applied_summary_and_option_bias',
+        reason: `web mock 已将提案应用到低风险输出层，plotTextHint 等待人工复核，target=${targetSegment}，scopes=${applyScopes.join(',')}，正文为：${paragraph}`,
       },
       fallbackUsed: false,
       elapsedMs: 0,
@@ -481,6 +504,540 @@ function appendWebNoNameTrace(
   }
 }
 
+function markWebNoNameControlledOutputReview(payload: NoNameHumanReviewMarkPayload): NoNameTrace {
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === payload.traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${payload.traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? [])
+    .find((item) => item.requestId === payload.requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${payload.requestId}`);
+  }
+  if (review.decision !== 'needsReview' || !review.requiresHumanReview) {
+    throw new Error(`NoName controlled output review does not require human review: ${payload.requestId}`);
+  }
+
+  review.humanReviewDecision = payload.decision;
+  review.humanReviewedAt = Math.floor(Date.now() / 1000);
+  review.humanReviewNote = payload.decision === 'approvedForHigherApply'
+    ? '人工确认可进入高层 apply 设计，仍需后端二次 guardrail'
+    : payload.decision === 'rejectedForHigherApply'
+      ? '人工确认暂不应用，保持当前安全边界'
+      : '人工复核已重置为待确认，未触发高层 apply';
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${payload.requestId}:human_review:${payload.decision}`,
+  ];
+  const target = review.safeApplyScope ?? 'controlled_output';
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  const priority = review.safeApplyScope === 'plotTextHint'
+    ? 325
+    : review.safeApplyScope === 'chapterSummaryHint'
+      ? 225
+      : review.safeApplyScope === 'optionBiasHint'
+        ? 125
+        : 35;
+
+  if (payload.decision === 'pending') {
+    trace.applyPlanLog = [
+      ...(trace.applyPlanLog ?? []),
+      {
+        order: nextOrder,
+        target,
+        decision: 'review_intent_pending',
+        priority,
+        note: '人工复核已重置为待确认，未进入二次 guardrail',
+      },
+    ];
+    trace.applyExecutionLog = [
+      ...(trace.applyExecutionLog ?? []),
+      {
+        target,
+        outcome: 'human_review_pending',
+        note: '等待人工确认，不触发高层 apply',
+      },
+    ];
+    trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:pending`);
+    return trace;
+  }
+
+  if (payload.decision === 'rejectedForHigherApply') {
+    trace.applyPlanLog = [
+      ...(trace.applyPlanLog ?? []),
+      {
+        order: nextOrder,
+        target,
+        decision: 'reject',
+        priority,
+        note: '人工复核拒绝进入高层 apply，保持安全边界',
+      },
+    ];
+    trace.applyExecutionLog = [
+      ...(trace.applyExecutionLog ?? []),
+      {
+        target,
+        outcome: 'rejected_by_human_review',
+        note: '开发者选择暂不应用，未触发二次 guardrail',
+      },
+    ];
+    trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:rejected_by_human_review`);
+    return trace;
+  }
+
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => payload.requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  const secondGuardrailRejected = trace.mode !== 'assisted'
+    || review.safeApplyScope !== 'plotTextHint'
+    || !proposal
+    || proposal.status !== 'applied'
+    || !proposal.applyable
+    || !['current_turn_head', 'current_turn_tail'].includes(proposal.targetSegment);
+  if (secondGuardrailRejected) {
+    trace.applyPlanLog = [
+      ...(trace.applyPlanLog ?? []),
+      {
+        order: nextOrder,
+        target,
+        decision: 'second_guardrail_reject',
+        priority,
+        note: 'web mock 二次 guardrail 拒绝高层 apply intent',
+      },
+    ];
+    trace.applyExecutionLog = [
+      ...(trace.applyExecutionLog ?? []),
+      {
+        target,
+        outcome: 'second_guardrail_rejected',
+        note: 'web mock 未满足高层 apply intent 条件',
+      },
+    ];
+    trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:second_guardrail_rejected`);
+    return trace;
+  }
+
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target,
+      decision: 'review_intent_ready',
+      priority,
+      note: '人工确认已通过，已排入二次 guardrail / apply planner，未写入正文',
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target,
+      outcome: 'awaiting_second_guardrail',
+      note: '高层 apply intent 已记录，等待后续二次 guardrail 决策',
+    },
+  ];
+  trace.proposalTransitionLog.push(`${payload.requestId}:apply_intent:awaiting_second_guardrail`);
+  return trace;
+}
+
+function resolveWebNoNameSecondGuardrail(payload: NoNameSecondGuardrailResolvePayload): NoNameTrace {
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === payload.traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${payload.traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? [])
+    .find((item) => item.requestId === payload.requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${payload.requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for second guardrail: ${payload.requestId}`);
+  }
+
+  const target = review.safeApplyScope ?? 'controlled_output';
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  const priority = review.safeApplyScope === 'plotTextHint'
+    ? 350
+    : review.safeApplyScope === 'chapterSummaryHint'
+      ? 250
+      : review.safeApplyScope === 'optionBiasHint'
+        ? 150
+        : 60;
+  const isWaiting = (trace.proposalTransitionLog ?? [])
+    .includes(`${payload.requestId}:apply_intent:awaiting_second_guardrail`)
+    || (trace.applyExecutionLog ?? []).some((item) => item.outcome === 'awaiting_second_guardrail');
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => payload.requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  const revalidateRejected = !isWaiting
+    || trace.mode !== 'assisted'
+    || review.safeApplyScope !== 'plotTextHint'
+    || !proposal
+    || proposal.status !== 'applied'
+    || !proposal.applyable
+    || !['current_turn_head', 'current_turn_tail'].includes(proposal.targetSegment);
+
+  const finalDecision = revalidateRejected ? 'reject' : payload.decision;
+  const planDecision = finalDecision === 'allow'
+    ? 'second_guardrail_allow'
+    : finalDecision === 'fallback'
+      ? 'second_guardrail_fallback'
+      : 'second_guardrail_reject';
+  const outcome = finalDecision === 'allow'
+    ? 'second_guardrail_allowed'
+    : finalDecision === 'fallback'
+      ? 'second_guardrail_fallback'
+      : 'second_guardrail_rejected';
+  const note = revalidateRejected
+    ? 'web mock 二次 guardrail 复核未通过'
+    : finalDecision === 'allow'
+      ? '二次 guardrail 允许进入后续人工 apply 命令；当前不写正文'
+      : finalDecision === 'fallback'
+        ? '二次 guardrail 要求回退经典链路'
+        : '二次 guardrail 人工拒绝高层 apply';
+
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target,
+      decision: planDecision,
+      priority,
+      note,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target,
+      outcome,
+      note: finalDecision === 'allow'
+        ? '已允许进入下一步人工 apply，但未改写剧情正文'
+        : note,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${payload.requestId}:second_guardrail:${finalDecision}`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: planDecision,
+    reason: note,
+  };
+  if (finalDecision === 'fallback') {
+    trace.fallbackUsed = true;
+    trace.graphPath = [...trace.graphPath, 'ApplyFallback'];
+  }
+  return trace;
+}
+
+function applyWebNoNameManualPlotTextHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  segmentIndex?: unknown;
+  expectedSegmentText?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const segmentIndex = Number(args.segmentIndex);
+  const expectedSegmentText = String(args.expectedSegmentText ?? '');
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'plotTextHint') {
+    throw new Error('manual apply currently only supports plotTextHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'plotTextHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web 模式下剧情未初始化。');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (plotState.current_chapter.content[segmentIndex] !== expectedSegmentText) {
+    throw new Error('segment snapshot mismatch; refusing stale manual apply');
+  }
+  if (expectedSegmentText.includes('【NoName】') || expectedSegmentText.includes('NoName提示')) {
+    throw new Error('segment already contains a NoName marker');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const hint = `【NoName】重点关注：${proposal.focus}`;
+  const updatedSegment = proposal.targetSegment === 'current_turn_head'
+    ? `${hint}\n\n${expectedSegmentText.trim()}`
+    : `${expectedSegmentText.trim()}\n\n${hint}`;
+  plotState.current_chapter.content[segmentIndex] = updatedSegment;
+  const historyIndex = plotState.plot_history.lastIndexOf(expectedSegmentText);
+  if (historyIndex < 0) {
+    throw new Error('plot history snapshot mismatch; refusing partial manual apply');
+  }
+  plotState.plot_history[historyIndex] = updatedSegment;
+  plotState.current_scene.description = plotState.current_chapter.content.join('\n\n');
+  if (plotState.last_action_result?.description === expectedSegmentText) {
+    plotState.last_action_result.description = updatedSegment;
+  }
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'plotTextHint',
+      decision: 'manual_apply',
+      priority: 375,
+      note: `显式人工 apply 已确认 chapter=${chapterIndex} segment=${segmentIndex}`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'plotTextHint',
+      outcome: 'manual_plot_text_applied',
+      note: `已由显式人工命令写入正文提示，聚焦“${proposal.focus}”`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:plot_text_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_plot_text_applied',
+    reason: '显式人工 apply 已写入正文提示',
+  };
+  return { trace, plotState };
+}
+
+function applyWebNoNameManualChapterSummaryHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  expectedSummary?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const expectedSummary = String(args.expectedSummary ?? '');
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'chapterSummaryHint') {
+    throw new Error('manual apply scope mismatch: expected chapterSummaryHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'chapterSummaryHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  if ((trace.applyExecutionLog ?? []).some((item) => (
+    item.target === 'chapterSummaryHint' && item.outcome === 'manual_chapter_summary_hint_applied'
+  ))) {
+    throw new Error('manual chapterSummaryHint has already been applied for this trace');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web runtime plot state is not initialized');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (plotState.current_chapter.summary !== expectedSummary) {
+    throw new Error('summary snapshot mismatch; refusing stale manual apply');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const focus = proposal.focus.trim();
+  const hint = `NoName summary hint: ${focus}`;
+  if (focus && (expectedSummary.includes(focus) || expectedSummary.includes(hint))) {
+    throw new Error('chapter summary already contains this NoName hint');
+  }
+  const currentSummary = expectedSummary.trim();
+  const updatedSummary = !currentSummary
+    ? hint
+    : proposal.targetSegment === 'chapter_summary_head'
+      ? `${hint}; ${currentSummary}`
+      : `${currentSummary}; ${hint}`;
+
+  plotState.current_chapter.summary = updatedSummary;
+  const chapter = plotState.chapters.find((item) => item.index === chapterIndex);
+  if (chapter) {
+    chapter.summary = updatedSummary;
+  }
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'chapterSummaryHint',
+      decision: 'manual_apply',
+      priority: 275,
+      note: `manual apply confirmed for chapter=${chapterIndex} scope=chapterSummaryHint`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'chapterSummaryHint',
+      outcome: 'manual_chapter_summary_hint_applied',
+      note: `manual chapter summary hint applied for focus=${proposal.focus}`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:chapter_summary_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_chapter_summary_hint_applied',
+    reason: 'manual chapter summary hint applied',
+  };
+  return { trace, plotState };
+}
+
+function applyWebNoNameManualOptionBiasHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  expectedGenerationDiagnostics?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const expectedGenerationDiagnostics = String(args.expectedGenerationDiagnostics ?? '');
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'optionBiasHint') {
+    throw new Error('manual apply scope mismatch: expected optionBiasHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'optionBiasHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  if ((trace.applyExecutionLog ?? []).some((item) => (
+    item.target === 'optionBiasHint' && item.outcome === 'manual_option_bias_hint_applied'
+  ))) {
+    throw new Error('manual optionBiasHint has already been applied for this trace');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web runtime plot state is not initialized');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (!plotState.is_waiting_for_input) {
+    throw new Error('optionBiasHint manual apply requires waiting-for-input state');
+  }
+  const currentDiagnostics = plotState.last_generation_diagnostics ?? '';
+  if (currentDiagnostics !== expectedGenerationDiagnostics) {
+    throw new Error('diagnostics snapshot mismatch; refusing stale manual apply');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const hint = `NoName option bias: next turn should prioritize actions around ${proposal.focus.trim()}`;
+  if (currentDiagnostics.includes(hint)) {
+    throw new Error('diagnostics already contains this NoName option bias hint');
+  }
+  plotState.last_generation_diagnostics = currentDiagnostics.trim()
+    ? `${currentDiagnostics}; ${hint}`
+    : hint;
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'optionBiasHint',
+      decision: 'manual_apply',
+      priority: 175,
+      note: `manual apply confirmed for chapter=${chapterIndex} scope=optionBiasHint`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'optionBiasHint',
+      outcome: 'manual_option_bias_hint_applied',
+      note: `manual option bias hint applied for focus=${proposal.focus}`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:option_bias_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_option_bias_hint_applied',
+    reason: 'manual option bias hint applied',
+  };
+  return { trace, plotState };
+}
+
 function resolveActionText(action: PlayerAction, options: PlayerOption[]): string {
   if (action.action_type === ActionType.FreeText) {
     return action.content.trim() || '你静静观察局势变化。';
@@ -499,9 +1056,7 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
   const baseParagraph = quickMode
     ? `你迅速执行“${text}”，局势发生了可控变化。`
     : `你选择“${text}”，新的线索逐渐浮现。`;
-  const paragraph = runtimeState.noNameMode === 'assisted' && applyScopes.includes('plotTextHint')
-    ? applyWebNoNamePlotHint(baseParagraph, text, targetSegment)
-    : baseParagraph;
+  const paragraph = baseParagraph;
 
   plotState.current_chapter.content.push(paragraph);
   plotState.plot_history.push(paragraph);
@@ -513,9 +1068,7 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
     plotState.last_generation_diagnostics += `；NoName.observeOnly：focus=${text}；target_segment=${targetSegment}；apply=skipped_observe_only`;
   }
   if (runtimeState.noNameMode === 'assisted') {
-    const applyOutcome = applyScopes.includes('plotTextHint')
-      ? 'applied_summary_option_bias_and_plot_text'
-      : 'applied_summary_and_option_bias';
+    const applyOutcome = 'applied_summary_and_option_bias';
     plotState.last_generation_diagnostics += `；NoName.assisted：focus=${text}；target_segment=${targetSegment}；scopes=${applyScopes.join(',')}；apply=${applyOutcome}`;
     if (applyScopes.includes('chapterSummaryHint')) {
       plotState.current_chapter.summary = applyWebNoNameSummaryHint(
@@ -730,6 +1283,34 @@ export async function invokeWebRuntime<T>(
       runtimeState.noNameTraces = [];
       persistState();
       return undefined as T;
+    case 'mark_noname_controlled_output_review': {
+      const trace = markWebNoNameControlledOutputReview(args as unknown as NoNameHumanReviewMarkPayload);
+      persistState();
+      return trace as T;
+    }
+    case 'resolve_noname_second_guardrail': {
+      const trace = resolveWebNoNameSecondGuardrail(args as unknown as NoNameSecondGuardrailResolvePayload);
+      persistState();
+      return trace as T;
+    }
+    case 'apply_noname_manual_plot_text_hint': {
+      const result = applyWebNoNameManualPlotTextHint(args);
+      persistState();
+      return result as T;
+    }
+    case 'apply_noname_reviewed_output': {
+      const result = args.scope === 'chapterSummaryHint'
+        ? applyWebNoNameManualChapterSummaryHint(args)
+        : args.scope === 'optionBiasHint'
+          ? applyWebNoNameManualOptionBiasHint(args)
+          : args.scope === 'plotTextHint'
+            ? applyWebNoNameManualPlotTextHint(args)
+            : (() => {
+              throw new Error(`Web mock reviewed apply currently does not support ${String(args.scope)}`);
+            })();
+      persistState();
+      return result as T;
+    }
     case 'get_noname_mode':
       return runtimeState.noNameMode as T;
     case 'set_noname_mode':

--- a/src/platform/webRuntime.ts
+++ b/src/platform/webRuntime.ts
@@ -8,7 +8,9 @@ import {
   type ConsistencyPolicy,
   type GameState,
   type MapLocationOverview,
+  type NoNameApplyExecutionRecord,
   type NoNameApplyScope,
+  type NoNameControlledOutputKind,
   type NoNameHumanReviewMarkPayload,
   type NoNameMode,
   type NoNameSecondGuardrailResolvePayload,
@@ -24,6 +26,7 @@ import {
 } from '../types/game';
 
 type WebNoNameMode = NoNameMode;
+type WebNoNamePendingAugmentationExecution = Pick<NoNameApplyExecutionRecord, 'target' | 'outcome' | 'note'>;
 
 type SaveSnapshot = {
   script: Script;
@@ -259,6 +262,7 @@ function buildPlotState(gameState: GameState): PlotState {
     last_generation_diagnostics: '链路：web_mock',
     last_option_generation_source: 'web_mock_rule',
     last_consistency_risk_score: 0,
+    pending_plot_augmentation_hints: [],
     settings: defaultPlotSettings(),
     current_chapter: {
       index: 1,
@@ -325,9 +329,53 @@ function deriveWebNoNameApplyScopes(targetSegment: NoNameTargetSegment): NoNameA
     targetSegment === 'current_turn_head' ||
     targetSegment === 'current_turn_tail'
   ) {
-    return [...baseScopes, 'plotTextHint'];
+    return [...baseScopes, 'plotAugmentationHint', 'plotTextHint'];
   }
   return baseScopes;
+}
+
+function webNoNameScopeTraceKey(scope: NoNameApplyScope) {
+  return scope === 'plotTextHint'
+    ? 'plot_text_hint'
+    : scope === 'plotAugmentationHint'
+      ? 'plot_augmentation_hint'
+      : scope;
+}
+
+function webNoNameScopePriority(scope: NoNameApplyScope) {
+  if (scope === 'plotTextHint') {
+    return 300;
+  }
+  if (scope === 'plotAugmentationHint') {
+    return 250;
+  }
+  if (scope === 'chapterSummaryHint') {
+    return 200;
+  }
+  if (scope === 'optionBiasHint') {
+    return 100;
+  }
+  return 50;
+}
+
+function webNoNameScopeKind(scope: NoNameApplyScope): NoNameControlledOutputKind {
+  if (scope === 'plotTextHint') {
+    return 'sceneAugmentation';
+  }
+  if (scope === 'plotAugmentationHint') {
+    return 'nonFinalPlotAugmentation';
+  }
+  if (scope === 'chapterSummaryHint') {
+    return 'recapNote';
+  }
+  if (scope === 'optionBiasHint') {
+    return 'intermediateNarrativeHint';
+  }
+  return 'narrativeNote';
+}
+
+function webNoNameScopeRequiresHumanReview(scope: NoNameApplyScope) {
+  return scope === 'plotTextHint' || scope === 'plotAugmentationHint';
 }
 
 function applyWebNoNameSummaryHint(summary: string, focus: string, targetSegment: NoNameTargetSegment): string {
@@ -349,6 +397,7 @@ function appendWebNoNameTrace(
   paragraph: string,
   targetSegment: NoNameTargetSegment,
   applyScopes: NoNameApplyScope[],
+  pendingAugmentationExecution: WebNoNamePendingAugmentationExecution | null = null,
 ) {
   const traceId = `web-trace-${Date.now()}`;
   const proposalId = `proposal-${traceId}`;
@@ -394,25 +443,26 @@ function appendWebNoNameTrace(
         `${proposalId}:ready`,
         `${proposalId}:apply_preflight:ready`,
         ...applyScopes
-          .filter((scope) => scope !== 'plotTextHint')
+          .filter((scope) => !webNoNameScopeRequiresHumanReview(scope))
           .map((scope) => `${proposalId}:applied:${scope}`),
-        ...(applyScopes.includes('plotTextHint')
-          ? [`${proposalId}:controlled_output:plot_text_hint:needs_review`]
-          : []),
+        ...applyScopes
+          .filter((scope) => webNoNameScopeRequiresHumanReview(scope))
+          .map((scope) => `${proposalId}:controlled_output:${webNoNameScopeTraceKey(scope)}:needs_review`),
       ],
       applyPlanLog: applyScopes
         .map((scope) => ({
         target: scope,
-        decision: scope === 'plotTextHint' ? 'needs_review' : 'apply',
-        priority: scope === 'plotTextHint' ? 300 : scope === 'chapterSummaryHint' ? 200 : scope === 'optionBiasHint' ? 100 : 50,
-        note: scope === 'plotTextHint'
-          ? 'web mock plotTextHint 需要人工复核'
+        decision: webNoNameScopeRequiresHumanReview(scope) ? 'needs_review' : 'apply',
+        priority: webNoNameScopePriority(scope),
+        note: webNoNameScopeRequiresHumanReview(scope)
+          ? `web mock ${scope} 需要人工复核`
           : `web mock 允许执行 ${scope}`,
       }))
         .sort((left, right) => right.priority - left.priority)
         .map((item, index) => ({ ...item, order: index + 1 })),
-      applyExecutionLog: applyScopes
-        .filter((scope) => scope !== 'plotTextHint')
+      applyExecutionLog: [
+        ...applyScopes
+        .filter((scope) => !webNoNameScopeRequiresHumanReview(scope))
         .map((scope) => ({
         target: scope,
         outcome: 'applied',
@@ -422,29 +472,19 @@ function appendWebNoNameTrace(
               ? `已补充下轮选项偏置提示，聚焦“${text}”`
               : `已补充诊断提示，聚焦“${text}”`,
       })),
+        ...(pendingAugmentationExecution ? [pendingAugmentationExecution] : []),
+      ],
       controlledOutputReviews: applyScopes.map((scope) => ({
-        requestId: `controlled-output-${proposalId}-${scope === 'plotTextHint' ? 'plot_text_hint' : scope}`,
-        requestedKind: scope === 'plotTextHint'
-          ? 'sceneAugmentation'
-          : scope === 'chapterSummaryHint'
-            ? 'recapNote'
-            : scope === 'optionBiasHint'
-              ? 'intermediateNarrativeHint'
-              : 'narrativeNote',
-        decision: scope === 'plotTextHint' ? 'needsReview' : 'allow',
-        reason: scope === 'plotTextHint'
-          ? 'plot text hint requires human review before higher-layer apply'
+        requestId: `controlled-output-${proposalId}-${webNoNameScopeTraceKey(scope)}`,
+        requestedKind: webNoNameScopeKind(scope),
+        decision: webNoNameScopeRequiresHumanReview(scope) ? 'needsReview' : 'allow',
+        reason: webNoNameScopeRequiresHumanReview(scope)
+          ? `${scope} requires human review before higher-layer apply`
           : 'controlled output stays within allowed boundary',
-        normalizedKind: scope === 'plotTextHint'
-          ? 'sceneAugmentation'
-          : scope === 'chapterSummaryHint'
-            ? 'recapNote'
-            : scope === 'optionBiasHint'
-              ? 'intermediateNarrativeHint'
-              : 'narrativeNote',
+        normalizedKind: webNoNameScopeKind(scope),
         safeApplyScope: scope,
         policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
-        requiresHumanReview: scope === 'plotTextHint',
+        requiresHumanReview: webNoNameScopeRequiresHumanReview(scope),
       })),
       guardrailResult: { outcome: 'accept' },
       applyResult: {
@@ -486,7 +526,7 @@ function appendWebNoNameTrace(
         .map((scope) => ({
         target: scope,
         decision: 'skip',
-        priority: scope === 'plotTextHint' ? 300 : scope === 'chapterSummaryHint' ? 200 : scope === 'optionBiasHint' ? 100 : 50,
+        priority: webNoNameScopePriority(scope),
         note: `web mock observe-only：${scope} 仅记录不执行`,
       }))
         .sort((left, right) => right.priority - left.priority)
@@ -531,13 +571,9 @@ function markWebNoNameControlledOutputReview(payload: NoNameHumanReviewMarkPaylo
   ];
   const target = review.safeApplyScope ?? 'controlled_output';
   const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
-  const priority = review.safeApplyScope === 'plotTextHint'
-    ? 325
-    : review.safeApplyScope === 'chapterSummaryHint'
-      ? 225
-      : review.safeApplyScope === 'optionBiasHint'
-        ? 125
-        : 35;
+  const priority = typeof review.safeApplyScope === 'string'
+    ? webNoNameScopePriority(review.safeApplyScope) + 25
+    : 35;
 
   if (payload.decision === 'pending') {
     trace.applyPlanLog = [
@@ -591,7 +627,10 @@ function markWebNoNameControlledOutputReview(payload: NoNameHumanReviewMarkPaylo
     .find((item) => payload.requestId.includes(item.proposalId))
     ?? trace.proposals[trace.proposals.length - 1];
   const secondGuardrailRejected = trace.mode !== 'assisted'
-    || review.safeApplyScope !== 'plotTextHint'
+    || !(
+      review.safeApplyScope === 'plotTextHint'
+      || review.safeApplyScope === 'plotAugmentationHint'
+    )
     || !proposal
     || proposal.status !== 'applied'
     || !proposal.applyable
@@ -657,13 +696,9 @@ function resolveWebNoNameSecondGuardrail(payload: NoNameSecondGuardrailResolvePa
 
   const target = review.safeApplyScope ?? 'controlled_output';
   const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
-  const priority = review.safeApplyScope === 'plotTextHint'
-    ? 350
-    : review.safeApplyScope === 'chapterSummaryHint'
-      ? 250
-      : review.safeApplyScope === 'optionBiasHint'
-        ? 150
-        : 60;
+  const priority = typeof review.safeApplyScope === 'string'
+    ? webNoNameScopePriority(review.safeApplyScope) + 50
+    : 60;
   const isWaiting = (trace.proposalTransitionLog ?? [])
     .includes(`${payload.requestId}:apply_intent:awaiting_second_guardrail`)
     || (trace.applyExecutionLog ?? []).some((item) => item.outcome === 'awaiting_second_guardrail');
@@ -674,7 +709,10 @@ function resolveWebNoNameSecondGuardrail(payload: NoNameSecondGuardrailResolvePa
     ?? trace.proposals[trace.proposals.length - 1];
   const revalidateRejected = !isWaiting
     || trace.mode !== 'assisted'
-    || review.safeApplyScope !== 'plotTextHint'
+    || !(
+      review.safeApplyScope === 'plotTextHint'
+      || review.safeApplyScope === 'plotAugmentationHint'
+    )
     || !proposal
     || proposal.status !== 'applied'
     || !proposal.applyable
@@ -1038,6 +1076,104 @@ function applyWebNoNameManualOptionBiasHint(args: {
   return { trace, plotState };
 }
 
+function applyWebNoNameManualPlotAugmentationHint(args: {
+  traceId?: unknown;
+  requestId?: unknown;
+  chapterIndex?: unknown;
+  expectedPlotAugmentationHints?: unknown;
+}) {
+  const traceId = String(args.traceId ?? '');
+  const requestId = String(args.requestId ?? '');
+  const chapterIndex = Number(args.chapterIndex);
+  const expectedHints = Array.isArray(args.expectedPlotAugmentationHints)
+    ? args.expectedPlotAugmentationHints.map((item) => String(item))
+    : [];
+  const trace = runtimeState.noNameTraces.find((item) => item.traceId === traceId);
+  if (!trace) {
+    throw new Error(`NoName trace not found: ${traceId}`);
+  }
+  const review = (trace.controlledOutputReviews ?? []).find((item) => item.requestId === requestId);
+  if (!review) {
+    throw new Error(`NoName controlled output review not found: ${requestId}`);
+  }
+  if (review.humanReviewDecision !== 'approvedForHigherApply') {
+    throw new Error(`NoName controlled output review is not approved for manual apply: ${requestId}`);
+  }
+  if (review.safeApplyScope !== 'plotAugmentationHint') {
+    throw new Error('manual apply scope mismatch: expected plotAugmentationHint');
+  }
+  const hasSecondGuardrailAllow = (trace.proposalTransitionLog ?? [])
+    .includes(`${requestId}:second_guardrail:allow`)
+    || (trace.applyExecutionLog ?? []).some((item) => (
+      item.target === 'plotAugmentationHint' && item.outcome === 'second_guardrail_allowed'
+    ));
+  if (!hasSecondGuardrailAllow) {
+    throw new Error('second guardrail has not allowed this review');
+  }
+  if ((trace.applyExecutionLog ?? []).some((item) => (
+    item.target === 'plotAugmentationHint' && item.outcome === 'manual_plot_augmentation_hint_applied'
+  ))) {
+    throw new Error('manual plotAugmentationHint has already been applied for this trace');
+  }
+  const plotState = runtimeState.plotState;
+  if (!plotState) {
+    throw new Error('Web runtime plot state is not initialized');
+  }
+  if (plotState.current_chapter.index !== chapterIndex) {
+    throw new Error(`chapter mismatch: expected ${chapterIndex}, current ${plotState.current_chapter.index}`);
+  }
+  if (!plotState.is_waiting_for_input) {
+    throw new Error('plotAugmentationHint manual apply requires waiting-for-input state');
+  }
+  const currentHints = plotState.pending_plot_augmentation_hints ?? [];
+  if (JSON.stringify(currentHints) !== JSON.stringify(expectedHints)) {
+    throw new Error('plot augmentation snapshot mismatch; refusing stale manual apply');
+  }
+  const proposal = trace.proposals
+    .slice()
+    .reverse()
+    .find((item) => requestId.includes(item.proposalId))
+    ?? trace.proposals[trace.proposals.length - 1];
+  if (!proposal) {
+    throw new Error('NoName proposal not found for manual apply');
+  }
+  const hint = `NoName plot augmentation: focus=${proposal.focus.trim()} | effect=${proposal.intendedEffect.trim()}`;
+  if (currentHints.includes(hint)) {
+    throw new Error('plot augmentation already contains this NoName hint');
+  }
+  plotState.pending_plot_augmentation_hints = [...currentHints, hint];
+
+  const nextOrder = Math.max(0, ...(trace.applyPlanLog ?? []).map((item) => item.order)) + 1;
+  trace.applyPlanLog = [
+    ...(trace.applyPlanLog ?? []),
+    {
+      order: nextOrder,
+      target: 'plotAugmentationHint',
+      decision: 'manual_apply',
+      priority: 325,
+      note: `manual apply confirmed for chapter=${chapterIndex} scope=plotAugmentationHint`,
+    },
+  ];
+  trace.applyExecutionLog = [
+    ...(trace.applyExecutionLog ?? []),
+    {
+      target: 'plotAugmentationHint',
+      outcome: 'manual_plot_augmentation_hint_applied',
+      note: `manual plot augmentation hint staged for focus=${proposal.focus}`,
+    },
+  ];
+  trace.proposalTransitionLog = [
+    ...(trace.proposalTransitionLog ?? []),
+    `${requestId}:manual_apply:plot_augmentation_hint`,
+  ];
+  trace.applyResult = {
+    attempted: true,
+    outcome: 'manual_plot_augmentation_hint_applied',
+    reason: 'manual plot augmentation hint staged',
+  };
+  return { trace, plotState };
+}
+
 function resolveActionText(action: PlayerAction, options: PlayerOption[]): string {
   if (action.action_type === ActionType.FreeText) {
     return action.content.trim() || '你静静观察局势变化。';
@@ -1053,6 +1189,8 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
   const text = resolveActionText(action, plotState.current_scene.available_options);
   const targetSegment = pickWebNoNameTargetSegment(action);
   const applyScopes = deriveWebNoNameApplyScopes(targetSegment);
+  const pendingPlotAugmentationHints = [...(plotState.pending_plot_augmentation_hints ?? [])];
+  let pendingAugmentationExecution: WebNoNamePendingAugmentationExecution | null = null;
   const baseParagraph = quickMode
     ? `你迅速执行“${text}”，局势发生了可控变化。`
     : `你选择“${text}”，新的线索逐渐浮现。`;
@@ -1070,6 +1208,24 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
   if (runtimeState.noNameMode === 'assisted') {
     const applyOutcome = 'applied_summary_and_option_bias';
     plotState.last_generation_diagnostics += `；NoName.assisted：focus=${text}；target_segment=${targetSegment}；scopes=${applyScopes.join(',')}；apply=${applyOutcome}`;
+    if (pendingPlotAugmentationHints.length > 0) {
+      if (quickMode) {
+        pendingAugmentationExecution = {
+          target: 'plotAugmentationHint',
+          outcome: 'pending_plot_augmentation_retained',
+          note: `pending plot augmentation retained because quick_mode; count=${pendingPlotAugmentationHints.length}`,
+        };
+        plotState.last_generation_diagnostics += '; NoName pending plot augmentation retained(quick_mode)';
+      } else {
+        plotState.pending_plot_augmentation_hints = [];
+        pendingAugmentationExecution = {
+          target: 'plotAugmentationHint',
+          outcome: 'pending_plot_augmentation_consumed',
+          note: `pending plot augmentation consumed after web mock generation; count=${pendingPlotAugmentationHints.length}`,
+        };
+        plotState.last_generation_diagnostics += `; NoName pending plot augmentation consumed=${pendingPlotAugmentationHints.length}`;
+      }
+    }
     if (applyScopes.includes('chapterSummaryHint')) {
       plotState.current_chapter.summary = applyWebNoNameSummaryHint(
         plotState.current_chapter.summary,
@@ -1094,7 +1250,7 @@ function updateAfterAction(action: PlayerAction, quickMode: boolean) {
   gameState.game_time.total_days += 1;
   gameState.game_time.day += 1;
   gameState.player.stats.combat_power += 2;
-  appendWebNoNameTrace(text, paragraph, targetSegment, applyScopes);
+  appendWebNoNameTrace(text, paragraph, targetSegment, applyScopes, pendingAugmentationExecution);
 }
 
 function listReachable(): string[] {
@@ -1303,11 +1459,13 @@ export async function invokeWebRuntime<T>(
         ? applyWebNoNameManualChapterSummaryHint(args)
         : args.scope === 'optionBiasHint'
           ? applyWebNoNameManualOptionBiasHint(args)
-          : args.scope === 'plotTextHint'
-            ? applyWebNoNameManualPlotTextHint(args)
-            : (() => {
-              throw new Error(`Web mock reviewed apply currently does not support ${String(args.scope)}`);
-            })();
+          : args.scope === 'plotAugmentationHint'
+            ? applyWebNoNameManualPlotAugmentationHint(args)
+            : args.scope === 'plotTextHint'
+              ? applyWebNoNameManualPlotTextHint(args)
+              : (() => {
+                throw new Error(`Web mock reviewed apply currently does not support ${String(args.scope)}`);
+              })();
       persistState();
       return result as T;
     }

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -367,6 +367,7 @@ describe('gameStore', () => {
         safeApplyScope: 'plotTextHint',
         policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
         requiresHumanReview: true,
+        humanReviewDecision: 'approvedForHigherApply',
       }],
       relatedObservations: [{
         role: 'worldCurator',
@@ -413,9 +414,10 @@ describe('gameStore', () => {
 
     const text = store.getNoNameTraceDebugText();
     expect(text).toContain('预检：preflight_ready');
+    expect(text).toContain('应用生命周期：提案阶段:ready');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
-    expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact]');
+    expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact][人工=approvedForHigherApply]');
     expect(text).toContain('状态迁移：proposal-1:ready');
     expect(text).toContain('提案：Director提案：山门危机 / 山门危机 / ready');
     expect(text).toContain('目标段：current_turn_tail');
@@ -423,5 +425,164 @@ describe('gameStore', () => {
     expect(text).toContain('作用域：diagnostics, chapterSummaryHint');
     expect(text).toContain('agent:delegation:running');
     expect(text).toContain('协作观察：worldCurator:山门法阵');
+  });
+
+  it('marks a NoName controlled output review and updates local trace', async () => {
+    const store = useGameStore();
+    store.noNameTraces = [{
+      traceId: 'trace-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+      controlledOutputReviews: [{
+        requestId: 'review-1',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'requires review',
+        safeApplyScope: 'plotTextHint',
+        requiresHumanReview: true,
+      }],
+    }];
+    invokeMock.mockResolvedValue({
+      ...store.noNameTraces[0],
+      controlledOutputReviews: [{
+        requestId: 'review-1',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'requires review',
+        safeApplyScope: 'plotTextHint',
+        requiresHumanReview: true,
+        humanReviewDecision: 'rejectedForHigherApply',
+      }],
+    });
+
+    await store.markNoNameControlledOutputReview({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'rejectedForHigherApply',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('mark_noname_controlled_output_review', {
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'rejectedForHigherApply',
+    });
+    expect(store.noNameTraces[0].controlledOutputReviews?.[0].humanReviewDecision)
+      .toBe('rejectedForHigherApply');
+  });
+
+  it('resolves a NoName second guardrail decision and updates local trace', async () => {
+    const store = useGameStore();
+    store.noNameTraces = [{
+      traceId: 'trace-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+      applyPlanLog: [],
+      applyExecutionLog: [],
+    }];
+    invokeMock.mockResolvedValue({
+      ...store.noNameTraces[0],
+      applyPlanLog: [{
+        order: 1,
+        target: 'plot_text_hint',
+        decision: 'second_guardrail_allow',
+        priority: 350,
+        note: 'allowed',
+      }],
+    });
+
+    await store.resolveNoNameSecondGuardrail({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'allow',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('resolve_noname_second_guardrail', {
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      decision: 'allow',
+    });
+    expect(store.noNameTraces[0].applyPlanLog?.[0]?.decision).toBe('second_guardrail_allow');
+  });
+
+  it('applies a manual NoName plot text hint with current segment snapshot', async () => {
+    const store = useGameStore();
+    const plotState = basePlotState();
+    plotState.current_chapter.index = 1;
+    plotState.current_chapter.content = ['你看见山门风声渐紧。'];
+    plotState.plot_history = ['你看见山门风声渐紧。'];
+    store.plotState = plotState;
+    store.noNameTraces = [{
+      traceId: 'trace-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+    }];
+    invokeMock.mockResolvedValue({
+      trace: {
+        ...store.noNameTraces[0],
+        applyExecutionLog: [{
+          target: 'plot_text_hint',
+          outcome: 'manual_plot_text_applied',
+          note: 'applied',
+        }],
+      },
+      plotState: {
+        ...plotState,
+        current_chapter: {
+          ...plotState.current_chapter,
+          content: ['你看见山门风声渐紧。\n\n【NoName】重点关注：山门危机'],
+        },
+      },
+    });
+
+    await store.applyNoNameManualPlotTextHint({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('apply_noname_reviewed_output', {
+      traceId: 'trace-1',
+      requestId: 'review-1',
+      scope: 'plotTextHint',
+      chapterIndex: 1,
+      segmentIndex: 0,
+      expectedSegmentText: '你看见山门风声渐紧。',
+    });
+    expect(store.plotState?.current_chapter.content[0]).toContain('【NoName】重点关注');
+    expect(store.noNameTraces[0].applyExecutionLog?.[0]?.outcome)
+      .toBe('manual_plot_text_applied');
+  });
+
+  it('shows a friendly stale snapshot error for manual NoName plot text apply', async () => {
+    const store = useGameStore();
+    const plotState = basePlotState();
+    plotState.current_chapter.index = 1;
+    plotState.current_chapter.content = ['你看见山门风声渐紧。'];
+    store.plotState = plotState;
+    invokeMock.mockRejectedValue(new Error('segment snapshot mismatch; refusing stale manual apply'));
+
+    await expect(store.applyNoNameManualPlotTextHint({
+      traceId: 'trace-1',
+      requestId: 'review-1',
+    })).rejects.toThrow('当前剧情段落已变化');
+
+    expect(store.error).toBe('NoName 人工写入已取消：当前剧情段落已变化，请重新打开调试台确认差异预览。');
   });
 });

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -341,7 +341,7 @@ describe('gameStore', () => {
         intendedEffect: '为下一轮低风险输出提供导向',
         rationale: '当前章节冲突正在汇聚',
         labels: ['director', 'assisted_ready'],
-        applyScopes: ['diagnostics', 'chapterSummaryHint'],
+        applyScopes: ['diagnostics', 'chapterSummaryHint', 'plotAugmentationHint'],
         status: 'ready',
         applyable: true,
       }],
@@ -357,6 +357,10 @@ describe('gameStore', () => {
         target: 'chapter_summary_hint',
         outcome: 'applied',
         note: '已写入章节摘要提示',
+      }, {
+        target: 'plot_augmentation_hint',
+        outcome: 'pending_plot_augmentation_consumed',
+        note: 'pending plot augmentation consumed after plot_engine generation; count=1',
       }],
       controlledOutputReviews: [{
         requestId: 'controlled-output-proposal-1-plot_text_hint',
@@ -374,6 +378,13 @@ describe('gameStore', () => {
         actionSummary: '玩家返回山门',
         focus: '山门法阵',
         rationale: '需要补齐世界设定锚点',
+        roleGoal: 'Maintain world facts, scene constraints, and canon anchors.',
+        sceneFocus: '山门法阵',
+        forbiddenScopes: ['Must not decide NPC private intent.'],
+        noteTypeHits: ['goal: Hold Gate'],
+        sourceStats: [{ source: 'hard_facts', count: 2 }],
+        contextTokenBudgetUsed: 42,
+        contextSliceStats: [{ section: 'worldFacts', sourceCount: 4, visibleCount: 3 }],
         proposal: {
           proposalId: 'proposal-world-1',
           kind: 'worldPatchProposal',
@@ -417,14 +428,22 @@ describe('gameStore', () => {
     expect(text).toContain('应用生命周期：提案阶段:ready');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
+    expect(text).toContain('剧情增强提示:已消费[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]');
     expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact][人工=approvedForHigherApply]');
     expect(text).toContain('状态迁移：proposal-1:ready');
     expect(text).toContain('提案：Director提案：山门危机 / 山门危机 / ready');
     expect(text).toContain('目标段：current_turn_tail');
     expect(text).toContain('预期效果：为下一轮低风险输出提供导向');
     expect(text).toContain('作用域：diagnostics, chapterSummaryHint');
+    expect(text).toContain('剧情增强提示：已消费');
     expect(text).toContain('agent:delegation:running');
+    expect(text).toContain('[来源=hard_facts:2]');
+    expect(text).toContain('[token=42]');
+    expect(text).toContain('[裁剪=worldFacts:4->3]');
     expect(text).toContain('协作观察：worldCurator:山门法阵');
+    expect(text).toContain('[上下文=Maintain world facts, scene constraints, and canon anchors. / 山门法阵]');
+    expect(text).toContain('[禁区=Must not decide NPC private intent.]');
+    expect(text).toContain('[笔记=goal: Hold Gate]');
   });
 
   it('marks a NoName controlled output review and updates local trace', async () => {
@@ -568,6 +587,107 @@ describe('gameStore', () => {
     expect(store.plotState?.current_chapter.content[0]).toContain('【NoName】重点关注');
     expect(store.noNameTraces[0].applyExecutionLog?.[0]?.outcome)
       .toBe('manual_plot_text_applied');
+  });
+
+  it('applies a manual NoName chapter summary hint with current summary snapshot', async () => {
+    const store = useGameStore();
+    const plotState = basePlotState();
+    plotState.current_chapter.index = 2;
+    plotState.current_chapter.summary = '已有摘要';
+    store.plotState = plotState;
+    store.noNameTraces = [{
+      traceId: 'trace-summary',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+    }];
+    invokeMock.mockResolvedValue({
+      trace: {
+        ...store.noNameTraces[0],
+        applyExecutionLog: [{
+          target: 'chapter_summary_hint',
+          outcome: 'manual_chapter_summary_hint_applied',
+          note: 'applied',
+        }],
+      },
+      plotState: {
+        ...plotState,
+        current_chapter: {
+          ...plotState.current_chapter,
+          summary: '已有摘要; NoName summary hint: 山门危机',
+        },
+      },
+    });
+
+    await store.applyNoNameManualChapterSummaryHint({
+      traceId: 'trace-summary',
+      requestId: 'review-summary',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('apply_noname_reviewed_output', {
+      traceId: 'trace-summary',
+      requestId: 'review-summary',
+      scope: 'chapterSummaryHint',
+      chapterIndex: 2,
+      expectedSummary: '已有摘要',
+    });
+    expect(store.plotState?.current_chapter.summary).toContain('NoName summary hint');
+    expect(store.noNameTraces[0].applyExecutionLog?.[0]?.outcome)
+      .toBe('manual_chapter_summary_hint_applied');
+  });
+
+  it('applies a manual NoName option bias hint with current diagnostics snapshot', async () => {
+    const store = useGameStore();
+    const plotState = basePlotState();
+    plotState.current_chapter.index = 3;
+    plotState.last_generation_diagnostics = 'base diagnostics';
+    store.plotState = plotState;
+    store.noNameTraces = [{
+      traceId: 'trace-option',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      mode: 'assisted',
+      graphPath: [],
+      capabilityCalls: [],
+      proposals: [],
+      fallbackUsed: false,
+      elapsedMs: 0,
+    }];
+    invokeMock.mockResolvedValue({
+      trace: {
+        ...store.noNameTraces[0],
+        applyExecutionLog: [{
+          target: 'option_bias_hint',
+          outcome: 'manual_option_bias_hint_applied',
+          note: 'applied',
+        }],
+      },
+      plotState: {
+        ...plotState,
+        last_generation_diagnostics: 'base diagnostics; NoName option bias: focus',
+      },
+    });
+
+    await store.applyNoNameManualOptionBiasHint({
+      traceId: 'trace-option',
+      requestId: 'review-option',
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('apply_noname_reviewed_output', {
+      traceId: 'trace-option',
+      requestId: 'review-option',
+      scope: 'optionBiasHint',
+      chapterIndex: 3,
+      expectedGenerationDiagnostics: 'base diagnostics',
+    });
+    expect(store.plotState?.last_generation_diagnostics).toContain('NoName option bias');
+    expect(store.noNameTraces[0].applyExecutionLog?.[0]?.outcome)
+      .toBe('manual_option_bias_hint_applied');
   });
 
   it('shows a friendly stale snapshot error for manual NoName plot text apply', async () => {

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -358,6 +358,16 @@ describe('gameStore', () => {
         outcome: 'applied',
         note: '已写入章节摘要提示',
       }],
+      controlledOutputReviews: [{
+        requestId: 'controlled-output-proposal-1-plot_text_hint',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'plot text hint requires human review before higher-layer apply',
+        normalizedKind: 'sceneAugmentation',
+        safeApplyScope: 'plotTextHint',
+        policyForbiddenScopes: ['finalPlotState', 'canonWorldFact'],
+        requiresHumanReview: true,
+      }],
       relatedObservations: [{
         role: 'worldCurator',
         actionSummary: '玩家返回山门',
@@ -405,6 +415,7 @@ describe('gameStore', () => {
     expect(text).toContain('预检：preflight_ready');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
+    expect(text).toContain('受控输出复核：sceneAugmentation:plotTextHint:needsReview:human[禁区=finalPlotState/canonWorldFact]');
     expect(text).toContain('状态迁移：proposal-1:ready');
     expect(text).toContain('提案：Director提案：山门危机 / 山门危机 / ready');
     expect(text).toContain('目标段：current_turn_tail');

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -226,7 +226,12 @@ export const useGameStore = defineStore('game', {
         : '无';
       const controlledOutputReviews = latest.controlledOutputReviews && latest.controlledOutputReviews.length > 0
         ? latest.controlledOutputReviews
-          .map((item) => `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}`)
+          .map((item) => {
+            const policyScopes = item.policyForbiddenScopes?.length
+              ? `[禁区=${item.policyForbiddenScopes.join('/')}]`
+              : '';
+            return `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}${policyScopes}`;
+          })
           .join(', ')
         : '无';
       return [

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,6 +1,10 @@
 ﻿import { defineStore } from 'pinia';
 import { invokeRuntime, invokeWithTimeout } from '../utils/tauriInvoke';
-import { summarizeNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
+import {
+  summarizeNoNameApplyExecutions,
+  summarizeNoNameApplyLifecycle,
+  summarizeNoNamePendingPlotAugmentation,
+} from '../utils/noNameApplyLifecycle';
 import type {
   Script,
   GameState,
@@ -13,6 +17,9 @@ import type {
   GenerationTimingSummary,
   GenerationFailureSummary,
   NoNameHumanReviewMarkPayload,
+  NoNameManualChapterSummaryHintApplyPayload,
+  NoNameManualOptionBiasHintApplyPayload,
+  NoNameManualPlotAugmentationHintApplyPayload,
   NoNameManualPlotTextApplyPayload,
   NoNameManualPlotTextApplyResult,
   NoNameSecondGuardrailResolvePayload,
@@ -45,10 +52,22 @@ function humanizeNoNameManualApplyError(error: unknown) {
   if (message.includes('segment snapshot mismatch')) {
     return 'NoName 人工写入已取消：当前剧情段落已变化，请重新打开调试台确认差异预览。';
   }
+  if (message.includes('summary snapshot mismatch')) {
+    return 'NoName 人工写入已取消：当前章节摘要已变化，请重新打开调试台确认差异预览。';
+  }
+  if (message.includes('diagnostics snapshot mismatch')) {
+    return 'NoName 人工写入已取消：当前诊断提示已变化，请重新打开调试台确认差异预览。';
+  }
+  if (message.includes('plot augmentation snapshot mismatch')) {
+    return 'NoName 人工写入已取消：当前剧情增强提示列表已变化，请重新打开调试台确认差异预览。';
+  }
   if (message.includes('segment already contains a NoName marker')) {
     return 'NoName 人工写入已取消：当前段落已经包含 NoName 标记，避免重复写入。';
   }
-  if (message.includes('manual plot text hint has already been applied')) {
+  if (
+    message.includes('manual plot text hint has already been applied')
+    || message.includes('has already been applied for this trace')
+  ) {
     return 'NoName 人工写入已取消：这条提示已经应用过了。';
   }
   if (message.includes('second guardrail has not allowed')) {
@@ -58,6 +77,18 @@ function humanizeNoNameManualApplyError(error: unknown) {
     return 'NoName 人工写入已取消：当前章节已变化，请重新确认目标段落。';
   }
   return message;
+}
+
+function replaceNoNameTrace(traces: NoNameTrace[], trace: NoNameTrace) {
+  const index = traces.findIndex((item) => item.traceId === trace.traceId);
+  if (index < 0) {
+    return [...traces, trace];
+  }
+  return [
+    ...traces.slice(0, index),
+    trace,
+    ...traces.slice(index + 1),
+  ];
 }
 
 export const useGameStore = defineStore('game', {
@@ -277,16 +308,88 @@ export const useGameStore = defineStore('game', {
           },
         );
         this.plotState = result.plotState;
-        const index = this.noNameTraces.findIndex((trace) => trace.traceId === result.trace.traceId);
-        if (index >= 0) {
-          this.noNameTraces = [
-            ...this.noNameTraces.slice(0, index),
-            result.trace,
-            ...this.noNameTraces.slice(index + 1),
-          ];
-        } else {
-          this.noNameTraces = [...this.noNameTraces, result.trace];
-        }
+        this.noNameTraces = replaceNoNameTrace(this.noNameTraces, result.trace);
+      } catch (error) {
+        this.error = humanizeNoNameManualApplyError(error);
+        throw new Error(this.error);
+      }
+    },
+
+    async applyNoNameManualChapterSummaryHint(payload: NoNameManualChapterSummaryHintApplyPayload) {
+      const chapterIndex = this.plotState?.current_chapter.index;
+      const expectedSummary = this.plotState?.current_chapter.summary;
+      if (typeof chapterIndex !== 'number' || typeof expectedSummary !== 'string') {
+        this.error = '无法执行 NoName 人工写入：当前章节摘要不可用。';
+        throw new Error(this.error);
+      }
+
+      try {
+        const result = await invokeRuntime<NoNameManualPlotTextApplyResult>(
+          'apply_noname_reviewed_output',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            scope: 'chapterSummaryHint',
+            chapterIndex,
+            expectedSummary,
+          },
+        );
+        this.plotState = result.plotState;
+        this.noNameTraces = replaceNoNameTrace(this.noNameTraces, result.trace);
+      } catch (error) {
+        this.error = humanizeNoNameManualApplyError(error);
+        throw new Error(this.error);
+      }
+    },
+
+    async applyNoNameManualOptionBiasHint(payload: NoNameManualOptionBiasHintApplyPayload) {
+      const chapterIndex = this.plotState?.current_chapter.index;
+      const expectedGenerationDiagnostics = this.plotState?.last_generation_diagnostics ?? '';
+      if (typeof chapterIndex !== 'number') {
+        this.error = '无法执行 NoName 人工写入：当前章节不可用。';
+        throw new Error(this.error);
+      }
+
+      try {
+        const result = await invokeRuntime<NoNameManualPlotTextApplyResult>(
+          'apply_noname_reviewed_output',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            scope: 'optionBiasHint',
+            chapterIndex,
+            expectedGenerationDiagnostics,
+          },
+        );
+        this.plotState = result.plotState;
+        this.noNameTraces = replaceNoNameTrace(this.noNameTraces, result.trace);
+      } catch (error) {
+        this.error = humanizeNoNameManualApplyError(error);
+        throw new Error(this.error);
+      }
+    },
+
+    async applyNoNameManualPlotAugmentationHint(payload: NoNameManualPlotAugmentationHintApplyPayload) {
+      const chapterIndex = this.plotState?.current_chapter.index;
+      const expectedPlotAugmentationHints = [...(this.plotState?.pending_plot_augmentation_hints ?? [])];
+      if (typeof chapterIndex !== 'number') {
+        this.error = '无法执行 NoName 人工写入：当前章节不可用。';
+        throw new Error(this.error);
+      }
+
+      try {
+        const result = await invokeRuntime<NoNameManualPlotTextApplyResult>(
+          'apply_noname_reviewed_output',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            scope: 'plotAugmentationHint',
+            chapterIndex,
+            expectedPlotAugmentationHints,
+          },
+        );
+        this.plotState = result.plotState;
+        this.noNameTraces = replaceNoNameTrace(this.noNameTraces, result.trace);
       } catch (error) {
         this.error = humanizeNoNameManualApplyError(error);
         throw new Error(this.error);
@@ -320,11 +423,7 @@ export const useGameStore = defineStore('game', {
       const proposalScopes = proposal?.applyScopes && proposal.applyScopes.length > 0
         ? proposal.applyScopes.join(', ')
         : '无';
-      const applyExecutions = latest.applyExecutionLog && latest.applyExecutionLog.length > 0
-        ? latest.applyExecutionLog
-          .map((item) => `${item.target}:${item.outcome}${item.note ? `(${item.note})` : ''}`)
-          .join(', ')
-        : '无';
+      const applyExecutions = summarizeNoNameApplyExecutions(latest);
       const applyPlans = latest.applyPlanLog && latest.applyPlanLog.length > 0
         ? latest.applyPlanLog
           .map((item) => `#${item.order}:${item.target}:${item.decision}@${item.priority}${item.note ? `(${item.note})` : ''}`)
@@ -332,7 +431,27 @@ export const useGameStore = defineStore('game', {
         : '无';
       const relatedObservations = latest.relatedObservations && latest.relatedObservations.length > 0
         ? latest.relatedObservations
-          .map((item) => `${item.role}:${item.focus}`)
+          .map((item) => {
+            const roleContext = item.roleGoal || item.sceneFocus
+              ? `[上下文=${item.roleGoal || '无角色目标'} / ${item.sceneFocus || '无场景焦点'}]`
+              : '';
+            const forbiddenScopes = item.forbiddenScopes?.length
+              ? `[禁区=${item.forbiddenScopes.join('/')}]`
+              : '';
+            const noteTypeHits = item.noteTypeHits?.length
+              ? `[笔记=${item.noteTypeHits.join('/')}]`
+              : '';
+            const sourceStats = item.sourceStats?.length
+              ? `[来源=${item.sourceStats.map((source) => `${source.source}:${source.count}`).join('/')}]`
+              : '';
+            const tokenBudgetUsed = item.contextTokenBudgetUsed
+              ? `[token=${item.contextTokenBudgetUsed}]`
+              : '';
+            const contextSliceStats = item.contextSliceStats?.length
+              ? `[裁剪=${item.contextSliceStats.map((stat) => `${stat.section}:${stat.sourceCount}->${stat.visibleCount}`).join('/')}]`
+              : '';
+            return `${item.role}:${item.focus}${roleContext}${forbiddenScopes}${noteTypeHits}${sourceStats}${tokenBudgetUsed}${contextSliceStats}`;
+          })
           .join(', ')
         : '无';
       const protocolEvents = latest.protocolEvents && latest.protocolEvents.length > 0
@@ -355,6 +474,7 @@ export const useGameStore = defineStore('game', {
           .join(', ')
         : '无';
       const applyLifecycle = summarizeNoNameApplyLifecycle(latest);
+      const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(latest);
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -369,6 +489,7 @@ export const useGameStore = defineStore('game', {
         `作用域：${proposalScopes}`,
         `预检：${latest.applyResult ? `${latest.applyResult.outcome}${latest.applyResult.reason ? ` (${latest.applyResult.reason})` : ''}` : '无'}`,
         `应用生命周期：${applyLifecycle}`,
+        `剧情增强提示：${pendingPlotAugmentation}`,
         `应用计划：${applyPlans}`,
         `应用执行：${applyExecutions}`,
         `状态迁移：${latest.proposalTransitionLog && latest.proposalTransitionLog.length > 0 ? latest.proposalTransitionLog.join(', ') : '无'}`,

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,5 +1,6 @@
 ﻿import { defineStore } from 'pinia';
 import { invokeRuntime, invokeWithTimeout } from '../utils/tauriInvoke';
+import { summarizeNoNameApplyLifecycle } from '../utils/noNameApplyLifecycle';
 import type {
   Script,
   GameState,
@@ -11,6 +12,10 @@ import type {
   WorldRegistry,
   GenerationTimingSummary,
   GenerationFailureSummary,
+  NoNameHumanReviewMarkPayload,
+  NoNameManualPlotTextApplyPayload,
+  NoNameManualPlotTextApplyResult,
+  NoNameSecondGuardrailResolvePayload,
   NoNameTrace,
 } from '../types/game';
 
@@ -34,6 +39,26 @@ interface GameStoreState {
 const LLM_TIMEOUT_MS = 60 * 1000;
 const OPTION_LLM_STORY_BLOCKED_MARKER = '本轮为选项续写：未获得可用 LLM 剧情文本';
 const MAX_GENERATION_DIAGNOSTICS = 40;
+
+function humanizeNoNameManualApplyError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('segment snapshot mismatch')) {
+    return 'NoName 人工写入已取消：当前剧情段落已变化，请重新打开调试台确认差异预览。';
+  }
+  if (message.includes('segment already contains a NoName marker')) {
+    return 'NoName 人工写入已取消：当前段落已经包含 NoName 标记，避免重复写入。';
+  }
+  if (message.includes('manual plot text hint has already been applied')) {
+    return 'NoName 人工写入已取消：这条提示已经应用过了。';
+  }
+  if (message.includes('second guardrail has not allowed')) {
+    return 'NoName 人工写入已取消：二次护栏尚未允许该复核项。';
+  }
+  if (message.includes('chapter mismatch')) {
+    return 'NoName 人工写入已取消：当前章节已变化，请重新确认目标段落。';
+  }
+  return message;
+}
 
 export const useGameStore = defineStore('game', {
   state: (): GameStoreState => ({
@@ -176,6 +201,98 @@ export const useGameStore = defineStore('game', {
       }
     },
 
+    async markNoNameControlledOutputReview(payload: NoNameHumanReviewMarkPayload) {
+      try {
+        const updatedTrace = await invokeRuntime<NoNameTrace>(
+          'mark_noname_controlled_output_review',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            decision: payload.decision,
+          },
+        );
+        const index = this.noNameTraces.findIndex((trace) => trace.traceId === updatedTrace.traceId);
+        if (index >= 0) {
+          this.noNameTraces = [
+            ...this.noNameTraces.slice(0, index),
+            updatedTrace,
+            ...this.noNameTraces.slice(index + 1),
+          ];
+        } else {
+          this.noNameTraces = [...this.noNameTraces, updatedTrace];
+        }
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+        throw error;
+      }
+    },
+
+    async resolveNoNameSecondGuardrail(payload: NoNameSecondGuardrailResolvePayload) {
+      try {
+        const updatedTrace = await invokeRuntime<NoNameTrace>(
+          'resolve_noname_second_guardrail',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            decision: payload.decision,
+          },
+        );
+        const index = this.noNameTraces.findIndex((trace) => trace.traceId === updatedTrace.traceId);
+        if (index >= 0) {
+          this.noNameTraces = [
+            ...this.noNameTraces.slice(0, index),
+            updatedTrace,
+            ...this.noNameTraces.slice(index + 1),
+          ];
+        } else {
+          this.noNameTraces = [...this.noNameTraces, updatedTrace];
+        }
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+        throw error;
+      }
+    },
+
+    async applyNoNameManualPlotTextHint(payload: NoNameManualPlotTextApplyPayload) {
+      const chapterIndex = this.plotState?.current_chapter.index;
+      const segmentIndex = (this.plotState?.current_chapter.content.length ?? 0) - 1;
+      const expectedSegmentText = segmentIndex >= 0
+        ? this.plotState?.current_chapter.content[segmentIndex]
+        : undefined;
+      if (typeof chapterIndex !== 'number' || segmentIndex < 0 || !expectedSegmentText) {
+        this.error = '无法执行 NoName 人工写入：当前剧情段落为空。';
+        throw new Error(this.error);
+      }
+
+      try {
+        const result = await invokeRuntime<NoNameManualPlotTextApplyResult>(
+          'apply_noname_reviewed_output',
+          {
+            traceId: payload.traceId,
+            requestId: payload.requestId,
+            scope: 'plotTextHint',
+            chapterIndex,
+            segmentIndex,
+            expectedSegmentText,
+          },
+        );
+        this.plotState = result.plotState;
+        const index = this.noNameTraces.findIndex((trace) => trace.traceId === result.trace.traceId);
+        if (index >= 0) {
+          this.noNameTraces = [
+            ...this.noNameTraces.slice(0, index),
+            result.trace,
+            ...this.noNameTraces.slice(index + 1),
+          ];
+        } else {
+          this.noNameTraces = [...this.noNameTraces, result.trace];
+        }
+      } catch (error) {
+        this.error = humanizeNoNameManualApplyError(error);
+        throw new Error(this.error);
+      }
+    },
+
     getGenerationDiagnosticsText() {
       if (this.generationDiagnostics.length === 0) {
         return '暂无诊断数据。';
@@ -230,10 +347,14 @@ export const useGameStore = defineStore('game', {
             const policyScopes = item.policyForbiddenScopes?.length
               ? `[禁区=${item.policyForbiddenScopes.join('/')}]`
               : '';
-            return `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}${policyScopes}`;
+            const humanDecision = item.humanReviewDecision
+              ? `[人工=${item.humanReviewDecision}]`
+              : '';
+            return `${item.requestedKind}:${item.safeApplyScope ?? 'none'}:${item.decision}${item.requiresHumanReview ? ':human' : ''}${policyScopes}${humanDecision}`;
           })
           .join(', ')
         : '无';
+      const applyLifecycle = summarizeNoNameApplyLifecycle(latest);
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -247,6 +368,7 @@ export const useGameStore = defineStore('game', {
         `预期效果：${proposal?.intendedEffect || '无'}`,
         `作用域：${proposalScopes}`,
         `预检：${latest.applyResult ? `${latest.applyResult.outcome}${latest.applyResult.reason ? ` (${latest.applyResult.reason})` : ''}` : '无'}`,
+        `应用生命周期：${applyLifecycle}`,
         `应用计划：${applyPlans}`,
         `应用执行：${applyExecutions}`,
         `状态迁移：${latest.proposalTransitionLog && latest.proposalTransitionLog.length > 0 ? latest.proposalTransitionLog.join(', ') : '无'}`,

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -349,6 +349,44 @@ export interface NoNameControlledOutputReviewRecord {
   safeApplyScope?: NoNameApplyScope | null;
   policyForbiddenScopes?: NoNameForbiddenOutputScope[];
   requiresHumanReview: boolean;
+  humanReviewDecision?: NoNameHumanReviewDecision | null;
+  humanReviewedAt?: number | null;
+  humanReviewNote?: string | null;
+}
+
+export type NoNameHumanReviewDecision =
+  | 'pending'
+  | 'approvedForHigherApply'
+  | 'rejectedForHigherApply';
+
+export interface NoNameHumanReviewMarkPayload {
+  traceId: string;
+  requestId: string;
+  decision: NoNameHumanReviewDecision;
+}
+
+export type NoNameSecondGuardrailDecision = 'allow' | 'reject' | 'fallback';
+
+export interface NoNameSecondGuardrailResolvePayload {
+  traceId: string;
+  requestId: string;
+  decision: NoNameSecondGuardrailDecision;
+}
+
+export interface NoNameManualPlotTextApplyPayload {
+  traceId: string;
+  requestId: string;
+}
+
+export interface NoNameManualApplySegmentSnapshot {
+  chapterIndex: number;
+  segmentIndex: number;
+  text: string;
+}
+
+export interface NoNameManualPlotTextApplyResult {
+  trace: NoNameTrace;
+  plotState: PlotState;
 }
 
 export type NoNameProposalStatus = 'observed' | 'ready' | 'blocked' | 'applied' | 'fallback';

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -175,6 +175,7 @@ export interface PlotState {
   last_generation_diagnostics?: string | null;
   last_option_generation_source?: string | null;
   last_consistency_risk_score?: number | null;
+  pending_plot_augmentation_hints?: string[];
   settings: PlotSettings;
   current_chapter: ChapterState;
   chapters: ChapterState[];
@@ -328,6 +329,7 @@ export type NoNameControlledOutputDecision = 'allow' | 'reject' | 'needsReview';
 export type NoNameControlledOutputKind =
   | 'recapNote'
   | 'sceneAugmentation'
+  | 'nonFinalPlotAugmentation'
   | 'narrativeNote'
   | 'intermediateNarrativeHint';
 export type NoNameForbiddenOutputScope =
@@ -378,10 +380,40 @@ export interface NoNameManualPlotTextApplyPayload {
   requestId: string;
 }
 
+export interface NoNameManualChapterSummaryHintApplyPayload {
+  traceId: string;
+  requestId: string;
+}
+
+export interface NoNameManualOptionBiasHintApplyPayload {
+  traceId: string;
+  requestId: string;
+}
+
+export interface NoNameManualPlotAugmentationHintApplyPayload {
+  traceId: string;
+  requestId: string;
+}
+
 export interface NoNameManualApplySegmentSnapshot {
   chapterIndex: number;
   segmentIndex: number;
   text: string;
+}
+
+export interface NoNameManualApplySummarySnapshot {
+  chapterIndex: number;
+  summary: string;
+}
+
+export interface NoNameManualApplyDiagnosticsSnapshot {
+  chapterIndex: number;
+  diagnostics: string;
+}
+
+export interface NoNameManualApplyPlotAugmentationSnapshot {
+  chapterIndex: number;
+  hints: string[];
 }
 
 export interface NoNameManualPlotTextApplyResult {
@@ -394,6 +426,7 @@ export type NoNameApplyScope =
   | 'diagnostics'
   | 'chapterSummaryHint'
   | 'optionBiasHint'
+  | 'plotAugmentationHint'
   | 'plotTextHint';
 export type NoNameTargetSegment =
   | 'current_turn_head'
@@ -418,11 +451,29 @@ export interface NoNameProposal {
   applyable: boolean;
 }
 
+export interface NoNameContextSourceStat {
+  source: string;
+  count: number;
+}
+
+export interface NoNameRoleContextSliceStat {
+  section: string;
+  sourceCount: number;
+  visibleCount: number;
+}
+
 export interface NoNameRelatedObservation {
   role: string;
   actionSummary: string;
   focus: string;
   rationale: string;
+  roleGoal?: string | null;
+  sceneFocus?: string | null;
+  forbiddenScopes?: string[];
+  noteTypeHits?: string[];
+  sourceStats?: NoNameContextSourceStat[];
+  contextTokenBudgetUsed?: number | null;
+  contextSliceStats?: NoNameRoleContextSliceStat[];
   proposal: NoNameProposal;
 }
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -330,6 +330,15 @@ export type NoNameControlledOutputKind =
   | 'sceneAugmentation'
   | 'narrativeNote'
   | 'intermediateNarrativeHint';
+export type NoNameForbiddenOutputScope =
+  | 'finalPlotState'
+  | 'canonWorldFact'
+  | 'characterStats'
+  | 'inventoryOrResource'
+  | 'mapTopology'
+  | 'chapterLifecycle'
+  | 'playerChoice'
+  | 'combatOutcome';
 
 export interface NoNameControlledOutputReviewRecord {
   requestId: string;
@@ -338,6 +347,7 @@ export interface NoNameControlledOutputReviewRecord {
   reason: string;
   normalizedKind?: NoNameControlledOutputKind | null;
   safeApplyScope?: NoNameApplyScope | null;
+  policyForbiddenScopes?: NoNameForbiddenOutputScope[];
   requiresHumanReview: boolean;
 }
 

--- a/src/utils/noNameApplyLifecycle.test.ts
+++ b/src/utils/noNameApplyLifecycle.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { NoNameTrace } from '../types/game';
+import {
+  buildNoNameApplyLifecycle,
+  formatNoNameApplyExecutionRecord,
+  summarizeNoNameApplyExecutions,
+  summarizeNoNameApplyLifecycle,
+  summarizeNoNamePendingPlotAugmentation,
+} from './noNameApplyLifecycle';
+
+function buildTrace(outcome: string, note: string): NoNameTrace {
+  return {
+    traceId: 'trace-pending-augmentation',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    mode: 'assisted',
+    graphPath: ['CollectTurnInput', 'PlanTurn', 'ApplyProposal'],
+    capabilityCalls: [],
+    proposals: [{
+      proposalId: 'proposal-1',
+      kind: 'plotCandidate',
+      producerRole: 'director',
+      title: 'plot augmentation proposal',
+      summary: 'stage non-final plot augmentation',
+      focus: 'hidden cave clue',
+      targetSegment: 'current_turn_tail',
+      intendedEffect: 'guide the next generation without mutating final state',
+      rationale: 'test',
+      labels: ['director'],
+      applyScopes: ['plotAugmentationHint'],
+      status: 'applied',
+      applyable: true,
+    }],
+    proposalTransitionLog: [`proposal-1:pending_plot_augmentation:${outcome}`],
+    applyPlanLog: [],
+    applyExecutionLog: [{
+      target: 'plot_augmentation_hint',
+      outcome,
+      note,
+    }],
+    guardrailResult: { outcome: 'accept' },
+    applyResult: { attempted: true, outcome: 'applied_scoped_outputs' },
+    fallbackUsed: false,
+    elapsedMs: 3,
+  };
+}
+
+describe('buildNoNameApplyLifecycle', () => {
+  it('surfaces consumed pending plot augmentation hints', () => {
+    const trace = buildTrace(
+      'pending_plot_augmentation_consumed',
+      'pending plot augmentation consumed after plot_engine generation; count=1',
+    );
+
+    const step = buildNoNameApplyLifecycle(trace)
+      .find((item) => item.key === 'plot-augmentation-consumption');
+
+    expect(step?.label).toBe('剧情增强消费');
+    expect(step?.state).toBe('已消费');
+    expect(step?.tone).toBe('done');
+    expect(step?.detail).toContain('count=1');
+    expect(summarizeNoNameApplyLifecycle(trace)).toContain('剧情增强消费:已消费');
+    expect(summarizeNoNamePendingPlotAugmentation(trace)).toContain('已消费');
+    expect(summarizeNoNamePendingPlotAugmentation(trace)).toContain('count=1');
+  });
+
+  it('surfaces retained pending plot augmentation hints', () => {
+    const trace = buildTrace(
+      'pending_plot_augmentation_retained',
+      'pending plot augmentation retained because quick_mode; count=1',
+    );
+
+    const step = buildNoNameApplyLifecycle(trace)
+      .find((item) => item.key === 'plot-augmentation-consumption');
+
+    expect(step?.label).toBe('剧情增强消费');
+    expect(step?.state).toBe('已保留');
+    expect(step?.tone).toBe('pending');
+    expect(step?.detail).toContain('quick_mode');
+    expect(summarizeNoNamePendingPlotAugmentation(trace)).toContain('已保留');
+  });
+
+  it('summarizes staged pending plot augmentation hints', () => {
+    const trace = buildTrace(
+      'manual_plot_augmentation_hint_applied',
+      'manual plot augmentation hint staged for focus=hidden cave clue',
+    );
+
+    expect(summarizeNoNamePendingPlotAugmentation(trace)).toContain('待消费');
+    expect(summarizeNoNamePendingPlotAugmentation(trace)).toContain('hidden cave clue');
+  });
+
+  it('formats pending plot augmentation execution records for display', () => {
+    expect(formatNoNameApplyExecutionRecord({
+      target: 'plot_augmentation_hint',
+      outcome: 'pending_plot_augmentation_consumed',
+    })).toEqual({
+      targetLabel: '剧情增强提示',
+      outcomeLabel: '已消费',
+    });
+    expect(formatNoNameApplyExecutionRecord({
+      target: 'plotAugmentationHint',
+      outcome: 'pending_plot_augmentation_retained',
+    })).toEqual({
+      targetLabel: '剧情增强提示',
+      outcomeLabel: '已保留',
+    });
+  });
+
+  it('summarizes apply execution records with readable and raw labels', () => {
+    const trace = buildTrace(
+      'pending_plot_augmentation_consumed',
+      'pending plot augmentation consumed after plot_engine generation; count=1',
+    );
+
+    expect(summarizeNoNameApplyExecutions(trace)).toContain(
+      '剧情增强提示:已消费[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]',
+    );
+    expect(summarizeNoNameApplyExecutions(trace, {
+      emptyLabel: 'none',
+      rawPrefix: ' [raw=',
+      notePrefix: ' (',
+    })).toContain(
+      '剧情增强提示:已消费 [raw=plot_augmentation_hint:pending_plot_augmentation_consumed]',
+    );
+  });
+});

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -1,4 +1,5 @@
 import type {
+  NoNameApplyExecutionRecord,
   NoNameHumanReviewDecision,
   NoNameTrace,
 } from '../types/game';
@@ -11,6 +12,11 @@ export interface NoNameApplyLifecycleStep {
   state: string;
   detail: string;
   tone: NoNameApplyLifecycleTone;
+}
+
+export interface NoNameApplyExecutionDisplay {
+  targetLabel: string;
+  outcomeLabel: string;
 }
 
 function normalizeTarget(value: string | undefined) {
@@ -29,8 +35,85 @@ function hasExecutionOutcome(trace: NoNameTrace, outcome: string) {
   return Boolean(trace.applyExecutionLog?.some((item) => item.outcome === outcome));
 }
 
+function latestExecutionForTarget(
+  trace: NoNameTrace,
+  target: string,
+  outcomes: string[],
+): NoNameApplyExecutionRecord | null {
+  const normalizedTarget = normalizeTarget(target);
+  return trace.applyExecutionLog
+    ?.slice()
+    .reverse()
+    .find((item) => (
+      normalizeTarget(item.target) === normalizedTarget
+      && outcomes.includes(item.outcome)
+    )) ?? null;
+}
+
 function hasTransition(trace: NoNameTrace, suffix: string) {
   return Boolean(trace.proposalTransitionLog?.some((item) => item.endsWith(suffix)));
+}
+
+export function formatNoNameApplyExecutionRecord(
+  record: NoNameApplyExecutionRecord,
+): NoNameApplyExecutionDisplay {
+  if (normalizeTarget(record.target) === normalizeTarget('plotAugmentationHint')) {
+    if (record.outcome === 'pending_plot_augmentation_consumed') {
+      return {
+        targetLabel: '剧情增强提示',
+        outcomeLabel: '已消费',
+      };
+    }
+    if (record.outcome === 'pending_plot_augmentation_retained') {
+      return {
+        targetLabel: '剧情增强提示',
+        outcomeLabel: '已保留',
+      };
+    }
+    if (record.outcome === 'manual_plot_augmentation_hint_applied') {
+      return {
+        targetLabel: '剧情增强提示',
+        outcomeLabel: '已暂存待消费',
+      };
+    }
+  }
+  return {
+    targetLabel: record.target,
+    outcomeLabel: record.outcome,
+  };
+}
+
+export function summarizeNoNameApplyExecutions(
+  trace: NoNameTrace,
+  options: {
+    emptyLabel?: string;
+    rawPrefix?: string;
+    rawSuffix?: string;
+    notePrefix?: string;
+    noteSuffix?: string;
+  } = {},
+) {
+  const {
+    emptyLabel = '无',
+    rawPrefix = '[raw=',
+    rawSuffix = ']',
+    notePrefix = '(',
+    noteSuffix = ')',
+  } = options;
+  const executionLog = trace.applyExecutionLog ?? [];
+  if (executionLog.length === 0) {
+    return emptyLabel;
+  }
+  return executionLog
+    .map((item) => {
+      const display = formatNoNameApplyExecutionRecord(item);
+      const raw = display.targetLabel !== item.target || display.outcomeLabel !== item.outcome
+        ? `${rawPrefix}${item.target}:${item.outcome}${rawSuffix}`
+        : '';
+      const note = item.note ? `${notePrefix}${item.note}${noteSuffix}` : '';
+      return `${display.targetLabel}:${display.outcomeLabel}${raw}${note}`;
+    })
+    .join(', ');
 }
 
 function resolvePreflightTone(outcome: string | undefined): NoNameApplyLifecycleTone {
@@ -48,6 +131,7 @@ function resolvePreflightTone(outcome: string | undefined): NoNameApplyLifecycle
     || outcome.includes('applied')
     || outcome.includes('allow')
     || outcome.includes('manual_plot_text_applied')
+    || outcome.includes('manual_plot_augmentation_hint_applied')
   ) {
     return 'done';
   }
@@ -64,6 +148,45 @@ function lifecycleHumanDecision(
     ?? 'pending';
 }
 
+export function summarizeNoNamePendingPlotAugmentation(trace: NoNameTrace): string {
+  const consumptionExecution = latestExecutionForTarget(
+    trace,
+    'plotAugmentationHint',
+    ['pending_plot_augmentation_consumed', 'pending_plot_augmentation_retained'],
+  );
+  if (consumptionExecution?.outcome === 'pending_plot_augmentation_consumed') {
+    return consumptionExecution.note
+      ? `已消费（${consumptionExecution.note}）`
+      : '已消费';
+  }
+  if (consumptionExecution?.outcome === 'pending_plot_augmentation_retained') {
+    return consumptionExecution.note
+      ? `已保留（${consumptionExecution.note}）`
+      : '已保留';
+  }
+
+  const stagedExecution = latestExecutionForTarget(
+    trace,
+    'plotAugmentationHint',
+    ['manual_plot_augmentation_hint_applied'],
+  );
+  if (stagedExecution) {
+    return stagedExecution.note
+      ? `待消费（${stagedExecution.note}）`
+      : '待消费';
+  }
+
+  const latestProposal = trace.proposals[trace.proposals.length - 1] ?? null;
+  const hasPlotAugmentationScope = latestProposal?.applyScopes?.some((scope) => (
+    normalizeTarget(scope) === normalizeTarget('plotAugmentationHint')
+  ));
+  if (hasPlotAugmentationScope) {
+    return '待观察（proposal 支持 PlotAugmentationHint，但尚未看到 pending 消费记录）';
+  }
+
+  return '无';
+}
+
 export function buildNoNameApplyLifecycle(
   trace: NoNameTrace,
   reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
@@ -76,6 +199,14 @@ export function buildNoNameApplyLifecycle(
   )).length;
   const lowRiskTargets = ['diagnostics', 'chapterSummaryHint', 'optionBiasHint'];
   const appliedLowRiskTargets = lowRiskTargets.filter((target) => hasExecution(trace, target, 'applied'));
+  const pendingAugmentationExecution = latestExecutionForTarget(
+    trace,
+    'plotAugmentationHint',
+    ['pending_plot_augmentation_consumed', 'pending_plot_augmentation_retained'],
+  );
+  const latestProposalScopes = latestProposal?.applyScopes ?? [];
+  const hasPlotAugmentationScope = latestProposalScopes
+    .some((scope) => normalizeTarget(scope) === normalizeTarget('plotAugmentationHint'));
   const secondGuardrailAllowed = hasExecutionOutcome(trace, 'second_guardrail_allowed')
     || hasTransition(trace, ':second_guardrail:allow');
   const secondGuardrailRejected = hasExecutionOutcome(trace, 'second_guardrail_rejected')
@@ -85,7 +216,13 @@ export function buildNoNameApplyLifecycle(
   const awaitingSecondGuardrail = hasExecutionOutcome(trace, 'awaiting_second_guardrail')
     || hasTransition(trace, ':apply_intent:awaiting_second_guardrail');
   const manualApplied = hasExecutionOutcome(trace, 'manual_plot_text_applied')
-    || hasTransition(trace, ':manual_apply:plot_text_hint');
+    || hasExecutionOutcome(trace, 'manual_chapter_summary_hint_applied')
+    || hasExecutionOutcome(trace, 'manual_option_bias_hint_applied')
+    || hasExecutionOutcome(trace, 'manual_plot_augmentation_hint_applied')
+    || hasTransition(trace, ':manual_apply:plot_text_hint')
+    || hasTransition(trace, ':manual_apply:chapter_summary_hint')
+    || hasTransition(trace, ':manual_apply:option_bias_hint')
+    || hasTransition(trace, ':manual_apply:plot_augmentation_hint');
   const preflightOutcome = trace.applyResult?.outcome;
 
   const steps: NoNameApplyLifecycleStep[] = [
@@ -133,6 +270,23 @@ export function buildNoNameApplyLifecycle(
     },
   ];
 
+  if (pendingAugmentationExecution || hasPlotAugmentationScope) {
+    const consumed = pendingAugmentationExecution?.outcome === 'pending_plot_augmentation_consumed';
+    const retained = pendingAugmentationExecution?.outcome === 'pending_plot_augmentation_retained';
+    steps.push({
+      key: 'plot-augmentation-consumption',
+      label: '剧情增强消费',
+      state: consumed
+        ? '已消费'
+        : retained
+          ? '已保留'
+          : '待观察',
+      detail: pendingAugmentationExecution?.note
+        ?? 'PlotAugmentationHint 已进入待消费层，等待下一次 plot_engine 生成结果确认',
+      tone: consumed ? 'done' : retained ? 'pending' : 'info',
+    });
+  }
+
   if (humanReviews.length > 0 || awaitingSecondGuardrail || secondGuardrailAllowed || secondGuardrailRejected || secondGuardrailFallback) {
     steps.push({
       key: 'second-guardrail',
@@ -163,7 +317,14 @@ export function buildNoNameApplyLifecycle(
     });
   }
 
-  if (humanReviews.some((item) => item.safeApplyScope === 'plotTextHint') || secondGuardrailAllowed || manualApplied) {
+  if (
+    humanReviews.some((item) => (
+      ['plotTextHint', 'chapterSummaryHint', 'optionBiasHint', 'plotAugmentationHint']
+        .includes(item.safeApplyScope ?? '')
+    ))
+    || secondGuardrailAllowed
+    || manualApplied
+  ) {
     steps.push({
       key: 'manual-plot-text',
       label: '人工写入',
@@ -173,7 +334,7 @@ export function buildNoNameApplyLifecycle(
           ? '等待显式命令'
           : '未就绪',
       detail: manualApplied
-        ? '已记录 manual_plot_text_applied'
+        ? '已记录显式人工 apply 结果'
         : secondGuardrailAllowed
           ? '需要开发者确认差异预览后手动写入'
           : 'PlotTextHint 需要人工复核与二次护栏',

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -1,0 +1,204 @@
+import type {
+  NoNameHumanReviewDecision,
+  NoNameTrace,
+} from '../types/game';
+
+export type NoNameApplyLifecycleTone = 'done' | 'pending' | 'blocked' | 'fallback' | 'info';
+
+export interface NoNameApplyLifecycleStep {
+  key: string;
+  label: string;
+  state: string;
+  detail: string;
+  tone: NoNameApplyLifecycleTone;
+}
+
+function normalizeTarget(value: string | undefined) {
+  return (value ?? '').replace(/_/g, '').toLowerCase();
+}
+
+function hasExecution(trace: NoNameTrace, target: string, outcome: string) {
+  const normalizedTarget = normalizeTarget(target);
+  return Boolean(trace.applyExecutionLog?.some((item) => (
+    normalizeTarget(item.target) === normalizedTarget
+    && item.outcome === outcome
+  )));
+}
+
+function hasExecutionOutcome(trace: NoNameTrace, outcome: string) {
+  return Boolean(trace.applyExecutionLog?.some((item) => item.outcome === outcome));
+}
+
+function hasTransition(trace: NoNameTrace, suffix: string) {
+  return Boolean(trace.proposalTransitionLog?.some((item) => item.endsWith(suffix)));
+}
+
+function resolvePreflightTone(outcome: string | undefined): NoNameApplyLifecycleTone {
+  if (!outcome) {
+    return 'pending';
+  }
+  if (outcome.includes('fallback')) {
+    return 'fallback';
+  }
+  if (outcome.includes('reject') || outcome.includes('rejected') || outcome.includes('blocked')) {
+    return 'blocked';
+  }
+  if (
+    outcome.includes('ready')
+    || outcome.includes('applied')
+    || outcome.includes('allow')
+    || outcome.includes('manual_plot_text_applied')
+  ) {
+    return 'done';
+  }
+  return 'info';
+}
+
+function lifecycleHumanDecision(
+  trace: NoNameTrace,
+  requestId: string,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision>,
+) {
+  return reviewDecisions[requestId]
+    ?? trace.controlledOutputReviews?.find((item) => item.requestId === requestId)?.humanReviewDecision
+    ?? 'pending';
+}
+
+export function buildNoNameApplyLifecycle(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+): NoNameApplyLifecycleStep[] {
+  const latestProposal = trace.proposals[trace.proposals.length - 1] ?? null;
+  const controlledReviews = trace.controlledOutputReviews ?? [];
+  const humanReviews = controlledReviews.filter((item) => item.requiresHumanReview);
+  const pendingHumanReviewCount = humanReviews.filter((item) => (
+    lifecycleHumanDecision(trace, item.requestId, reviewDecisions) === 'pending'
+  )).length;
+  const lowRiskTargets = ['diagnostics', 'chapterSummaryHint', 'optionBiasHint'];
+  const appliedLowRiskTargets = lowRiskTargets.filter((target) => hasExecution(trace, target, 'applied'));
+  const secondGuardrailAllowed = hasExecutionOutcome(trace, 'second_guardrail_allowed')
+    || hasTransition(trace, ':second_guardrail:allow');
+  const secondGuardrailRejected = hasExecutionOutcome(trace, 'second_guardrail_rejected')
+    || hasTransition(trace, ':second_guardrail:reject');
+  const secondGuardrailFallback = hasExecutionOutcome(trace, 'second_guardrail_fallback')
+    || hasTransition(trace, ':second_guardrail:fallback');
+  const awaitingSecondGuardrail = hasExecutionOutcome(trace, 'awaiting_second_guardrail')
+    || hasTransition(trace, ':apply_intent:awaiting_second_guardrail');
+  const manualApplied = hasExecutionOutcome(trace, 'manual_plot_text_applied')
+    || hasTransition(trace, ':manual_apply:plot_text_hint');
+  const preflightOutcome = trace.applyResult?.outcome;
+
+  const steps: NoNameApplyLifecycleStep[] = [
+    {
+      key: 'proposal',
+      label: '提案阶段',
+      state: latestProposal
+        ? (latestProposal.status ?? (latestProposal.applyable ? 'ready' : 'observed'))
+        : '无提案',
+      detail: latestProposal
+        ? `${latestProposal.producerRole} · ${latestProposal.targetSegment} · ${latestProposal.applyScopes?.join('/') || 'no-scope'}`
+        : '尚未生成 NoName proposal',
+      tone: latestProposal?.applyable || latestProposal?.status === 'applied' || latestProposal?.status === 'ready'
+        ? 'done'
+        : 'info',
+    },
+    {
+      key: 'preflight',
+      label: 'Apply 预检',
+      state: preflightOutcome ?? '未尝试',
+      detail: trace.applyResult?.reason ?? '尚未记录 applyResult',
+      tone: resolvePreflightTone(preflightOutcome),
+    },
+    {
+      key: 'low-risk',
+      label: '低风险输出',
+      state: appliedLowRiskTargets.length > 0 ? '已应用' : '未应用',
+      detail: appliedLowRiskTargets.length > 0
+        ? `已应用：${appliedLowRiskTargets.join(' / ')}`
+        : '尚未看到 diagnostics / chapterSummaryHint / optionBiasHint 的 applied 记录',
+      tone: appliedLowRiskTargets.length > 0 ? 'done' : 'pending',
+    },
+    {
+      key: 'review',
+      label: '人工复核',
+      state: humanReviews.length === 0
+        ? '无需人工'
+        : pendingHumanReviewCount === 0
+          ? '已确认'
+          : `待确认 ${pendingHumanReviewCount}`,
+      detail: controlledReviews.length > 0
+        ? `受控输出 ${controlledReviews.length} 条，其中人工复核 ${humanReviews.length} 条`
+        : '无 controlled output review',
+      tone: pendingHumanReviewCount > 0 ? 'pending' : 'done',
+    },
+  ];
+
+  if (humanReviews.length > 0 || awaitingSecondGuardrail || secondGuardrailAllowed || secondGuardrailRejected || secondGuardrailFallback) {
+    steps.push({
+      key: 'second-guardrail',
+      label: '二次护栏',
+      state: secondGuardrailFallback
+        ? 'fallback'
+        : secondGuardrailRejected
+          ? 'rejected'
+          : secondGuardrailAllowed
+            ? 'allow'
+            : awaitingSecondGuardrail
+              ? 'waiting'
+              : '未进入',
+      detail: secondGuardrailAllowed
+        ? '已允许进入显式人工 apply；仍不会自动写正文'
+        : secondGuardrailFallback
+          ? '已要求回退经典链路'
+          : secondGuardrailRejected
+            ? '已拒绝高层 apply'
+            : '等待人工批准后进入二次护栏',
+      tone: secondGuardrailFallback
+        ? 'fallback'
+        : secondGuardrailRejected
+          ? 'blocked'
+          : secondGuardrailAllowed
+            ? 'done'
+            : 'pending',
+    });
+  }
+
+  if (humanReviews.some((item) => item.safeApplyScope === 'plotTextHint') || secondGuardrailAllowed || manualApplied) {
+    steps.push({
+      key: 'manual-plot-text',
+      label: '人工写入',
+      state: manualApplied
+        ? '已写入'
+        : secondGuardrailAllowed
+          ? '等待显式命令'
+          : '未就绪',
+      detail: manualApplied
+        ? '已记录 manual_plot_text_applied'
+        : secondGuardrailAllowed
+          ? '需要开发者确认差异预览后手动写入'
+          : 'PlotTextHint 需要人工复核与二次护栏',
+      tone: manualApplied ? 'done' : secondGuardrailAllowed ? 'pending' : 'info',
+    });
+  }
+
+  if (trace.fallbackUsed) {
+    steps.push({
+      key: 'fallback',
+      label: '回退',
+      state: '已回退',
+      detail: 'fallbackUsed=true，后续继续依赖经典链路',
+      tone: 'fallback',
+    });
+  }
+
+  return steps;
+}
+
+export function summarizeNoNameApplyLifecycle(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+) {
+  return buildNoNameApplyLifecycle(trace, reviewDecisions)
+    .map((step) => `${step.label}:${step.state}`)
+    .join(' -> ');
+}


### PR DESCRIPTION
## Summary
- extend reviewed apply runtime coverage and frontend trace lifecycle reporting
- add role context observability for note hits, source stats, token usage, and slice deltas
- update NoName architecture docs through the latest T8 role-context progress

## Verification
- npm test -- --run src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts
- cargo test noname_context -- --nocapture
- cargo test noname_runtime -- --nocapture
- cargo test noname_agent_registry -- --nocapture
- cargo clippy -- -D warnings
- git diff --check