### PR TITLE
feat(noname): surface reviewed apply lifecycle checkpoints

### DIFF
--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -17,6 +17,8 @@
 - 角色上下文差异度已完成第一轮增强，`source_stats` 与 `visible_constraints` 能显示角色级上下文偏好
 - 检索与 notes 已完成第一轮串联，active notes 可作为检索上下文桥帮助召回相关记忆，archived notes 不参与扩展召回
 - 调试台信息结构已完成第一轮优化，trace 面板提供前置快读条，复制摘要提供 `Trace Breakdown`
+- reviewed apply 生命周期展示已完成第一轮收口，前端可核对 `Human Review -> Second Guardrail -> Manual Apply`
+- 下一层安全输出接口已完成第一轮试点评估，当前结论是只适合先探索非最终状态的 pending / draft / diagnostics-like 输出层
 
 ## 3. 当前主要风险
 
@@ -54,6 +56,10 @@
 ### 3.5 记忆检索与 notes 串联仍未完成
 
 检索排序解释性、notes 生命周期和 notes/retrieval 串联第一轮已经具备，但 structured notes 与 compaction、context builder 的贯通仍不完整。后续需要继续验证 note-aware retrieval 是否应接入更多上下文构建路径，避免新能力只停留在 manager 层报告。
+
+### 3.6 下一层安全输出仍不能扩大权限边界
+
+下一层输出接口目前只完成试点评估，不代表可以直接写最终剧情状态。后续若实现 `draft / pending hint` 类输出，仍必须保留人工复核、二次护栏、显式写入和 stale snapshot 校验。
 
 ## 4. 当前最合理的发展策略
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -108,6 +108,14 @@
 - trace 面板已提供 `Trace 快读` 条，调试台复制摘要已提供 `Trace Breakdown`
 - 当前改动不增加后端协议字段，仅重组现有 trace 信息
 
+### 任务 6.7：收口 reviewed apply 生命周期展示
+
+当前状态：
+
+- 第一轮已完成
+- trace 面板、调试台复制摘要和 store 诊断均已展示 `Human Review -> Second Guardrail -> Manual Apply` 顺序核对
+- 当前改动不增加后端命令，也不扩大 apply scope
+
 ## P3：中期探索
 
 ### 任务 7：推进下一层安全输出接口
@@ -116,6 +124,13 @@
   - 主链减压完成
   - mock/后端语义一致
   - reviewed apply 结构稳定
+
+当前状态：
+
+- 第一轮评估已完成
+- 当前只建议试点非最终状态的 pending / draft / diagnostics-like 输出层
+- 不建议直接试点最终剧情、世界硬事实、NPC 隐藏意图或绕过 reviewed apply 的自动写入
+- 评估文档见 [下一层安全输出接口试点评估](./05-下一层安全输出接口试点评估.md)
 
 ### 任务 8：评估多角色协作与更强知识检索
 

--- a/docs/项目文档/03-规划/03-协作任务清单.md
+++ b/docs/项目文档/03-规划/03-协作任务清单.md
@@ -101,6 +101,7 @@
 - 第一轮已完成
 - trace 面板已新增前置快读条，便于快速核对 proposal / review / human review / apply / guardrail 概览
 - 调试台复制摘要已补充 `Trace Breakdown`
+- reviewed apply 生命周期展示已补充 `Human Review -> Second Guardrail -> Manual Apply` 顺序核对
 - 未新增后端协议字段，仍只消费现有 trace 数据
 
 ### 协作任务 5：检索与 notes 串联增强

--- a/docs/项目文档/03-规划/04-未来两周开发排期.md
+++ b/docs/项目文档/03-规划/04-未来两周开发排期.md
@@ -224,6 +224,18 @@
 - 最小验证：
   - `npm run test -- --run src/stores/__tests__/gameStore.test.ts src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts`
 
+当前状态：
+
+- 第一轮已完成
+- `AgentTracePanel` 已新增 `Lifecycle Checkpoints`，稳定展示 `Human Review -> Second Guardrail -> Manual Apply` 三段顺序
+- `NoNameDebugConsole` 的复制摘要已补充 `Lifecycle Checkpoints`，便于 PR 审查时核对 reviewed apply 是否按顺序推进
+- `gameStore` 的 NoName trace 诊断文本已补充 `应用阶段核对`
+- 未新增后端命令，未把 UI 展示逻辑反向塞回后端结构
+- 已补充 utility、组件和 store 定向测试
+- 已验证：
+  - `npm run test -- --run src/utils/noNameApplyLifecycle.test.ts`
+  - `npm run test -- --run src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts`
+
 ### 任务 A5：评估下一层安全输出接口的试点条件
 
 - 目标：
@@ -238,6 +250,14 @@
   - 不在评估任务里顺手把新 apply scope 做出来
 - 最小验证：
   - 文档评审通过
+
+当前状态：
+
+- 第一轮已完成
+- 已新增 [下一层安全输出接口试点评估](./05-下一层安全输出接口试点评估.md)
+- 当前判断为：可以试点“非最终状态的候选输出层 / pending hint / diagnostics-like draft”，不能直接试点最终剧情、世界硬事实、NPC 隐藏意图或绕过 reviewed apply 的自动写入
+- 试点前置条件已明确：A4 生命周期展示稳定、trace 证据完整、stale snapshot 校验存在、拒绝 / fallback / pending 不误写入
+- 未新增正式产品逻辑，未新增 apply scope
 
 ## 5.2 协作者线
 

