### PR TITLE
refactor(noname): extract review guardrail helpers

### DIFF
--- a/docs/项目文档/02-架构/02-NoName-代理系统.md
+++ b/docs/项目文档/02-架构/02-NoName-代理系统.md
@@ -71,9 +71,18 @@
 
 ## 5. 当前主要问题
 
-### 5.1 命令层仍然过重
+### 5.1 命令层压力正在下降
 
-`reviewed apply` 的核心逻辑虽已下沉到 `noname_apply.rs`，但命令编排仍强依赖 `tauri_commands.rs`。
+`reviewed apply` 的请求构造、快照校验、显式 apply、人工 review intent 与 second guardrail 记录逻辑已经下沉到 `noname_apply.rs`。
+
+`tauri_commands.rs` 在这条链路上主要保留：
+
+- Tauri 参数接收
+- runtime trace 读取与回写
+- game engine / plot state 读取与回写
+- 命令错误返回
+
+后续仍可继续观察低风险 apply 与生成主链中是否还有适合抽离的重复编排，但不应再把新的 reviewed apply 权限逻辑直接堆回命令层。
 
 ### 5.2 Web mock 与后端容易漂移
 
@@ -90,10 +99,10 @@
 
 ## 6. 当前结论
 
-`NoName` 已经完成 `V1` 骨架并进入 `T7 reviewed apply runtime` 阶段。  
+`NoName` 已经完成 `V1` 骨架并进入 reviewed apply runtime 收口阶段。
 后续不建议立即扩大它对正文和主剧情状态的控制权，应该先完成：
 
-- 命令层减压
+- 命令层剩余编排减压
 - 前后端语义对齐
 - 记忆与 structured notes 串联
 - 协作文档重建

--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -15,9 +15,17 @@
 
 ## 3. 当前主要风险
 
-### 3.1 命令主链压力过大
+### 3.1 命令主链压力仍需继续收口
 
-`tauri_commands.rs` 仍然承担了过多编排工作，继续向里面叠逻辑会提高维护风险和冲突概率。
+`tauri_commands.rs` 仍然承担大量主游戏编排工作，继续向里面叠逻辑会提高维护风险和冲突概率。
+
+当前 `NoName reviewed apply` 链路已经完成第三轮减压：
+
+- reviewed apply request 构造、快照校验与显式 apply 已下沉到 `noname_apply.rs`
+- trace 获取 / plot state 更新 / trace 回写已复用命令层共用壳层
+- human review intent 与 second guardrail 决策记录已下沉到 `noname_apply.rs`
+
+后续风险重点不再是 reviewed apply 本身，而是其他低风险 apply 与剧情生成主链是否继续膨胀。
 
 ### 3.2 前后端 mock 语义漂移
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -53,10 +53,12 @@
 
 当前状态：
 
-- 已完成第二轮下沉
+- 已完成第三轮下沉
 - reviewed apply 的 request builder 与 plotText manual apply helper 已进入 `noname_apply.rs`
 - `tauri_commands.rs` 在 reviewed apply 路径上已减少内联快照构造与包装逻辑
 - reviewed apply 命令已开始复用共享的 trace 读取、plot state 更新和 trace 回写壳层
+- human review intent 与 second guardrail 决策记录已进入 `noname_apply.rs`
+- 下一步若继续减压，应优先评估低风险 apply 或剧情生成主链中仍重复的编排，而不是扩大新的 apply scope
 
 ## P2：收口后继续推进
 

--- a/docs/项目文档/03-规划/04-未来两周开发排期.md
+++ b/docs/项目文档/03-规划/04-未来两周开发排期.md
@@ -91,10 +91,11 @@
 
 当前状态：
 
-- 第二轮已完成
+- 第三轮已完成
 - `NoNameReviewedApplyRequest` 构造与 plotText manual apply helper 已从命令层下沉到 `noname_apply.rs`
 - trace 获取 / result 回写的共用壳层已开始抽出并复用到两个 reviewed apply 命令
