### PR TITLE
test(noname): guard web runtime trace field drift

### DIFF
--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -43,6 +43,7 @@
 
 - Web mock 的 `policyForbiddenScopes` 已补齐到与后端一致的默认禁区集合
 - review 到 proposal 的绑定不再走模糊匹配
+- Web mock 已补充一层字段漂移守卫：assisted trace 会暴露 `relatedObservations`、`sourceStats: noteContext`、`contextSliceStats` 与 controlled output review 的完整安全边界，确保前端调试台继续消费后端当前真实语义
 
 但后续只要后端 review / apply 语义继续演化，Web mock 仍需同步维护。
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -49,6 +49,7 @@
 - 第一轮已完成
 - 已补齐 `policy forbidden scopes`
 - 已收紧 review 对 proposal 的精确绑定
+- 字段漂移守卫第一轮已完成：Web mock 的 assisted trace 已补充 `relatedObservations`、`noteContext` source stats、context slice stats，并用测试覆盖 `controlledOutputReviews` / `policyForbiddenScopes` / human-review 边界
 - 后续继续关注新增 trace / review / apply 字段的同步
 
 ### 任务 4：继续从 `tauri_commands.rs` 抽离 `NoName` 编排

--- a/docs/项目文档/03-规划/04-未来两周开发排期.md
+++ b/docs/项目文档/03-规划/04-未来两周开发排期.md
@@ -76,6 +76,14 @@
 - 最小验证：
   - `npm run test -- --run src/platform/webRuntime.test.ts`
 
+当前状态：
+
+- 第二轮已完成
+- Web mock 的 assisted / observe trace 已补充 `relatedObservations`，让前端 mock 继续暴露后端已有的 role context 消费路径
+- assisted trace 已包含 `sourceStats: noteContext`、`contextSliceStats`、`noteTypeHits` 和 role forbidden scopes，便于调试台核对 note-aware context 是否仍可读
+- `webRuntime.test.ts` 已新增字段漂移守卫，覆盖 `controlledOutputReviews`、`policyForbiddenScopes`、`plotTextHint` / `plotAugmentationHint` 人工复核边界，以及 `noteContext` 来源统计
+- 本轮未新增后端字段、未扩大 apply scope、未重做 Web runtime
+
 ### 任务 A2：抽离 reviewed apply 请求与校验编排
 
 - 目标：

--- a/docs/项目文档/03-规划/06-近期开发任务卡片.md
+++ b/docs/项目文档/03-规划/06-近期开发任务卡片.md
@@ -183,6 +183,18 @@
   - 让 Trace 面板和调试台读到的 NoName 数据更可信
   - 为后续安全输出草稿层探索保留稳定前端底座
 
+当前状态：
+
+- 第一轮已完成
+- `webRuntime.ts` 的 Web mock trace 已补充 `relatedObservations`，让 assisted / observe 模式都能暴露后端已有的 role context 字段形状
+- assisted trace 现在会携带 `sourceStats: noteContext`、`contextSliceStats`、`noteTypeHits`、role forbidden scopes 与 world curator 观察 proposal，前端调试台可继续按真实后端语义读取上下文来源
+- `webRuntime.test.ts` 已新增字段漂移守卫，覆盖 `controlledOutputReviews`、`policyForbiddenScopes`、`plotTextHint` / `plotAugmentationHint` 人工复核边界，以及 `noteContext` 来源统计
+- 本轮未新增后端协议字段，未扩大 apply scope，未重做 Web runtime
+
+已验证：
+
+- `npm run test -- --run src/platform/webRuntime.test.ts src/stores/__tests__/gameStore.test.ts`
+
 ### 卡片 C6：为“安全输出草稿层”补一层轻量探针，而不是直接落正式逻辑
 
 - 优先级：

--- a/src/platform/webRuntime.test.ts
+++ b/src/platform/webRuntime.test.ts
@@ -134,6 +134,74 @@ describe('webRuntime', () => {
     expect(latestTrace?.applyResult?.reason).toContain('target=current_turn_head');
   });
 