--- a/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
+++ b/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
@@ -1,0 +1,79 @@
+# 下一层安全输出接口试点评估
+
+更新时间：2026-04-21
+
+## 1. 评估结论
+
+下一层安全输出接口可以进入“试点评估”，但不应直接进入正式产品逻辑。
+
+当前最适合试点的是“非最终状态的候选输出层”，例如继续沿用 `PlotAugmentationHint` 这类暂存提示，或新增只存在于 trace / pending hint / 调试报告中的草稿型输出。它可以帮助后续剧情生成获得更明确的方向，但不能绕过 reviewed apply、second guardrail 和人工显式写入。
+
+不建议现在试点“直接写入最终剧情正文、世界硬事实、NPC 隐藏意图或长期 canon 状态”的接口。
+
+## 2. 能试什么
+
+- 可以试：非最终状态的剧情方向提示。
+- 可以试：只进入 pending 层、下一轮生成时再消费的提示。
+- 可以试：只进入 trace / debug console 的诊断型输出。
+- 可以试：需要人工确认、二次护栏允许、显式 apply 命令三段证据都齐全后才进入更高层的写入链路。
+
+这类输出的共同特征是：它们不会直接成为最终剧情事实，只为下一步生成提供候选方向。
+
+## 3. 不能试什么
+
+- 不能试：自动写入最终剧情段落。
+- 不能试：自动写入世界硬事实或 canon world fact。
+- 不能试：自动决定 NPC 的隐藏意图、最终动机或关键背叛。
+- 不能试：跳过人工复核或二次护栏的高层 apply。
+- 不能试：在 A5 评估任务中顺手新增正式 apply scope。
+
+这些输出一旦写入，会改变玩家可见故事或长期设定，回滚成本明显高于当前 reviewed apply 链路能承受的范围。
+
+## 4. 为什么这样判断
+
+当前项目已经具备 reviewed apply 的核心证据链：
+
+- trace 能记录 controlled output review。
+- 前端能展示 review -> second guardrail -> manual apply 的顺序核对。
+- store 诊断和 debug console 能复制同一条生命周期摘要。
+- `PlotAugmentationHint` 已经证明“非最终 pending 层”比“直接写最终状态”更安全。
+
+但当前仍存在两个限制：
+
+- 主链复杂度仍需要继续收口，不能再把新接口直接堆进命令层。
+- Web mock、后端、前端展示虽然已经第一轮对齐，但后续新增字段仍需要同步维护。
+
+因此，下一层接口应该先作为受控试点，而不是直接扩大权限边界。
+
+## 5. 试点前置条件
+
+- A4 生命周期展示必须稳定，至少能读出 Human Review、Second Guardrail、Manual Apply 三段状态。
+- 新输出必须默认落在 pending / draft / diagnostics 层，不得直接写最终剧情状态。
+- 必须有 trace 证据能说明“谁提出、为什么提出、是否经过人工确认、二次护栏如何决策”。
+- 必须有 stale snapshot 或等价校验，避免用户看到的内容和写入目标错位。
+- 必须有测试证明被拒绝、fallback、pending 三种状态不会误写入。
+- 必须先写设计文档和测试探针，再决定是否落正式产品代码。
+
+## 6. 建议的第一轮试点形态
+
+建议第一轮只做“安全输出草稿层”设计，不落正式后端命令。
+
+候选形态：
+
+- 名称：`NoNameSafeOutputDraft`
+- 位置：先只存在于文档和测试探针中
+- 内容：`draftId / sourceProposalId / outputKind / safeApplyScope / summary / rationale / lifecycleState`
+- 生命周期：`drafted -> reviewed -> guardrailAllowed -> manuallyApplied`，其中 `manuallyApplied` 只代表显式命令完成，不代表自动写入
+- 默认写入层：trace / pending hint / diagnostics，不写 final plot state
+
+如果后续要落代码，应优先从 utility 与测试开始，而不是从 `tauri_commands.rs` 新增命令开始。
+
+## 7. 当前决策
+
+可以开始设计试点，但不能开始扩大 apply scope。
+
+下一步更合理的动作是：
+
+- 先把 A4 的生命周期展示作为前置能力合并稳定。
+- 再为 `NoNameSafeOutputDraft` 写一份轻量设计或测试探针。
+- 等 trace、mock、后端语义都能说明该草稿层不会自动写终态后，再评估是否进入正式实现。

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -108,6 +108,9 @@
         <p class="agent-trace-card-title">
           应用生命周期
         </p>
+        <p class="agent-trace-muted">
+          Lifecycle Checkpoints: {{ applyLifecycleCheckpointSummary }}
+        </p>
         <ul class="agent-trace-lifecycle">
           <li
             v-for="step in applyLifecycleSteps"