-- 下一轮可继续观察 review / second guardrail 命令是否也值得抽出同类 runtime helper
+- human review intent 与 second guardrail 决策记录已从命令层下沉到 `noname_apply.rs`
+- 下一轮若继续 A2，应只评估剩余低风险 apply / 生成主链重复编排，不新增 apply scope，不扩张 second guardrail 语义
 
 ### 任务 A3：建立 `NoName` 主链变更的文档闭环
 

--- a/src-tauri/src/noname_apply.rs
+++ b/src-tauri/src/noname_apply.rs
@@ -1,5 +1,8 @@
-use crate::noname_trace::{NoNameHumanReviewDecision, NoNameTrace};
-use crate::noname_types::{NoNameApplyScope, NoNameProposal, NoNameTargetSegment};
+use crate::noname_trace::{NoNameHumanReviewDecision, NoNameSecondGuardrailDecision, NoNameTrace};
+use crate::noname_types::{
+    NoNameApplyScope, NoNameMode, NoNameProposal, NoNameProposalStatus, NoNameTargetSegment,
+    NoNameTraceStage,
+};
 use crate::plot_engine::PlotState;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -155,6 +158,291 @@ fn target_segment_supports_apply_scope(
         ),
         _ => true,
     }
+}
+
+fn review_is_waiting_for_second_guardrail(trace: &NoNameTrace, request_id: &str) -> bool {
+    let transition = format!("{}:apply_intent:awaiting_second_guardrail", request_id);
+    trace
+        .proposal_transition_log
+        .iter()
+        .any(|entry| entry == &transition)
+        || trace.apply_execution_log.iter().any(|entry| {
+            entry.outcome == "awaiting_second_guardrail"
+                && entry.target == NoNameApplyScope::PlotTextHint.as_str()
+        })
+}
+
+fn second_guardrail_revalidation_reason(
+    trace: &NoNameTrace,
+    request_id: &str,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) -> Option<String> {
+    if trace.mode != NoNameMode::Assisted {
+        return Some("当前 trace 不是 assisted 模式，二次 guardrail 拒绝".to_string());
+    }
+    if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+        return Some("当前二次 guardrail 只允许处理 plot_text_hint".to_string());
+    }
+    if !review_is_waiting_for_second_guardrail(trace, request_id) {
+        return Some("review 尚未进入 awaiting_second_guardrail 队列".to_string());
+    }
+
+    match find_review_proposal(trace, request_id) {
+        Some(proposal)
+            if proposal.status == NoNameProposalStatus::Applied
+                && proposal.applyable
+                && target_segment_supports_apply_scope(
+                    proposal.target_segment,
+                    NoNameApplyScope::PlotTextHint,
+                ) =>
+        {
+            None
+        }
+        Some(proposal)
+            if proposal.status != NoNameProposalStatus::Applied || !proposal.applyable =>
+        {
+            Some(format!(
+                "proposal 状态为 {} / applyable={}，二次 guardrail 拒绝",
+                proposal.status.as_str(),
+                proposal.applyable
+            ))
+        }
+        Some(proposal) => Some(format!(
+            "target_segment={} 不支持 plot_text_hint 二次 guardrail",
+            proposal.target_segment.as_str()
+        )),
+        None => Some("未找到 review 对应 proposal，二次 guardrail 拒绝".to_string()),
+    }
+}
+
+fn human_review_apply_intent_rejection_reason(
+    trace: &NoNameTrace,
+    request_id: &str,
+    safe_apply_scope: Option<NoNameApplyScope>,
+    target: &str,
+) -> Option<String> {
+    if trace.mode != NoNameMode::Assisted {
+        return Some("当前 trace 不是 assisted 模式，拒绝进入高层 apply intent".to_string());
+    }
+    if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
+        return Some(format!(
+            "当前仅允许 plot_text_hint 进入人工确认后的二次 guardrail，实际作用域为 {}",
+            target
+        ));
+    }
+
+    match find_review_proposal(trace, request_id) {
+        Some(proposal)
+            if proposal.status == NoNameProposalStatus::Applied
+                && proposal.applyable
+                && target_segment_supports_apply_scope(
+                    proposal.target_segment,
+                    NoNameApplyScope::PlotTextHint,
+                ) =>
+        {
+            None
+        }
+        Some(proposal)
+            if proposal.status != NoNameProposalStatus::Applied || !proposal.applyable =>
+        {
+            Some(format!(
+                "proposal 状态为 {} / applyable={}，拒绝进入高层 apply intent",
+                proposal.status.as_str(),
+                proposal.applyable
+            ))
+        }
+        Some(proposal) => Some(format!(
+            "target_segment={} 不支持 plot_text_hint 二次 apply",
+            proposal.target_segment.as_str()
+        )),
+        None => Some("未找到 review 对应 proposal，拒绝进入高层 apply intent".to_string()),
+    }
+}
+
+pub fn record_human_review_apply_intent(
+    trace: &mut NoNameTrace,
+    request_id: &str,
+    decision: NoNameHumanReviewDecision,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) {
+    let target = safe_apply_scope
+        .map(|scope| scope.as_str())
+        .unwrap_or("controlled_output");
+    let order = next_apply_plan_order(trace);
+    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 25;
+
+    match decision {
+        NoNameHumanReviewDecision::Pending => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "review_intent_pending",
+                priority,
+                Some("人工复核已重置为待确认，未进入二次 guardrail".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "human_review_pending",
+                Some("等待人工确认，不触发高层 apply".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:apply_intent:pending", request_id));
+        }
+        NoNameHumanReviewDecision::RejectedForHigherApply => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "reject",
+                priority,
+                Some("人工复核拒绝进入高层 apply，保持安全边界".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "rejected_by_human_review",
+                Some("开发者选择暂不应用，未触发二次 guardrail".to_string()),
+            );
+            trace.record_proposal_transition(format!(
+                "{}:apply_intent:rejected_by_human_review",
+                request_id
+            ));
+        }
+        NoNameHumanReviewDecision::ApprovedForHigherApply => {
+            if let Some(reason) = human_review_apply_intent_rejection_reason(
+                trace,
+                request_id,
+                safe_apply_scope,
+                target,
+            ) {
+                trace.record_apply_plan(
+                    order,
+                    target,
+                    "second_guardrail_reject",
+                    priority,
+                    Some(reason.clone()),
+                );
+                trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason));
+                trace.record_proposal_transition(format!(
+                    "{}:apply_intent:second_guardrail_rejected",
+                    request_id
+                ));
+                return;
+            }
+
+            trace.record_apply_plan(
+                order,
+                target,
+                "review_intent_ready",
+                priority,
+                Some(
+                    "人工确认已通过，已排入二次 guardrail / apply planner，未写入正文".to_string(),
+                ),
+            );
+            trace.record_apply_execution(
+                target,
+                "awaiting_second_guardrail",
+                Some("高层 apply intent 已记录，等待后续二次 guardrail 决策".to_string()),
+            );
+            trace.record_proposal_transition(format!(
+                "{}:apply_intent:awaiting_second_guardrail",
+                request_id
+            ));
+        }
+    }
+}
+
+pub fn record_second_guardrail_decision(
+    trace: &mut NoNameTrace,
+    request_id: &str,
+    decision: NoNameSecondGuardrailDecision,
+    safe_apply_scope: Option<NoNameApplyScope>,
+) -> Result<(), String> {
+    let target = safe_apply_scope
+        .map(|scope| scope.as_str())
+        .unwrap_or("controlled_output");
+    let order = next_apply_plan_order(trace);
+    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 50;
+    let revalidation_reason =
+        second_guardrail_revalidation_reason(trace, request_id, safe_apply_scope);
+
+    if let Some(reason) = revalidation_reason {
+        trace.record_apply_plan(
+            order,
+            target,
+            "second_guardrail_reject",
+            priority,
+            Some(reason.clone()),
+        );
+        trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason.clone()));
+        trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
+        trace.set_apply_result(true, "second_guardrail_reject", Some(reason));
+        return Ok(());
+    }
+
+    match decision {
+        NoNameSecondGuardrailDecision::Allow => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_allow",
+                priority,
+                Some("二次 guardrail 允许进入后续人工 apply 命令；当前不写正文".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_allowed",
+                Some("已允许进入下一步人工 apply，但未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:allow", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_allow",
+                Some("二次 guardrail 已允许；等待显式人工 apply 命令".to_string()),
+            );
+        }
+        NoNameSecondGuardrailDecision::Reject => {
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_reject",
+                priority,
+                Some("二次 guardrail 人工拒绝高层 apply".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_rejected",
+                Some("二次 guardrail 决策为拒绝，未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_reject",
+                Some("二次 guardrail 已拒绝高层 apply".to_string()),
+            );
+        }
+        NoNameSecondGuardrailDecision::Fallback => {
+            trace.push_stage(NoNameTraceStage::ApplyFallback);
+            trace.fallback_used = true;
+            trace.record_apply_plan(
+                order,
+                target,
+                "second_guardrail_fallback",
+                priority,
+                Some("二次 guardrail 要求回退经典链路".to_string()),
+            );
+            trace.record_apply_execution(
+                target,
+                "second_guardrail_fallback",
+                Some("已记录回退决策，未改写剧情正文".to_string()),
+            );
+            trace.record_proposal_transition(format!("{}:second_guardrail:fallback", request_id));
+            trace.set_apply_result(
+                true,
+                "second_guardrail_fallback",
+                Some("二次 guardrail 决策为 fallback，继续依赖经典链路".to_string()),
+            );
+        }
+    }
+
+    Ok(())
 }
 
 fn trace_has_second_guardrail_allow(
@@ -643,6 +931,145 @@ mod tests {
             None,
         );
         (trace, request_id)
+    }
+
+    fn make_trace_for_plot_text_review() -> (NoNameTrace, String) {
+        let proposal_id = "proposal-plot-text".to_string();
+        let request_id = "controlled-output-proposal-plot-text-plot_text_hint".to_string();
+        let mut trace = NoNameTrace::empty("trace-3", "session-1", "turn-3", NoNameMode::Assisted);
+        trace.record_proposal(NoNameProposal {
+            proposal_id,
+            kind: NoNameProposalKind::PlotCandidate,
+            producer_role: NoNameRole::Director,
+            title: "plot text hint".to_string(),
+            summary: "suggest plot text hint".to_string(),
+            focus: "mountain gate".to_string(),
+            target_segment: NoNameTargetSegment::CurrentTurnTail,
+            intended_effect: "append a reviewed narrative hint".to_string(),
+            rationale: "keep the next beat focused".to_string(),
+            suggested_action: Some("manual apply".to_string()),
+            labels: vec!["test".to_string()],
+            apply_scopes: vec![NoNameApplyScope::PlotTextHint],
+            status: NoNameProposalStatus::Applied,
+            applyable: true,
+        });
+        trace.record_controlled_output_review(
+            Some("proposal-plot-text".to_string()),
+            NoNameControlledOutputKind::SceneAugmentation,
+            Vec::new(),
+            NoNameControlledOutputReview {
+                request_id: request_id.clone(),
+                decision: NoNameControlledOutputDecision::NeedsReview,
+                reason: "plot text hint requires human review".to_string(),
+                normalized_kind: Some(NoNameControlledOutputKind::SceneAugmentation),
+                safe_apply_scope: Some(NoNameApplyScope::PlotTextHint),
+                requires_human_review: true,
+            },
+        );
+        (trace, request_id)
+    }
+
+    #[test]
+    fn human_review_apply_intent_records_ready_for_plot_text() {
+        let (mut trace, request_id) = make_trace_for_plot_text_review();
+
+        record_human_review_apply_intent(
+            &mut trace,
+            &request_id,
+            NoNameHumanReviewDecision::ApprovedForHigherApply,
+            Some(NoNameApplyScope::PlotTextHint),
+        );
+
+        assert!(trace.apply_plan_log.iter().any(|entry| {
+            entry.target == "plot_text_hint" && entry.decision == "review_intent_ready"
+        }));
+        assert!(trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "plot_text_hint" && entry.outcome == "awaiting_second_guardrail"
+        }));
+        assert!(trace
+            .proposal_transition_log
+            .iter()
+            .any(|entry| entry.ends_with(":apply_intent:awaiting_second_guardrail")));
+    }
+
+    #[test]
+    fn human_review_apply_intent_rejects_non_plot_text_scope() {
+        let (mut trace, request_id) = make_trace_for_summary_apply();
+
+        record_human_review_apply_intent(
+            &mut trace,
+            &request_id,
+            NoNameHumanReviewDecision::ApprovedForHigherApply,
+            Some(NoNameApplyScope::ChapterSummaryHint),
+        );
+
+        assert!(trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "chapter_summary_hint"
+                && entry.outcome == "second_guardrail_rejected"
+                && entry
+                    .note
+                    .as_deref()
+                    .is_some_and(|note| note.contains("当前仅允许 plot_text_hint"))
+        }));
+    }
+
+    #[test]
+    fn second_guardrail_allow_records_reviewed_apply_gate() {
+        let (mut trace, request_id) = make_trace_for_plot_text_review();
+        record_human_review_apply_intent(
+            &mut trace,
+            &request_id,
+            NoNameHumanReviewDecision::ApprovedForHigherApply,
+            Some(NoNameApplyScope::PlotTextHint),
+        );
+
+        record_second_guardrail_decision(
+            &mut trace,
+            &request_id,
+            NoNameSecondGuardrailDecision::Allow,
+            Some(NoNameApplyScope::PlotTextHint),
+        )
+        .expect("second guardrail allow should be recorded");
+
+        assert!(trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "plot_text_hint" && entry.outcome == "second_guardrail_allowed"
+        }));
+        assert_eq!(
+            trace
+                .apply_result
+                .as_ref()
+                .map(|item| item.outcome.as_str()),
+            Some("second_guardrail_allow")
+        );
+    }
+
+    #[test]
+    fn second_guardrail_rejects_review_that_is_not_waiting() {
+        let (mut trace, request_id) = make_trace_for_plot_text_review();
+
+        record_second_guardrail_decision(
+            &mut trace,
+            &request_id,
+            NoNameSecondGuardrailDecision::Allow,
+            Some(NoNameApplyScope::PlotTextHint),
+        )
+        .expect("second guardrail rejection should be recorded as trace outcome");
+
+        assert!(trace.apply_execution_log.iter().any(|entry| {
+            entry.target == "plot_text_hint"
+                && entry.outcome == "second_guardrail_rejected"
+                && entry
+                    .note
+                    .as_deref()
+                    .is_some_and(|note| note.contains("awaiting_second_guardrail"))
+        }));
+        assert_eq!(
+            trace
+                .apply_result
+                .as_ref()
+                .map(|item| item.outcome.as_str()),
+            Some("second_guardrail_reject")
+        );
     }
 
     #[test]