+  it('keeps Web NoName mock aligned with backend review and context fields', async () => {
+    const script = await invokeWebRuntime<Script>('generate_random_script');
+    await invokeWebRuntime('initialize_game', { script });
+    await invokeWebRuntime('initialize_plot');
+    await invokeWebRuntime('set_noname_mode', { mode: 'assisted' });
+
+    await invokeWebRuntime('execute_player_action', {
+      action: {
+        action_type: ActionType.FreeText,
+        content: '校准护山阵纹',
+        selected_option_id: null,
+      },
+    });
+
+    const traces = await invokeWebRuntime<NoNameTrace[]>('get_noname_recent_traces');
+    const latestTrace = traces[traces.length - 1];
+    const reviews = latestTrace.controlledOutputReviews ?? [];
+    const relatedObservations = latestTrace.relatedObservations ?? [];
+    const plotTextReview = reviews.find((item) => item.safeApplyScope === 'plotTextHint');
+    const plotAugmentationReview = reviews.find((item) => item.safeApplyScope === 'plotAugmentationHint');
+    const diagnosticsReview = reviews.find((item) => item.safeApplyScope === 'diagnostics');
+    const worldContext = relatedObservations.find((item) => item.role === 'worldCurator');
+
+    expect(reviews).toHaveLength(5);
+    expect(plotTextReview).toEqual(expect.objectContaining({
+      requestedKind: 'sceneAugmentation',
+      decision: 'needsReview',
+      normalizedKind: 'sceneAugmentation',
+      requiresHumanReview: true,
+      humanReviewDecision: null,
+    }));
+    expect(plotTextReview?.proposalId).toBe(latestTrace.proposals[0]?.proposalId);
+    expect(plotTextReview?.policyForbiddenScopes).toEqual(expect.arrayContaining([
+      'finalPlotState',
+      'canonWorldFact',
+      'chapterLifecycle',
+      'playerChoice',
+    ]));
+    expect(plotAugmentationReview).toEqual(expect.objectContaining({
+      requestedKind: 'nonFinalPlotAugmentation',
+      decision: 'needsReview',
+      requiresHumanReview: true,
+    }));
+    expect(diagnosticsReview).toEqual(expect.objectContaining({
+      requestedKind: 'narrativeNote',
+      decision: 'allow',
+      requiresHumanReview: false,
+    }));
+
+    expect(worldContext).toBeTruthy();
+    expect(worldContext?.actionSummary).toBe('校准护山阵纹');
+    expect(worldContext?.roleGoal).toContain('Maintain world facts');
+    expect(worldContext?.forbiddenScopes).toEqual(expect.arrayContaining([
+      'Must not decide NPC private intent.',
+      'Must not write final plot state.',
+    ]));
+    expect(worldContext?.noteTypeHits).toContain('goal:web-mock-note-context');
+    expect(worldContext?.sourceStats).toEqual(expect.arrayContaining([
+      { source: 'semantic', count: 1 },
+      { source: 'noteContext', count: 1 },
+    ]));
+    expect(worldContext?.contextSliceStats).toEqual(expect.arrayContaining([
+      { section: 'narrativeNotes', sourceCount: 1, visibleCount: 1 },
+    ]));
+    expect(worldContext?.proposal.producerRole).toBe('worldCurator');
+    expect(worldContext?.proposal.applyable).toBe(false);
+  });
+
   it('records human review apply intent without mutating plot text in web mode', async () => {
     const script = await invokeWebRuntime<Script>('generate_random_script');
     await invokeWebRuntime('initialize_game', { script });

--- a/src/platform/webRuntime.ts
+++ b/src/platform/webRuntime.ts
@@ -14,6 +14,7 @@ import {
   type NoNameForbiddenOutputScope,
   type NoNameHumanReviewMarkPayload,
   type NoNameMode,
+  type NoNameRelatedObservation,
   type NoNameSecondGuardrailResolvePayload,
   type NoNameTargetSegment,
   type NoNameTrace,
@@ -28,6 +29,7 @@ import {
 
 type WebNoNameMode = NoNameMode;
 type WebNoNamePendingAugmentationExecution = Pick<NoNameApplyExecutionRecord, 'target' | 'outcome' | 'note'>;
+type WebNoNameProposal = NoNameTrace['proposals'][number];
 
 type SaveSnapshot = {
   script: Script;
@@ -412,6 +414,48 @@ function webNoNameScopeRequiresHumanReview(scope: NoNameApplyScope) {
   return scope === 'plotTextHint' || scope === 'plotAugmentationHint';
 }
 
+function buildWebNoNameRelatedObservations(
+  actionSummary: string,
+  proposal: WebNoNameProposal,
+): NoNameRelatedObservation[] {
+  return [
+    {
+      role: 'worldCurator',
+      actionSummary,
+      focus: proposal.focus,
+      rationale: 'web mock: keep backend role context fields visible for drift checks',
+      roleGoal: 'Maintain world facts, scene constraints, and canon anchors.',
+      sceneFocus: proposal.targetSegment,
+      forbiddenScopes: [
+        'Must not decide NPC private intent.',
+        'Must not write final plot state.',
+      ],
+      noteTypeHits: ['goal:web-mock-note-context'],
+      sourceStats: [
+        { source: 'semantic', count: 1 },
+        { source: 'noteContext', count: 1 },
+      ],
+      contextTokenBudgetUsed: 64,
+      contextSliceStats: [
+        { section: 'worldFacts', sourceCount: 2, visibleCount: 1 },
+        { section: 'narrativeNotes', sourceCount: 1, visibleCount: 1 },
+      ],
+      proposal: {
+        ...proposal,
+        proposalId: `${proposal.proposalId}-world-context`,
+        kind: 'world_patch_proposal',
+        producerRole: 'worldCurator',
+        title: `WorldCurator观察：${proposal.focus}`,
+        summary: `围绕“${proposal.focus}”保留世界设定与 noteContext 证据`,
+        rationale: 'web mock: role context drift guard',
+        labels: ['worldCurator', 'context_guard', 'noteContext'],
+        status: 'observed',
+        applyable: false,
+      },
+    },
+  ];
+}
+
 function applyWebNoNameSummaryHint(summary: string, focus: string, targetSegment: NoNameTargetSegment): string {
   const hint = `NoName提示：后续重点关注${focus}`;
   if (!summary.trim()) {
@@ -443,6 +487,23 @@ function appendWebNoNameTrace(
   }
 
   if (runtimeState.noNameMode === 'assisted') {
+    const proposal: WebNoNameProposal = {
+      proposalId,
+      kind: 'plot_candidate',
+      producerRole,
+      title: `Director提案：${text}`,
+      summary: `建议优先推进“${text}”`,
+      focus: text,
+      targetSegment,
+      intendedEffect: '为低风险输出提供稳定导向',
+      rationale: 'web mock: assisted apply',
+      suggestedAction: '进入低风险 apply',
+      labels: ['director', 'assisted_ready', 'apply_scope_diagnostics'],
+      applyScopes,
+      status: 'applied',
+      applyable: true,
+    };
+
     runtimeState.noNameTraces.push({
       traceId,
       sessionId: 'web-session',
@@ -457,24 +518,7 @@ function appendWebNoNameTrace(
         'PersistTrace',
       ],
       capabilityCalls: [],
-      proposals: [
-        {
-          proposalId,
-          kind: 'plot_candidate',
-          producerRole,
-          title: `Director提案：${text}`,
-          summary: `建议优先推进“${text}”`,
-          focus: text,
-          targetSegment,
-          intendedEffect: '为低风险输出提供稳定导向',
-          rationale: 'web mock: assisted apply',
-          suggestedAction: '进入低风险 apply',
-          labels: ['director', 'assisted_ready', 'apply_scope_diagnostics'],
-          applyScopes,
-          status: 'applied',
-          applyable: true,
-        },
-      ],
+      proposals: [proposal],
       proposalTransitionLog: [
         `${proposalId}:ready`,
         `${proposalId}:apply_preflight:ready`,
@@ -526,6 +570,7 @@ function appendWebNoNameTrace(
         humanReviewedAt: null,
         humanReviewNote: null,
       })),
+      relatedObservations: buildWebNoNameRelatedObservations(text, proposal),
       guardrailResult: { outcome: 'accept' },
       applyResult: {
         attempted: true,
@@ -536,6 +581,23 @@ function appendWebNoNameTrace(
       elapsedMs: 0,
     });
   } else {
+    const proposal: WebNoNameProposal = {
+      proposalId,
+      kind: 'plot_candidate',
+      producerRole: 'director',
+      title: `Director提案：${text}`,
+      summary: `建议优先观察“${text}”`,
+      focus: text,
+      targetSegment,
+      intendedEffect: '维持观察链路，不直接改写主剧情',
+      rationale: 'web mock: observe-only',
+      suggestedAction: '保持 observe-only',
+      labels: ['director', 'observe_only'],
+      applyScopes,
+      status: 'observed',
+      applyable: false,
+    };
+
     runtimeState.noNameTraces.push({
       traceId,
       sessionId: 'web-session',
@@ -543,24 +605,7 @@ function appendWebNoNameTrace(
       mode: 'observeOnly',
       graphPath: ['CollectTurnInput', 'BuildContextBundle', 'PlanTurn', 'PersistTrace'],
       capabilityCalls: [],
-      proposals: [
-        {
-          proposalId,
-          kind: 'plot_candidate',
-          producerRole: 'director',
-          title: `Director提案：${text}`,
-          summary: `建议优先观察“${text}”`,
-          focus: text,
-          targetSegment,
-          intendedEffect: '维持观察链路，不直接改写主剧情',
-          rationale: 'web mock: observe-only',
-          suggestedAction: '保持 observe-only',
-          labels: ['director', 'observe_only'],
-          applyScopes,
-          status: 'observed',
-          applyable: false,
-        },
-      ],
+      proposals: [proposal],
       proposalTransitionLog: [`${proposalId}:observed`],
       applyPlanLog: applyScopes
         .map((scope) => ({
@@ -572,6 +617,7 @@ function appendWebNoNameTrace(
         .sort((left, right) => right.priority - left.priority)
         .map((item, index) => ({ ...item, order: index + 1 })),
       applyExecutionLog: [],
+      relatedObservations: buildWebNoNameRelatedObservations(text, proposal),
       guardrailResult: { outcome: 'accept' },
       applyResult: { attempted: false, outcome: 'skipped_observe_only' },
       fallbackUsed: false,


### PR DESCRIPTION
## Summary
- add backend-aligned relatedObservations to Web NoName mock traces
- guard controlledOutputReviews, policyForbiddenScopes, human-review scopes, and noteContext source stats in webRuntime tests
- update planning docs for C5 status and verification

## Tests
- npm run test -- --run src/platform/webRuntime.test.ts src/stores/__tests__/gameStore.test.ts
- npm run test:web-core
- git diff --check