### PR TITLE
feat(noname): show safe output draft diagnostics

### DIFF
--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -142,6 +142,7 @@
 - 当前只建议试点非最终状态的 pending / draft / diagnostics-like 输出层
 - 不建议直接试点最终剧情、世界硬事实、NPC 隐藏意图或绕过 reviewed apply 的自动写入
 - 安全输出草稿层第一轮探针已完成：`NoNameSafeOutputDraft` 只读推导 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`，并固定 `finalPlotStateWriteAllowed=false`
+- 安全输出草稿层只读展示第一轮已完成：store 诊断文本与 debug console 复制摘要可展示 `Safe Output Drafts`，但没有新增写入按钮、后端命令或 apply scope
 - 评估文档见 [下一层安全输出接口试点评估](./05-下一层安全输出接口试点评估.md)
 
 ### 任务 8：评估多角色协作与更强知识检索

--- a/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
+++ b/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
@@ -80,9 +80,11 @@
 - 探针只读取 trace 证据，不新增后端命令，不写 runtime 状态
 - 测试已覆盖 pending 只停在 `drafted`，人工批准进入 `reviewed`，二次护栏允许进入 `guardrailAllowed`，显式 manual apply 才进入 `manuallyApplied`
 - 测试已覆盖 review reject、second guardrail reject 与 fallback 不会误进入 manual apply
+- 只读展示第一轮已完成：store 诊断文本与 debug console 复制摘要会展示 `Safe Output Drafts`，用于审查草稿层状态与 `final=false` 安全边界
+- 本轮展示不新增按钮、不新增命令、不新增 apply scope，也不写任何 runtime 状态
 
 下一步更合理的动作是：
 
-- 先观察该探针在 review / 调试交接中是否足够表达安全输出草稿层
-- 若要展示给 UI，应只做只读展示，不新增 apply scope
+- 先观察该探针与只读展示在 review / 调试交接中是否足够表达安全输出草稿层
+- 若继续扩展 UI，也应保持只读展示，不新增 apply scope
 - 等 trace、mock、后端语义都能说明该草稿层不会自动写终态后，再评估是否进入正式实现

--- a/docs/项目文档/03-规划/06-近期开发任务卡片.md
+++ b/docs/项目文档/03-规划/06-近期开发任务卡片.md
@@ -217,10 +217,13 @@
 - 草稿状态目前限定为 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`
 - 探针明确记录 `evidence.finalPlotStateWriteAllowed=false`，不新增后端命令，不新增正式 apply scope，不写最终剧情状态
 - 已补充测试覆盖 pending、人工批准、二次护栏允许、显式 manual apply、review reject、guardrail reject 与 fallback
+- 第二轮只读展示已完成：`gameStore` 诊断文本与 `NoNameDebugConsole` 复制摘要会输出 `Safe Output Drafts`，便于 review 时核对草稿层状态和 `final=false`
+- 本轮未新增 UI 写入按钮、未新增后端命令、未扩大 apply scope
 
 已验证：
 
 - `npm run test -- --run src/utils/noNameApplyLifecycle.test.ts`
+- `npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/stores/__tests__/gameStore.test.ts src/components/__tests__/NoNameDebugConsole.test.ts`
 
 ## 3. 文档管理动作
 

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -153,6 +153,7 @@ import {
   summarizeNoNameApplyLifecycle,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameSafeOutputDrafts,
 } from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