--- a/src-tauri/src/tauri_commands.rs
+++ b/src-tauri/src/tauri_commands.rs
@@ -16,7 +16,8 @@ use crate::llm_service::{LLMConfig, LLMRequest, LLMService};
 use crate::memory_layers::{ChapterSummary, MemoryEntry, WorldFact};
 use crate::noname_apply::{
     apply_manual_plot_text_hint_to_plot_state, apply_reviewed_output_to_plot_state,
-    build_reviewed_apply_request,
+    build_reviewed_apply_request, record_human_review_apply_intent,
+    record_second_guardrail_decision,
 };
 use crate::noname_config::NoNameConfig;
 use crate::noname_context_builder::build_context_packet;
@@ -243,7 +244,10 @@ fn apply_noname_outcome_with_engine<F>(
     apply: F,
 ) -> Result<NoNameManualPlotTextApplyResult, String>
 where
-    F: FnOnce(NoNameTrace, PlotState) -> Result<crate::noname_apply::NoNameReviewedApplyOutcome, String>,
+    F: FnOnce(
+        NoNameTrace,
+        PlotState,
+    ) -> Result<crate::noname_apply::NoNameReviewedApplyOutcome, String>,
 {
     let trace = load_noname_trace(trace_id)?;
     let result = {
@@ -464,306 +468,6 @@ fn record_noname_apply_plan_and_skip_execution(
     if let NoNameApplyTargetDecision::Skip { outcome, note } = &plan.decision {
         trace.record_apply_execution(plan.target, *outcome, Some(note.clone()));
     }
-}
-
-fn next_noname_apply_plan_order(trace: &NoNameTrace) -> u32 {
-    trace
-        .apply_plan_log
-        .iter()
-        .map(|item| item.order)
-        .max()
-        .unwrap_or_default()
-        + 1
-}
-
-fn find_review_proposal<'a>(
-    trace: &'a NoNameTrace,
-    request_id: &str,
-) -> Option<&'a crate::noname_types::NoNameProposal> {
-    trace
-        .proposals
-        .iter()
-        .rev()
-        .find(|proposal| request_id.contains(&proposal.proposal_id))
-        .or_else(|| trace.proposals.last())
-}
-
-fn record_noname_human_review_apply_intent(
-    trace: &mut NoNameTrace,
-    request_id: &str,
-    decision: NoNameHumanReviewDecision,
-    safe_apply_scope: Option<NoNameApplyScope>,
-) {
-    let target = safe_apply_scope
-        .map(|scope| scope.as_str())
-        .unwrap_or("controlled_output");
-    let order = next_noname_apply_plan_order(trace);
-    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 25;
-
-    match decision {
-        NoNameHumanReviewDecision::Pending => {
-            trace.record_apply_plan(
-                order,
-                target,
-                "review_intent_pending",
-                priority,
-                Some("人工复核已重置为待确认，未进入二次 guardrail".to_string()),
-            );
-            trace.record_apply_execution(
-                target,
-                "human_review_pending",
-                Some("等待人工确认，不触发高层 apply".to_string()),
-            );
-            trace.record_proposal_transition(format!("{}:apply_intent:pending", request_id));
-        }
-        NoNameHumanReviewDecision::RejectedForHigherApply => {
-            trace.record_apply_plan(
-                order,
-                target,
-                "reject",
-                priority,
-                Some("人工复核拒绝进入高层 apply，保持安全边界".to_string()),
-            );
-            trace.record_apply_execution(
-                target,
-                "rejected_by_human_review",
-                Some("开发者选择暂不应用，未触发二次 guardrail".to_string()),
-            );
-            trace.record_proposal_transition(format!(
-                "{}:apply_intent:rejected_by_human_review",
-                request_id
-            ));
-        }
-        NoNameHumanReviewDecision::ApprovedForHigherApply => {
-            let rejection_reason = if trace.mode != NoNameMode::Assisted {
-                Some("当前 trace 不是 assisted 模式，拒绝进入高层 apply intent".to_string())
-            } else if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
-                Some(format!(
-                    "当前仅允许 plot_text_hint 进入人工确认后的二次 guardrail，实际作用域为 {}",
-                    target
-                ))
-            } else {
-                match find_review_proposal(trace, request_id) {
-                    Some(proposal)
-                        if proposal.status
-                            == crate::noname_types::NoNameProposalStatus::Applied
-                            && proposal.applyable
-                            && target_segment_supports_apply_scope(
-                                proposal.target_segment,
-                                NoNameApplyScope::PlotTextHint,
-                            ) =>
-                    {
-                        None
-                    }
-                    Some(proposal)
-                        if proposal.status
-                            != crate::noname_types::NoNameProposalStatus::Applied
-                            || !proposal.applyable =>
-                    {
-                        Some(format!(
-                            "proposal 状态为 {} / applyable={}，拒绝进入高层 apply intent",
-                            proposal.status.as_str(),
-                            proposal.applyable
-                        ))
-                    }
-                    Some(proposal) => Some(format!(
-                        "target_segment={} 不支持 plot_text_hint 二次 apply",
-                        proposal.target_segment.as_str()
-                    )),
-                    None => {
-                        Some("未找到 review 对应 proposal，拒绝进入高层 apply intent".to_string())
-                    }
-                }
-            };
-
-            if let Some(reason) = rejection_reason {
-                trace.record_apply_plan(
-                    order,
-                    target,
-                    "second_guardrail_reject",
-                    priority,
-                    Some(reason.clone()),
-                );
-                trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason));
-                trace.record_proposal_transition(format!(
-                    "{}:apply_intent:second_guardrail_rejected",
-                    request_id
-                ));
-                return;
-            }
-
-            trace.record_apply_plan(
-                order,
-                target,
-                "review_intent_ready",
-                priority,
-                Some(
-                    "人工确认已通过，已排入二次 guardrail / apply planner，未写入正文".to_string(),
-                ),
-            );
-            trace.record_apply_execution(
-                target,
-                "awaiting_second_guardrail",
-                Some("高层 apply intent 已记录，等待后续二次 guardrail 决策".to_string()),
-            );
-            trace.record_proposal_transition(format!(
-                "{}:apply_intent:awaiting_second_guardrail",
-                request_id
-            ));
-        }
-    }
-}
-
-fn review_is_waiting_for_second_guardrail(trace: &NoNameTrace, request_id: &str) -> bool {
-    let transition = format!("{}:apply_intent:awaiting_second_guardrail", request_id);
-    trace
-        .proposal_transition_log
-        .iter()
-        .any(|entry| entry == &transition)
-        || trace.apply_execution_log.iter().any(|entry| {
-            entry.outcome == "awaiting_second_guardrail"
-                && entry.target == NoNameApplyScope::PlotTextHint.as_str()
-        })
-}
-
-fn second_guardrail_revalidation_reason(
-    trace: &NoNameTrace,
-    request_id: &str,
-    safe_apply_scope: Option<NoNameApplyScope>,
-) -> Option<String> {
-    if trace.mode != NoNameMode::Assisted {
-        return Some("当前 trace 不是 assisted 模式，二次 guardrail 拒绝".to_string());
-    }
-    if safe_apply_scope != Some(NoNameApplyScope::PlotTextHint) {
-        return Some("当前二次 guardrail 只允许处理 plot_text_hint".to_string());
-    }
-    if !review_is_waiting_for_second_guardrail(trace, request_id) {
-        return Some("review 尚未进入 awaiting_second_guardrail 队列".to_string());
-    }
-
-    match find_review_proposal(trace, request_id) {
-        Some(proposal)
-            if proposal.status == crate::noname_types::NoNameProposalStatus::Applied
-                && proposal.applyable
-                && target_segment_supports_apply_scope(
-                    proposal.target_segment,
-                    NoNameApplyScope::PlotTextHint,
-                ) =>
-        {
-            None
-        }
-        Some(proposal)
-            if proposal.status != crate::noname_types::NoNameProposalStatus::Applied
-                || !proposal.applyable =>
-        {
-            Some(format!(
-                "proposal 状态为 {} / applyable={}，二次 guardrail 拒绝",
-                proposal.status.as_str(),
-                proposal.applyable
-            ))
-        }
-        Some(proposal) => Some(format!(
-            "target_segment={} 不支持 plot_text_hint 二次 guardrail",
-            proposal.target_segment.as_str()
-        )),
-        None => Some("未找到 review 对应 proposal，二次 guardrail 拒绝".to_string()),
-    }
-}
-
-fn record_noname_second_guardrail_decision(
-    trace: &mut NoNameTrace,
-    request_id: &str,
-    decision: NoNameSecondGuardrailDecision,
-    safe_apply_scope: Option<NoNameApplyScope>,
-) -> Result<(), String> {
-    let target = safe_apply_scope
-        .map(|scope| scope.as_str())
-        .unwrap_or("controlled_output");
-    let order = next_noname_apply_plan_order(trace);
-    let priority = safe_apply_scope.map(priority_for_apply_scope).unwrap_or(10) + 50;
-    let revalidation_reason =
-        second_guardrail_revalidation_reason(trace, request_id, safe_apply_scope);
-
-    if let Some(reason) = revalidation_reason {
-        trace.record_apply_plan(
-            order,
-            target,
-            "second_guardrail_reject",
-            priority,
-            Some(reason.clone()),
-        );
-        trace.record_apply_execution(target, "second_guardrail_rejected", Some(reason.clone()));
-        trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
-        trace.set_apply_result(true, "second_guardrail_reject", Some(reason));
-        return Ok(());
-    }
-
-    match decision {
-        NoNameSecondGuardrailDecision::Allow => {
-            trace.record_apply_plan(
-                order,
-                target,
-                "second_guardrail_allow",
-                priority,
-                Some("二次 guardrail 允许进入后续人工 apply 命令；当前不写正文".to_string()),
-            );
-            trace.record_apply_execution(
-                target,
-                "second_guardrail_allowed",
-                Some("已允许进入下一步人工 apply，但未改写剧情正文".to_string()),
-            );
-            trace.record_proposal_transition(format!("{}:second_guardrail:allow", request_id));
-            trace.set_apply_result(
-                true,
-                "second_guardrail_allow",
-                Some("二次 guardrail 已允许；等待显式人工 apply 命令".to_string()),
-            );
-        }
-        NoNameSecondGuardrailDecision::Reject => {
-            trace.record_apply_plan(
-                order,
-                target,
-                "second_guardrail_reject",
-                priority,
-                Some("二次 guardrail 人工拒绝高层 apply".to_string()),
-            );
-            trace.record_apply_execution(
-                target,
-                "second_guardrail_rejected",
-                Some("二次 guardrail 决策为拒绝，未改写剧情正文".to_string()),
-            );
-            trace.record_proposal_transition(format!("{}:second_guardrail:reject", request_id));
-            trace.set_apply_result(
-                true,
-                "second_guardrail_reject",
-                Some("二次 guardrail 已拒绝高层 apply".to_string()),
-            );
-        }
-        NoNameSecondGuardrailDecision::Fallback => {
-            trace.push_stage(crate::noname_types::NoNameTraceStage::ApplyFallback);
-            trace.fallback_used = true;
-            trace.record_apply_plan(
-                order,
-                target,
-                "second_guardrail_fallback",
-                priority,
-                Some("二次 guardrail 要求回退经典链路".to_string()),
-            );
-            trace.record_apply_execution(
-                target,
-                "second_guardrail_fallback",
-                Some("已记录回退决策，未改写剧情正文".to_string()),
-            );
-            trace.record_proposal_transition(format!("{}:second_guardrail:fallback", request_id));
-            trace.set_apply_result(
-                true,
-                "second_guardrail_fallback",
-                Some("二次 guardrail 决策为 fallback，继续依赖经典链路".to_string()),
-            );
-        }
-    }
-
-    Ok(())
 }
 
 fn apply_noname_plot_text_hint(
@@ -4433,7 +4137,7 @@ pub async fn mark_noname_controlled_output_review(
     }
 
     trace.record_proposal_transition(format!("{}:human_review:{}", request_id, decision.as_str()));
-    record_noname_human_review_apply_intent(&mut trace, &request_id, decision, safe_apply_scope);
+    record_human_review_apply_intent(&mut trace, &request_id, decision, safe_apply_scope);
 
     if !runtime.replace_trace(trace.clone()) {
         return Err(format!("NoName trace not found: {}", trace_id));
@@ -4475,7 +4179,7 @@ pub async fn resolve_noname_second_guardrail(
         review.safe_apply_scope
     };
 
-    record_noname_second_guardrail_decision(&mut trace, &request_id, decision, safe_apply_scope)?;
+    record_second_guardrail_decision(&mut trace, &request_id, decision, safe_apply_scope)?;
 
     if !runtime.replace_trace(trace.clone()) {
         return Err(format!("NoName trace not found: {}", trace_id));


### PR DESCRIPTION
目标：继续主开发线 A2，将 NoName reviewed apply 链路中的 human review intent 与 second guardrail 决策记录从 tauri_commands.rs 下沉到 noname_apply.rs，让命令层继续变薄。主要改动：新增 record_human_review_apply_intent 与 record_second_guardrail_decision；移除 tauri_commands.rs 中对应私有编排 helper；为 noname_apply 增加 human review intent 与 second guardrail 直接单测；同步更新中文项目文档。红线：未新增 apply scope，未扩大 second guardrail 语义，未让 NoName 直接写入最终剧情状态或世界硬事实。验证：cargo test noname_apply -- --nocapture；cargo test tauri_commands::tests::test_mark_noname_controlled_output_review_records_human_intent -- --nocapture；cargo test noname_ -- --nocapture；cargo test tauri_commands -- --nocapture；git diff --check。