@@ -515,6 +518,7 @@ import type {
 import {
   buildNoNameApplyLifecycle,
   formatNoNameApplyExecutionRecord,
+  summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
 } from '../utils/noNameApplyLifecycle';
 
@@ -560,6 +564,9 @@ const protocolEvents = computed(() => props.trace?.protocolEvents ?? []);
 const controlledOutputReviews = computed(() => props.trace?.controlledOutputReviews ?? []);
 const applyLifecycleSteps = computed(() => (
   props.trace ? buildNoNameApplyLifecycle(props.trace, props.reviewDecisions) : []
+));
+const applyLifecycleCheckpointSummary = computed(() => (
+  props.trace ? summarizeNoNameApplyLifecycleCheckpoints(props.trace, props.reviewDecisions) : 'none'
 ));
 const pendingPlotAugmentationSummary = computed(() => (
   props.trace ? summarizeNoNamePendingPlotAugmentation(props.trace) : '无'

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -151,6 +151,7 @@ import type {
 import {
   summarizeNoNameApplyExecutions,
   summarizeNoNameApplyLifecycle,
+  summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
 } from '../utils/noNameApplyLifecycle';
 
@@ -352,6 +353,7 @@ function buildTraceReport(
     ? `${trace.applyResult.outcome}${trace.applyResult.reason ? ` (${trace.applyResult.reason})` : ''}`
     : '无';
   const lifecycle = summarizeNoNameApplyLifecycle(trace, reviewDecisions);
+  const lifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(trace, reviewDecisions);
   const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(trace);
   const applyExecutions = summarizeNoNameApplyExecutions(trace, {
     emptyLabel: 'none',
@@ -374,6 +376,7 @@ function buildTraceReport(
     `Guardrail: ${guardrail}`,
     `Apply Result: ${applyResult}`,
     `Apply Lifecycle: ${lifecycle}`,
+    `Lifecycle Checkpoints: ${lifecycleCheckpoints}`,
     `Apply Executions: ${applyExecutions}`,
     `Plot Augmentation: ${pendingPlotAugmentation}`,
     `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -126,6 +126,7 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('未回退');
     expect(wrapper.text()).toContain('ApplyProposal');
     expect(wrapper.text()).toContain('应用生命周期');
+    expect(wrapper.text()).toContain('Lifecycle Checkpoints: 1.Human Review=pending');
     expect(wrapper.text()).toContain('提案阶段');
     expect(wrapper.text()).toContain('低风险输出');
     expect(wrapper.text()).toContain('协作观察');

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -150,6 +150,7 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('Trace Breakdown: proposals=1, reviews=1, humanReview=1, applyExecutions=2');
     expect(wrapper.text()).toContain('Human Review Decisions: 0 approved / 0 rejected / 1 pending');
     expect(wrapper.text()).toContain('Apply Lifecycle:');
+    expect(wrapper.text()).toContain('Lifecycle Checkpoints: 1.Human Review=pending');
     expect(wrapper.text()).toContain('Plot Augmentation: 已消费');
     expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
@@ -233,6 +234,7 @@ describe('NoNameDebugConsole', () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Controlled Reviews: 1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace Breakdown: proposals=1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Lifecycle Checkpoints:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Executions:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('剧情增强提示:已消费'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]'));

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -426,6 +426,7 @@ describe('gameStore', () => {
     const text = store.getNoNameTraceDebugText();
     expect(text).toContain('预检：preflight_ready');
     expect(text).toContain('应用生命周期：提案阶段:ready');
+    expect(text).toContain('应用阶段核对：1.Human Review=approved');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
     expect(text).toContain('剧情增强提示:已消费[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]');

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -3,6 +3,7 @@ import { invokeRuntime, invokeWithTimeout } from '../utils/tauriInvoke';
 import {
   summarizeNoNameApplyExecutions,
   summarizeNoNameApplyLifecycle,
+  summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
 } from '../utils/noNameApplyLifecycle';
 import type {
@@ -474,6 +475,7 @@ export const useGameStore = defineStore('game', {
           .join(', ')
         : '无';
       const applyLifecycle = summarizeNoNameApplyLifecycle(latest);
+      const applyLifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(latest);
       const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(latest);
       return [
         `最近 Trace：${latest.traceId}`,
@@ -489,6 +491,7 @@ export const useGameStore = defineStore('game', {
         `作用域：${proposalScopes}`,
         `预检：${latest.applyResult ? `${latest.applyResult.outcome}${latest.applyResult.reason ? ` (${latest.applyResult.reason})` : ''}` : '无'}`,
         `应用生命周期：${applyLifecycle}`,
+        `应用阶段核对：${applyLifecycleCheckpoints}`,
         `剧情增强提示：${pendingPlotAugmentation}`,
         `应用计划：${applyPlans}`,
         `应用执行：${applyExecutions}`,

--- a/src/utils/noNameApplyLifecycle.test.ts
+++ b/src/utils/noNameApplyLifecycle.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { NoNameTrace } from '../types/game';
 import {
+  buildNoNameApplyLifecycleCheckpoints,
   buildNoNameApplyLifecycle,
   formatNoNameApplyExecutionRecord,
+  summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNameApplyExecutions,
   summarizeNoNameApplyLifecycle,
   summarizeNoNamePendingPlotAugmentation,
@@ -46,6 +48,112 @@ function buildTrace(outcome: string, note: string): NoNameTrace {
 }
 
 describe('buildNoNameApplyLifecycle', () => {
+  it('summarizes the human review, second guardrail, and manual apply order', () => {
+    const trace: NoNameTrace = {
+      ...buildTrace(
+        'manual_plot_augmentation_hint_applied',
+        'manual plot augmentation hint staged for focus=hidden cave clue',
+      ),
+      traceId: 'trace-manual-apply-order',
+      proposals: [{
+        ...buildTrace(
+          'manual_plot_augmentation_hint_applied',
+          'manual plot augmentation hint staged for focus=hidden cave clue',
+        ).proposals[0],
+        proposalId: 'proposal-manual-apply-order',
+        applyScopes: ['plotTextHint'],
+      }],
+      controlledOutputReviews: [{
+        requestId: 'review-plot-text',
+        proposalId: 'proposal-manual-apply-order',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'plot text hint requires review',
+        normalizedKind: 'sceneAugmentation',
+        safeApplyScope: 'plotTextHint',
+        policyForbiddenScopes: ['finalPlotState'],
+        requiresHumanReview: true,
+        humanReviewDecision: 'approvedForHigherApply',
+      }],
+      proposalTransitionLog: [
+        'proposal-manual-apply-order:apply_intent:awaiting_second_guardrail',
+        'proposal-manual-apply-order:second_guardrail:allow',
+        'proposal-manual-apply-order:manual_apply:plot_text_hint',
+      ],
+      applyExecutionLog: [{
+        target: 'plot_text_hint',
+        outcome: 'awaiting_second_guardrail',
+      }, {
+        target: 'plot_text_hint',
+        outcome: 'second_guardrail_allowed',
+      }, {
+        target: 'plot_text_hint',
+        outcome: 'manual_plot_text_applied',
+      }],
+    };
+
+    const checkpoints = buildNoNameApplyLifecycleCheckpoints(trace);
+
+    expect(checkpoints.map((checkpoint) => checkpoint.key)).toEqual([
+      'human-review',
+      'second-guardrail',
+      'manual-apply',
+    ]);
+    expect(checkpoints.map((checkpoint) => checkpoint.state)).toEqual([
+      'approved',
+      'allowed',
+      'applied',
+    ]);
+    expect(summarizeNoNameApplyLifecycleCheckpoints(trace)).toBe(
+      '1.Human Review=approved -> 2.Second Guardrail=allowed -> 3.Manual Apply=applied',
+    );
+  });
+
+  it('keeps manual apply not ready while human review is pending', () => {
+    const trace: NoNameTrace = {
+      ...buildTrace(
+        'manual_plot_augmentation_hint_applied',
+        'manual plot augmentation hint staged for focus=hidden cave clue',
+      ),
+      controlledOutputReviews: [{
+        requestId: 'review-pending',
+        proposalId: 'proposal-1',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'plot text hint requires review',
+        normalizedKind: 'sceneAugmentation',
+        safeApplyScope: 'plotTextHint',
+        policyForbiddenScopes: ['finalPlotState'],
+        requiresHumanReview: true,
+        humanReviewDecision: 'pending',
+      }],
+      proposalTransitionLog: ['proposal-1:apply_intent:awaiting_second_guardrail'],
+      applyExecutionLog: [{
+        target: 'plot_text_hint',
+        outcome: 'awaiting_second_guardrail',
+      }],
+    };
+
+    expect(buildNoNameApplyLifecycleCheckpoints(trace).map((checkpoint) => checkpoint.state)).toEqual([
+      'pending',
+      'waiting',
+      'not-ready',
+    ]);
+  });
+
+  it('does not treat ordinary pending hints as reviewed apply checkpoints', () => {
+    const trace = buildTrace(
+      'pending_plot_augmentation_retained',
+      'pending plot augmentation retained because quick_mode; count=1',
+    );
+
+    expect(buildNoNameApplyLifecycleCheckpoints(trace).map((checkpoint) => checkpoint.state)).toEqual([
+      'not-required',
+      'not-required',
+      'not-required',
+    ]);
+  });
+
   it('surfaces consumed pending plot augmentation hints', () => {
     const trace = buildTrace(
       'pending_plot_augmentation_consumed',

--- a/src/utils/noNameApplyLifecycle.test.ts
+++ b/src/utils/noNameApplyLifecycle.test.ts
@@ -141,6 +141,79 @@ describe('buildNoNameApplyLifecycle', () => {
     ]);
   });
 
+  it('summarizes mixed second guardrail outcomes without contradictory manual state', () => {
+    const trace: NoNameTrace = {
+      ...buildTrace(
+        'manual_plot_augmentation_hint_applied',
+        'manual plot augmentation hint staged for focus=hidden cave clue',
+      ),
+      traceId: 'trace-mixed-second-guardrail',
+      proposals: [{
+        ...buildTrace(
+          'manual_plot_augmentation_hint_applied',
+          'manual plot augmentation hint staged for focus=hidden cave clue',
+        ).proposals[0],
+        proposalId: 'proposal-mixed',
+        applyScopes: ['plotTextHint', 'optionBiasHint'],
+      }],
+      controlledOutputReviews: [{
+        requestId: 'controlled-output-proposal-mixed-plot_text_hint',
+        proposalId: 'proposal-mixed',
+        requestedKind: 'sceneAugmentation',
+        decision: 'needsReview',
+        reason: 'plot text hint requires review',
+        normalizedKind: 'sceneAugmentation',
+        safeApplyScope: 'plotTextHint',
+        policyForbiddenScopes: ['finalPlotState'],
+        requiresHumanReview: true,
+        humanReviewDecision: 'approvedForHigherApply',
+      }, {
+        requestId: 'controlled-output-proposal-mixed-option_bias_hint',
+        proposalId: 'proposal-mixed',
+        requestedKind: 'intermediateNarrativeHint',
+        decision: 'needsReview',
+        reason: 'option bias hint requires review',
+        normalizedKind: 'intermediateNarrativeHint',
+        safeApplyScope: 'optionBiasHint',
+        policyForbiddenScopes: ['finalPlotState'],
+        requiresHumanReview: true,
+        humanReviewDecision: 'approvedForHigherApply',
+      }],
+      proposalTransitionLog: [
+        'controlled-output-proposal-mixed-plot_text_hint:apply_intent:awaiting_second_guardrail',
+        'controlled-output-proposal-mixed-option_bias_hint:apply_intent:awaiting_second_guardrail',
+        'controlled-output-proposal-mixed-plot_text_hint:second_guardrail:allow',
+        'controlled-output-proposal-mixed-option_bias_hint:second_guardrail:reject',
+      ],
+      applyExecutionLog: [{
+        target: 'plot_text_hint',
+        outcome: 'awaiting_second_guardrail',
+      }, {
+        target: 'option_bias_hint',
+        outcome: 'awaiting_second_guardrail',
+      }, {
+        target: 'plot_text_hint',
+        outcome: 'second_guardrail_allowed',
+      }, {
+        target: 'option_bias_hint',
+        outcome: 'second_guardrail_rejected',
+      }],
+    };
+
+    expect(buildNoNameApplyLifecycleCheckpoints(trace).map((checkpoint) => checkpoint.state)).toEqual([
+      'approved',
+      'mixed',
+      'partially-ready',
+    ]);
+    expect(summarizeNoNameApplyLifecycleCheckpoints(trace)).toBe(
+      '1.Human Review=approved -> 2.Second Guardrail=mixed -> 3.Manual Apply=partially-ready',
+    );
+    expect(buildNoNameApplyLifecycle(trace).find((step) => step.key === 'second-guardrail')?.state)
+      .toBe('mixed');
+    expect(buildNoNameApplyLifecycle(trace).find((step) => step.key === 'manual-plot-text')?.state)
+      .toBe('partially-ready');
+  });
+
   it('does not treat ordinary pending hints as reviewed apply checkpoints', () => {
     const trace = buildTrace(
       'pending_plot_augmentation_retained',

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -14,6 +14,20 @@ export interface NoNameApplyLifecycleStep {
   tone: NoNameApplyLifecycleTone;
 }
 
+export type NoNameApplyLifecycleCheckpointKey =
+  | 'human-review'
+  | 'second-guardrail'
+  | 'manual-apply';
+
+export interface NoNameApplyLifecycleCheckpoint {
+  key: NoNameApplyLifecycleCheckpointKey;
+  label: string;
+  order: number;
+  state: string;
+  detail: string;
+  tone: NoNameApplyLifecycleTone;
+}
+
 export interface NoNameApplyExecutionDisplay {
   targetLabel: string;
   outcomeLabel: string;
@@ -146,6 +160,233 @@ function lifecycleHumanDecision(
   return reviewDecisions[requestId]
     ?? trace.controlledOutputReviews?.find((item) => item.requestId === requestId)?.humanReviewDecision
     ?? 'pending';
+}
+
+function hasManualApplyEvidence(trace: NoNameTrace) {
+  return hasExecutionOutcome(trace, 'manual_plot_text_applied')
+    || hasExecutionOutcome(trace, 'manual_chapter_summary_hint_applied')
+    || hasExecutionOutcome(trace, 'manual_option_bias_hint_applied')
+    || hasExecutionOutcome(trace, 'manual_plot_augmentation_hint_applied')
+    || hasTransition(trace, ':manual_apply:plot_text_hint')
+    || hasTransition(trace, ':manual_apply:chapter_summary_hint')
+    || hasTransition(trace, ':manual_apply:option_bias_hint')
+    || hasTransition(trace, ':manual_apply:plot_augmentation_hint');
+}
+
+function hasSecondGuardrailAllowed(trace: NoNameTrace) {
+  return hasExecutionOutcome(trace, 'second_guardrail_allowed')
+    || hasTransition(trace, ':second_guardrail:allow');
+}
+
+function hasSecondGuardrailRejected(trace: NoNameTrace) {
+  return hasExecutionOutcome(trace, 'second_guardrail_rejected')
+    || hasTransition(trace, ':second_guardrail:reject');
+}
+
+function hasSecondGuardrailFallback(trace: NoNameTrace) {
+  return hasExecutionOutcome(trace, 'second_guardrail_fallback')
+    || hasTransition(trace, ':second_guardrail:fallback');
+}
+
+function hasAwaitingSecondGuardrail(trace: NoNameTrace) {
+  return hasExecutionOutcome(trace, 'awaiting_second_guardrail')
+    || hasTransition(trace, ':apply_intent:awaiting_second_guardrail');
+}
+
+export function buildNoNameApplyLifecycleCheckpoints(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+): NoNameApplyLifecycleCheckpoint[] {
+  const controlledReviews = trace.controlledOutputReviews ?? [];
+  const humanReviews = controlledReviews.filter((item) => item.requiresHumanReview);
+  const decisionCounts = humanReviews.reduce(
+    (counts, review) => {
+      const decision = lifecycleHumanDecision(trace, review.requestId, reviewDecisions);
+      counts[decision] += 1;
+      return counts;
+    },
+    {
+      pending: 0,
+      approvedForHigherApply: 0,
+      rejectedForHigherApply: 0,
+    } satisfies Record<NoNameHumanReviewDecision, number>,
+  );
+  const secondGuardrailAllowed = hasSecondGuardrailAllowed(trace);
+  const secondGuardrailRejected = hasSecondGuardrailRejected(trace);
+  const secondGuardrailFallback = hasSecondGuardrailFallback(trace);
+  const awaitingSecondGuardrail = hasAwaitingSecondGuardrail(trace);
+  const manualApplied = hasManualApplyEvidence(trace);
+  const needsManualApplyPath = humanReviews.length > 0
+    || awaitingSecondGuardrail
+    || secondGuardrailAllowed
+    || secondGuardrailRejected
+    || secondGuardrailFallback
+    || manualApplied;
+
+  const reviewCheckpoint: NoNameApplyLifecycleCheckpoint = humanReviews.length === 0
+    ? {
+      key: 'human-review',
+      label: 'Human Review',
+      order: 1,
+      state: 'not-required',
+      detail: 'No controlled output currently requires human review.',
+      tone: 'info',
+    }
+    : decisionCounts.rejectedForHigherApply > 0
+      ? {
+        key: 'human-review',
+        label: 'Human Review',
+        order: 1,
+        state: 'rejected',
+        detail: `${decisionCounts.rejectedForHigherApply}/${humanReviews.length} review item(s) rejected for higher apply.`,
+        tone: 'blocked',
+      }
+      : decisionCounts.pending > 0
+        ? {
+          key: 'human-review',
+          label: 'Human Review',
+          order: 1,
+          state: 'pending',
+          detail: `${decisionCounts.pending}/${humanReviews.length} review item(s) still waiting for explicit confirmation.`,
+          tone: 'pending',
+        }
+        : {
+          key: 'human-review',
+          label: 'Human Review',
+          order: 1,
+          state: 'approved',
+          detail: `${decisionCounts.approvedForHigherApply}/${humanReviews.length} review item(s) approved for the next guardrail.`,
+          tone: 'done',
+        };
+
+  let secondGuardrailCheckpoint: NoNameApplyLifecycleCheckpoint;
+  if (!needsManualApplyPath) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'not-required',
+      detail: 'No higher-layer apply path is currently staged.',
+      tone: 'info',
+    };
+  } else if (secondGuardrailFallback) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'fallback',
+      detail: 'The second guardrail requested fallback to the classic path.',
+      tone: 'fallback',
+    };
+  } else if (secondGuardrailRejected) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'rejected',
+      detail: 'The second guardrail rejected the higher-layer apply.',
+      tone: 'blocked',
+    };
+  } else if (secondGuardrailAllowed) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'allowed',
+      detail: 'The second guardrail allows explicit manual apply only.',
+      tone: 'done',
+    };
+  } else if (decisionCounts.rejectedForHigherApply > 0) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'blocked-by-review',
+      detail: 'Human review rejection blocks the second guardrail path.',
+      tone: 'blocked',
+    };
+  } else if (decisionCounts.pending > 0 || awaitingSecondGuardrail) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'waiting',
+      detail: 'Waiting for approved review evidence before resolving the second guardrail.',
+      tone: 'pending',
+    };
+  } else {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'not-entered',
+      detail: 'No second guardrail resolution has been recorded yet.',
+      tone: 'pending',
+    };
+  }
+
+  let manualApplyCheckpoint: NoNameApplyLifecycleCheckpoint;
+  if (manualApplied) {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'applied',
+      detail: 'An explicit manual apply execution is recorded.',
+      tone: 'done',
+    };
+  } else if (!needsManualApplyPath) {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'not-required',
+      detail: 'No manual apply scope is currently staged.',
+      tone: 'info',
+    };
+  } else if (secondGuardrailAllowed) {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'awaiting-command',
+      detail: 'Ready for an explicit developer-triggered apply command.',
+      tone: 'pending',
+    };
+  } else if (secondGuardrailRejected || secondGuardrailFallback || decisionCounts.rejectedForHigherApply > 0) {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'blocked',
+      detail: 'Manual apply is blocked by review or second guardrail result.',
+      tone: secondGuardrailFallback ? 'fallback' : 'blocked',
+    };
+  } else {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'not-ready',
+      detail: 'Manual apply is waiting for review and second guardrail evidence.',
+      tone: 'pending',
+    };
+  }
+
+  return [
+    reviewCheckpoint,
+    secondGuardrailCheckpoint,
+    manualApplyCheckpoint,
+  ];
+}
+
+export function summarizeNoNameApplyLifecycleCheckpoints(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+) {
+  return buildNoNameApplyLifecycleCheckpoints(trace, reviewDecisions)
+    .map((checkpoint) => `${checkpoint.order}.${checkpoint.label}=${checkpoint.state}`)
+    .join(' -> ');
 }
 
 export function summarizeNoNamePendingPlotAugmentation(trace: NoNameTrace): string {

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -33,6 +33,14 @@ export interface NoNameApplyExecutionDisplay {
   outcomeLabel: string;
 }
 
+interface NoNameSecondGuardrailStats {
+  allowed: number;
+  rejected: number;
+  fallback: number;
+  awaiting: number;
+  manualApplied: number;
+}
+
 function normalizeTarget(value: string | undefined) {
   return (value ?? '').replace(/_/g, '').toLowerCase();
 }
@@ -43,10 +51,6 @@ function hasExecution(trace: NoNameTrace, target: string, outcome: string) {
     normalizeTarget(item.target) === normalizedTarget
     && item.outcome === outcome
   )));
-}
-
-function hasExecutionOutcome(trace: NoNameTrace, outcome: string) {
-  return Boolean(trace.applyExecutionLog?.some((item) => item.outcome === outcome));
 }
 
 function latestExecutionForTarget(
@@ -64,8 +68,69 @@ function latestExecutionForTarget(
     )) ?? null;
 }
 
-function hasTransition(trace: NoNameTrace, suffix: string) {
-  return Boolean(trace.proposalTransitionLog?.some((item) => item.endsWith(suffix)));
+function countTransitions(trace: NoNameTrace, suffix: string) {
+  return trace.proposalTransitionLog?.filter((item) => item.endsWith(suffix)).length ?? 0;
+}
+
+function countTransitionMatches(trace: NoNameTrace, predicate: (item: string) => boolean) {
+  return trace.proposalTransitionLog?.filter(predicate).length ?? 0;
+}
+
+function countExecutionOutcomes(trace: NoNameTrace, outcome: string) {
+  return trace.applyExecutionLog?.filter((item) => item.outcome === outcome).length ?? 0;
+}
+
+function countExecutionMatches(trace: NoNameTrace, predicate: (item: NoNameApplyExecutionRecord) => boolean) {
+  return trace.applyExecutionLog?.filter(predicate).length ?? 0;
+}
+
+function countOutcomeEvidence(
+  trace: NoNameTrace,
+  transitionSuffix: string,
+  executionOutcome: string,
+) {
+  const transitionCount = countTransitions(trace, transitionSuffix);
+  return transitionCount > 0
+    ? transitionCount
+    : countExecutionOutcomes(trace, executionOutcome);
+}
+
+function countManualApplyEvidence(trace: NoNameTrace) {
+  const transitionCount = countTransitionMatches(
+    trace,
+    (item) => item.includes(':manual_apply:'),
+  );
+  if (transitionCount > 0) {
+    return transitionCount;
+  }
+  return countExecutionMatches(trace, (item) => [
+    'manual_plot_text_applied',
+    'manual_chapter_summary_hint_applied',
+    'manual_option_bias_hint_applied',
+    'manual_plot_augmentation_hint_applied',
+  ].includes(item.outcome));
+}
+
+function buildSecondGuardrailStats(trace: NoNameTrace): NoNameSecondGuardrailStats {
+  return {
+    allowed: countOutcomeEvidence(trace, ':second_guardrail:allow', 'second_guardrail_allowed'),
+    rejected: countOutcomeEvidence(trace, ':second_guardrail:reject', 'second_guardrail_rejected'),
+    fallback: countOutcomeEvidence(trace, ':second_guardrail:fallback', 'second_guardrail_fallback'),
+    awaiting: countOutcomeEvidence(trace, ':apply_intent:awaiting_second_guardrail', 'awaiting_second_guardrail'),
+    manualApplied: countManualApplyEvidence(trace),
+  };
+}
+
+function hasMixedSecondGuardrailOutcomes(stats: NoNameSecondGuardrailStats) {
+  return [
+    stats.allowed > 0,
+    stats.rejected > 0,
+    stats.fallback > 0,
+  ].filter(Boolean).length > 1;
+}
+
+function formatSecondGuardrailCounts(stats: NoNameSecondGuardrailStats) {
+  return `allow=${stats.allowed}, reject=${stats.rejected}, fallback=${stats.fallback}`;
 }
 
 export function formatNoNameApplyExecutionRecord(
@@ -162,37 +227,6 @@ function lifecycleHumanDecision(
     ?? 'pending';
 }
 
-function hasManualApplyEvidence(trace: NoNameTrace) {
-  return hasExecutionOutcome(trace, 'manual_plot_text_applied')
-    || hasExecutionOutcome(trace, 'manual_chapter_summary_hint_applied')
-    || hasExecutionOutcome(trace, 'manual_option_bias_hint_applied')
-    || hasExecutionOutcome(trace, 'manual_plot_augmentation_hint_applied')
-    || hasTransition(trace, ':manual_apply:plot_text_hint')
-    || hasTransition(trace, ':manual_apply:chapter_summary_hint')
-    || hasTransition(trace, ':manual_apply:option_bias_hint')
-    || hasTransition(trace, ':manual_apply:plot_augmentation_hint');
-}
-
-function hasSecondGuardrailAllowed(trace: NoNameTrace) {
-  return hasExecutionOutcome(trace, 'second_guardrail_allowed')
-    || hasTransition(trace, ':second_guardrail:allow');
-}
-
-function hasSecondGuardrailRejected(trace: NoNameTrace) {
-  return hasExecutionOutcome(trace, 'second_guardrail_rejected')
-    || hasTransition(trace, ':second_guardrail:reject');
-}
-
-function hasSecondGuardrailFallback(trace: NoNameTrace) {
-  return hasExecutionOutcome(trace, 'second_guardrail_fallback')
-    || hasTransition(trace, ':second_guardrail:fallback');
-}
-
-function hasAwaitingSecondGuardrail(trace: NoNameTrace) {
-  return hasExecutionOutcome(trace, 'awaiting_second_guardrail')
-    || hasTransition(trace, ':apply_intent:awaiting_second_guardrail');
-}
-
 export function buildNoNameApplyLifecycleCheckpoints(
   trace: NoNameTrace,
   reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
@@ -211,11 +245,13 @@ export function buildNoNameApplyLifecycleCheckpoints(
       rejectedForHigherApply: 0,
     } satisfies Record<NoNameHumanReviewDecision, number>,
   );
-  const secondGuardrailAllowed = hasSecondGuardrailAllowed(trace);
-  const secondGuardrailRejected = hasSecondGuardrailRejected(trace);
-  const secondGuardrailFallback = hasSecondGuardrailFallback(trace);
-  const awaitingSecondGuardrail = hasAwaitingSecondGuardrail(trace);
-  const manualApplied = hasManualApplyEvidence(trace);
+  const secondGuardrailStats = buildSecondGuardrailStats(trace);
+  const secondGuardrailAllowed = secondGuardrailStats.allowed > 0;
+  const secondGuardrailRejected = secondGuardrailStats.rejected > 0;
+  const secondGuardrailFallback = secondGuardrailStats.fallback > 0;
+  const mixedSecondGuardrail = hasMixedSecondGuardrailOutcomes(secondGuardrailStats);
+  const awaitingSecondGuardrail = secondGuardrailStats.awaiting > 0;
+  const manualApplied = secondGuardrailStats.manualApplied > 0;
   const needsManualApplyPath = humanReviews.length > 0
     || awaitingSecondGuardrail
     || secondGuardrailAllowed
@@ -268,6 +304,15 @@ export function buildNoNameApplyLifecycleCheckpoints(
       state: 'not-required',
       detail: 'No higher-layer apply path is currently staged.',
       tone: 'info',
+    };
+  } else if (mixedSecondGuardrail) {
+    secondGuardrailCheckpoint = {
+      key: 'second-guardrail',
+      label: 'Second Guardrail',
+      order: 2,
+      state: 'mixed',
+      detail: `Multiple reviewed apply scopes have different second guardrail outcomes (${formatSecondGuardrailCounts(secondGuardrailStats)}).`,
+      tone: 'blocked',
     };
   } else if (secondGuardrailFallback) {
     secondGuardrailCheckpoint = {
@@ -326,7 +371,16 @@ export function buildNoNameApplyLifecycleCheckpoints(
   }
 
   let manualApplyCheckpoint: NoNameApplyLifecycleCheckpoint;
-  if (manualApplied) {
+  if (manualApplied && mixedSecondGuardrail) {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'partially-applied',
+      detail: `Some reviewed apply scopes were manually applied while others are blocked (${formatSecondGuardrailCounts(secondGuardrailStats)}).`,
+      tone: 'blocked',
+    };
+  } else if (manualApplied) {
     manualApplyCheckpoint = {
       key: 'manual-apply',
       label: 'Manual Apply',
@@ -343,6 +397,15 @@ export function buildNoNameApplyLifecycleCheckpoints(
       state: 'not-required',
       detail: 'No manual apply scope is currently staged.',
       tone: 'info',
+    };
+  } else if (mixedSecondGuardrail && secondGuardrailAllowed) {
+    manualApplyCheckpoint = {
+      key: 'manual-apply',
+      label: 'Manual Apply',
+      order: 3,
+      state: 'partially-ready',
+      detail: `Only the allowed reviewed apply scope(s) can continue; rejected or fallback scope(s) stay blocked (${formatSecondGuardrailCounts(secondGuardrailStats)}).`,
+      tone: 'blocked',
     };
   } else if (secondGuardrailAllowed) {
     manualApplyCheckpoint = {
@@ -448,22 +511,13 @@ export function buildNoNameApplyLifecycle(
   const latestProposalScopes = latestProposal?.applyScopes ?? [];
   const hasPlotAugmentationScope = latestProposalScopes
     .some((scope) => normalizeTarget(scope) === normalizeTarget('plotAugmentationHint'));
-  const secondGuardrailAllowed = hasExecutionOutcome(trace, 'second_guardrail_allowed')
-    || hasTransition(trace, ':second_guardrail:allow');
-  const secondGuardrailRejected = hasExecutionOutcome(trace, 'second_guardrail_rejected')
-    || hasTransition(trace, ':second_guardrail:reject');
-  const secondGuardrailFallback = hasExecutionOutcome(trace, 'second_guardrail_fallback')
-    || hasTransition(trace, ':second_guardrail:fallback');
-  const awaitingSecondGuardrail = hasExecutionOutcome(trace, 'awaiting_second_guardrail')
-    || hasTransition(trace, ':apply_intent:awaiting_second_guardrail');
-  const manualApplied = hasExecutionOutcome(trace, 'manual_plot_text_applied')
-    || hasExecutionOutcome(trace, 'manual_chapter_summary_hint_applied')
-    || hasExecutionOutcome(trace, 'manual_option_bias_hint_applied')
-    || hasExecutionOutcome(trace, 'manual_plot_augmentation_hint_applied')
-    || hasTransition(trace, ':manual_apply:plot_text_hint')
-    || hasTransition(trace, ':manual_apply:chapter_summary_hint')
-    || hasTransition(trace, ':manual_apply:option_bias_hint')
-    || hasTransition(trace, ':manual_apply:plot_augmentation_hint');
+  const secondGuardrailStats = buildSecondGuardrailStats(trace);
+  const secondGuardrailAllowed = secondGuardrailStats.allowed > 0;
+  const secondGuardrailRejected = secondGuardrailStats.rejected > 0;
+  const secondGuardrailFallback = secondGuardrailStats.fallback > 0;
+  const mixedSecondGuardrail = hasMixedSecondGuardrailOutcomes(secondGuardrailStats);
+  const awaitingSecondGuardrail = secondGuardrailStats.awaiting > 0;
+  const manualApplied = secondGuardrailStats.manualApplied > 0;
   const preflightOutcome = trace.applyResult?.outcome;
 
   const steps: NoNameApplyLifecycleStep[] = [
@@ -532,25 +586,31 @@ export function buildNoNameApplyLifecycle(
     steps.push({
       key: 'second-guardrail',
       label: '二次护栏',
-      state: secondGuardrailFallback
-        ? 'fallback'
-        : secondGuardrailRejected
+      state: mixedSecondGuardrail
+        ? 'mixed'
+        : secondGuardrailFallback
+          ? 'fallback'
+          : secondGuardrailRejected
           ? 'rejected'
           : secondGuardrailAllowed
             ? 'allow'
             : awaitingSecondGuardrail
               ? 'waiting'
               : '未进入',
-      detail: secondGuardrailAllowed
+      detail: mixedSecondGuardrail
+        ? `Multiple second guardrail outcomes: ${formatSecondGuardrailCounts(secondGuardrailStats)}`
+        : secondGuardrailAllowed
         ? '已允许进入显式人工 apply；仍不会自动写正文'
         : secondGuardrailFallback
           ? '已要求回退经典链路'
           : secondGuardrailRejected
             ? '已拒绝高层 apply'
             : '等待人工批准后进入二次护栏',
-      tone: secondGuardrailFallback
-        ? 'fallback'
-        : secondGuardrailRejected
+      tone: mixedSecondGuardrail
+        ? 'blocked'
+        : secondGuardrailFallback
+          ? 'fallback'
+          : secondGuardrailRejected
           ? 'blocked'
           : secondGuardrailAllowed
             ? 'done'
@@ -569,17 +629,31 @@ export function buildNoNameApplyLifecycle(
     steps.push({
       key: 'manual-plot-text',
       label: '人工写入',
-      state: manualApplied
+      state: manualApplied && mixedSecondGuardrail
+        ? 'partially-applied'
+        : manualApplied
         ? '已写入'
-        : secondGuardrailAllowed
-          ? '等待显式命令'
-          : '未就绪',
-      detail: manualApplied
+        : mixedSecondGuardrail && secondGuardrailAllowed
+          ? 'partially-ready'
+          : secondGuardrailAllowed
+            ? '等待显式命令'
+            : '未就绪',
+      detail: manualApplied && mixedSecondGuardrail
+        ? `Some manual apply scopes completed while others are blocked: ${formatSecondGuardrailCounts(secondGuardrailStats)}`
+        : manualApplied
         ? '已记录显式人工 apply 结果'
-        : secondGuardrailAllowed
+        : mixedSecondGuardrail && secondGuardrailAllowed
+          ? `Only allowed scopes can continue: ${formatSecondGuardrailCounts(secondGuardrailStats)}`
+          : secondGuardrailAllowed
           ? '需要开发者确认差异预览后手动写入'
           : 'PlotTextHint 需要人工复核与二次护栏',
-      tone: manualApplied ? 'done' : secondGuardrailAllowed ? 'pending' : 'info',
+      tone: manualApplied
+        ? (mixedSecondGuardrail ? 'blocked' : 'done')
+        : mixedSecondGuardrail
+          ? 'blocked'
+          : secondGuardrailAllowed
+            ? 'pending'
+            : 'info',
     });
   }
 


### PR DESCRIPTION
## Summary
- Add reviewed apply lifecycle checkpoint utilities for Human Review -> Second Guardrail -> Manual Apply.
- Surface lifecycle checkpoints in AgentTracePanel, NoNameDebugConsole copy report, and gameStore diagnostics.
- Add A5 evaluation doc for the next safe output interface trial conditions and sync planning docs.

## Validation
- npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts
- git diff --check
- npm run build

## Boundaries
- No new backend command.
- No new apply scope.
- No direct final plot state or canon world fact write path.