@@ -355,6 +356,7 @@ function buildTraceReport(
   const lifecycle = summarizeNoNameApplyLifecycle(trace, reviewDecisions);
   const lifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(trace, reviewDecisions);
   const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(trace);
+  const safeOutputDrafts = summarizeNoNameSafeOutputDrafts(trace, reviewDecisions);
   const applyExecutions = summarizeNoNameApplyExecutions(trace, {
     emptyLabel: 'none',
     rawPrefix: ' [raw=',
@@ -377,6 +379,7 @@ function buildTraceReport(
     `Apply Result: ${applyResult}`,
     `Apply Lifecycle: ${lifecycle}`,
     `Lifecycle Checkpoints: ${lifecycleCheckpoints}`,
+    `Safe Output Drafts: ${safeOutputDrafts}`,
     `Apply Executions: ${applyExecutions}`,
     `Plot Augmentation: ${pendingPlotAugmentation}`,
     `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -114,6 +114,7 @@ const traces: NoNameTrace[] = [
     }],
     controlledOutputReviews: [{
       requestId: 'controlled-output-proposal-2-plot_text_hint',
+      proposalId: 'proposal-2',
       requestedKind: 'sceneAugmentation',
       decision: 'needsReview',
       reason: 'plot text hint requires human review before higher-layer apply',
@@ -151,6 +152,7 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('Human Review Decisions: 0 approved / 0 rejected / 1 pending');
     expect(wrapper.text()).toContain('Apply Lifecycle:');
     expect(wrapper.text()).toContain('Lifecycle Checkpoints: 1.Human Review=pending');
+    expect(wrapper.text()).toContain('Safe Output Drafts: drafted:plotTextHint:sceneAugmentation[final=false]');
     expect(wrapper.text()).toContain('Plot Augmentation: 已消费');
     expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
@@ -235,6 +237,7 @@ describe('NoNameDebugConsole', () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace Breakdown: proposals=1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Lifecycle Checkpoints:'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Safe Output Drafts: drafted:plotTextHint:sceneAugmentation[final=false]'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Executions:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('剧情增强提示:已消费'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]'));

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -364,6 +364,7 @@ describe('gameStore', () => {
       }],
       controlledOutputReviews: [{
         requestId: 'controlled-output-proposal-1-plot_text_hint',
+        proposalId: 'proposal-1',
         requestedKind: 'sceneAugmentation',
         decision: 'needsReview',
         reason: 'plot text hint requires human review before higher-layer apply',
@@ -427,6 +428,7 @@ describe('gameStore', () => {
     expect(text).toContain('预检：preflight_ready');
     expect(text).toContain('应用生命周期：提案阶段:ready');
     expect(text).toContain('应用阶段核对：1.Human Review=approved');
+    expect(text).toContain('安全输出草稿：reviewed:plotTextHint:sceneAugmentation[final=false]');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
     expect(text).toContain('剧情增强提示:已消费[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]');

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -5,6 +5,7 @@ import {
   summarizeNoNameApplyLifecycle,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameSafeOutputDrafts,
 } from '../utils/noNameApplyLifecycle';
 import type {
   Script,
@@ -477,6 +478,7 @@ export const useGameStore = defineStore('game', {
       const applyLifecycle = summarizeNoNameApplyLifecycle(latest);
       const applyLifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(latest);
       const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(latest);
+      const safeOutputDrafts = summarizeNoNameSafeOutputDrafts(latest, {}, '无');
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -492,6 +494,7 @@ export const useGameStore = defineStore('game', {
         `预检：${latest.applyResult ? `${latest.applyResult.outcome}${latest.applyResult.reason ? ` (${latest.applyResult.reason})` : ''}` : '无'}`,
         `应用生命周期：${applyLifecycle}`,
         `应用阶段核对：${applyLifecycleCheckpoints}`,
+        `安全输出草稿：${safeOutputDrafts}`,
         `剧情增强提示：${pendingPlotAugmentation}`,
         `应用计划：${applyPlans}`,
         `应用执行：${applyExecutions}`,

--- a/src/utils/noNameApplyLifecycle.test.ts
+++ b/src/utils/noNameApplyLifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   summarizeNoNameApplyExecutions,
   summarizeNoNameApplyLifecycle,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameSafeOutputDrafts,
 } from './noNameApplyLifecycle';
 
 function buildTrace(outcome: string, note: string): NoNameTrace {
@@ -453,5 +454,24 @@ describe('buildNoNameApplyLifecycle', () => {
     expect(fallback?.lifecycleState).toBe('fallback');
     expect(fallback?.evidence.manualApplyRecorded).toBe(false);
     expect(fallback?.evidence.finalPlotStateWriteAllowed).toBe(false);
+  });
+
+  it('summarizes safe output drafts for read-only diagnostics', () => {
+    const trace = buildReviewedDraftTrace({
+      humanReviewDecision: 'approvedForHigherApply',
+      secondGuardrail: 'allow',
+    });
+
+    expect(summarizeNoNameSafeOutputDrafts(trace)).toBe(
+      'guardrailAllowed:plotAugmentationHint:nonFinalPlotAugmentation[final=false]',
+    );
+    expect(summarizeNoNameSafeOutputDrafts({
+      ...trace,
+      controlledOutputReviews: [],
+    })).toBe('none');
+    expect(summarizeNoNameSafeOutputDrafts({
+      ...trace,
+      controlledOutputReviews: [],
+    }, {}, '无')).toBe('无');
   });
 });

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -659,6 +659,23 @@ export function buildNoNameSafeOutputDrafts(
     });
 }
 
+export function summarizeNoNameSafeOutputDrafts(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+  emptyLabel = 'none',
+) {
+  const drafts = buildNoNameSafeOutputDrafts(trace, reviewDecisions);
+  if (drafts.length === 0) {
+    return emptyLabel;
+  }
+  return drafts
+    .map((draft) => (
+      `${draft.lifecycleState}:${draft.safeApplyScope}:${draft.outputKind}`
+      + `[final=${draft.evidence.finalPlotStateWriteAllowed ? 'true' : 'false'}]`
+    ))
+    .join(', ');
+}
+
 export function buildNoNameApplyLifecycle(
   trace: NoNameTrace,
   reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},


### PR DESCRIPTION
## Summary
- add a read-only safe output draft summary for diagnostics
- show Safe Output Drafts in gameStore NoName debug text and NoNameDebugConsole copied reports
- keep this as display-only: no backend commands, no UI write buttons, no new apply scopes

## Stacked PR
- Base: codex/c6-safe-output-draft / PR #27
- This PR should be reviewed as the display layer on top of the C6 safe output draft probe

## Tests
- npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/stores/__tests__/gameStore.test.ts src/components/__tests__/NoNameDebugConsole.test.ts
- npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/stores/__tests__/gameStore.test.ts src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts
- git diff --check