### PR TITLE
test(noname): diagnose safe output draft evidence

### DIFF
--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -61,7 +61,7 @@
 
 ### 3.6 下一层安全输出仍不能扩大权限边界
 
-下一层输出接口目前只完成试点评估与只读探针，不代表可以直接写最终剧情状态。当前 `NoNameSafeOutputDraft` 只从 trace 证据推导 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`，并固定 `finalPlotStateWriteAllowed=false`。后续若实现 `draft / pending hint` 类输出，仍必须保留人工复核、二次护栏、显式写入和 stale snapshot 校验。
+下一层输出接口目前只完成试点评估与只读探针，不代表可以直接写最终剧情状态。当前 `NoNameSafeOutputDraft` 只从 trace 证据推导 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`，并固定 `finalPlotStateWriteAllowed=false`。草稿证据诊断已能标出缺失的人工复核、二次护栏或 manual apply 证据，以及 manual apply 早于复核链路的异常 trace。后续若实现 `draft / pending hint` 类输出，仍必须保留人工复核、二次护栏、显式写入和 stale snapshot 校验。
 
 ## 4. 当前最合理的发展策略
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -143,6 +143,7 @@
 - 不建议直接试点最终剧情、世界硬事实、NPC 隐藏意图或绕过 reviewed apply 的自动写入
 - 安全输出草稿层第一轮探针已完成：`NoNameSafeOutputDraft` 只读推导 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`，并固定 `finalPlotStateWriteAllowed=false`
 - 安全输出草稿层只读展示第一轮已完成：store 诊断文本与 debug console 复制摘要可展示 `Safe Output Drafts`，但没有新增写入按钮、后端命令或 apply scope
+- 安全输出草稿层证据诊断已补齐第一轮：只读摘要可标出缺失的 `humanReviewApproval / secondGuardrailDecision / manualApplyCommand` 证据，以及 manual apply 早于复核或缺少二次护栏允许的异常记录
 - 评估文档见 [下一层安全输出接口试点评估](./05-下一层安全输出接口试点评估.md)
 
 ### 任务 8：评估多角色协作与更强知识检索

--- a/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
+++ b/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
@@ -81,10 +81,11 @@
 - 测试已覆盖 pending 只停在 `drafted`，人工批准进入 `reviewed`，二次护栏允许进入 `guardrailAllowed`，显式 manual apply 才进入 `manuallyApplied`
 - 测试已覆盖 review reject、second guardrail reject 与 fallback 不会误进入 manual apply
 - 只读展示第一轮已完成：store 诊断文本与 debug console 复制摘要会展示 `Safe Output Drafts`，用于审查草稿层状态与 `final=false` 安全边界
+- 证据诊断第一轮已完成：store 诊断文本与 debug console 复制摘要会展示 `Safe Output Evidence`，用于核对缺失证据和异常 manual apply 记录
 - 本轮展示不新增按钮、不新增命令、不新增 apply scope，也不写任何 runtime 状态
 
 下一步更合理的动作是：
 
 - 先观察该探针与只读展示在 review / 调试交接中是否足够表达安全输出草稿层
-- 若继续扩展 UI，也应保持只读展示，不新增 apply scope
+- 若继续扩展 UI，也应保持只读展示，优先改善证据可读性，不新增 apply scope
 - 等 trace、mock、后端语义都能说明该草稿层不会自动写终态后，再评估是否进入正式实现

--- a/docs/项目文档/03-规划/06-近期开发任务卡片.md
+++ b/docs/项目文档/03-规划/06-近期开发任务卡片.md
@@ -218,6 +218,8 @@
 - 探针明确记录 `evidence.finalPlotStateWriteAllowed=false`，不新增后端命令，不新增正式 apply scope，不写最终剧情状态
 - 已补充测试覆盖 pending、人工批准、二次护栏允许、显式 manual apply、review reject、guardrail reject 与 fallback
 - 第二轮只读展示已完成：`gameStore` 诊断文本与 `NoNameDebugConsole` 复制摘要会输出 `Safe Output Drafts`，便于 review 时核对草稿层状态和 `final=false`
+- 第三轮证据诊断已完成：`NoNameSafeOutputDraft` evidence 增加 `missingEvidence / warnings`，store 诊断文本与 debug console 复制摘要会输出 `Safe Output Evidence`
+- 当前手动 apply 只有同时具备人工复核通过与 second guardrail allow 证据时，才会被只读探针提升为 `manuallyApplied`
 - 本轮未新增 UI 写入按钮、未新增后端命令、未扩大 apply scope
 
 已验证：

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -153,6 +153,7 @@ import {
   summarizeNoNameApplyLifecycle,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameSafeOutputDraftEvidence,
   summarizeNoNameSafeOutputDrafts,
 } from '../utils/noNameApplyLifecycle';
 
@@ -357,6 +358,7 @@ function buildTraceReport(
   const lifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(trace, reviewDecisions);
   const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(trace);
   const safeOutputDrafts = summarizeNoNameSafeOutputDrafts(trace, reviewDecisions);
+  const safeOutputDraftEvidence = summarizeNoNameSafeOutputDraftEvidence(trace, reviewDecisions);
   const applyExecutions = summarizeNoNameApplyExecutions(trace, {
     emptyLabel: 'none',
     rawPrefix: ' [raw=',
@@ -380,6 +382,7 @@ function buildTraceReport(
     `Apply Lifecycle: ${lifecycle}`,
     `Lifecycle Checkpoints: ${lifecycleCheckpoints}`,
     `Safe Output Drafts: ${safeOutputDrafts}`,
+    `Safe Output Evidence: ${safeOutputDraftEvidence}`,
     `Apply Executions: ${applyExecutions}`,
     `Plot Augmentation: ${pendingPlotAugmentation}`,
     `Fallback: ${trace.fallbackUsed ? 'yes' : 'no'}`,

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -153,6 +153,7 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('Apply Lifecycle:');
     expect(wrapper.text()).toContain('Lifecycle Checkpoints: 1.Human Review=pending');
     expect(wrapper.text()).toContain('Safe Output Drafts: drafted:plotTextHint:sceneAugmentation[final=false]');
+    expect(wrapper.text()).toContain('Safe Output Evidence: drafted:plotTextHint[missing=humanReviewApproval][warnings=none]');
     expect(wrapper.text()).toContain('Plot Augmentation: 已消费');
     expect(wrapper.text()).toContain('Proposals: 1/1 applyable');
 
@@ -238,6 +239,7 @@ describe('NoNameDebugConsole', () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Lifecycle Checkpoints:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Safe Output Drafts: drafted:plotTextHint:sceneAugmentation[final=false]'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Safe Output Evidence: drafted:plotTextHint[missing=humanReviewApproval][warnings=none]'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Executions:'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('剧情增强提示:已消费'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]'));

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -429,6 +429,7 @@ describe('gameStore', () => {
     expect(text).toContain('应用生命周期：提案阶段:ready');
     expect(text).toContain('应用阶段核对：1.Human Review=approved');
     expect(text).toContain('安全输出草稿：reviewed:plotTextHint:sceneAugmentation[final=false]');
+    expect(text).toContain('安全输出证据：reviewed:plotTextHint[missing=secondGuardrailDecision][warnings=none]');
     expect(text).toContain('应用计划：#1:chapter_summary_hint:apply@200');
     expect(text).toContain('应用执行：chapter_summary_hint:applied');
     expect(text).toContain('剧情增强提示:已消费[raw=plot_augmentation_hint:pending_plot_augmentation_consumed]');

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -5,6 +5,7 @@ import {
   summarizeNoNameApplyLifecycle,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameSafeOutputDraftEvidence,
   summarizeNoNameSafeOutputDrafts,
 } from '../utils/noNameApplyLifecycle';
 import type {
@@ -479,6 +480,7 @@ export const useGameStore = defineStore('game', {
       const applyLifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(latest);
       const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(latest);
       const safeOutputDrafts = summarizeNoNameSafeOutputDrafts(latest, {}, '无');
+      const safeOutputDraftEvidence = summarizeNoNameSafeOutputDraftEvidence(latest, {}, '无');
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -495,6 +497,7 @@ export const useGameStore = defineStore('game', {
         `应用生命周期：${applyLifecycle}`,
         `应用阶段核对：${applyLifecycleCheckpoints}`,
         `安全输出草稿：${safeOutputDrafts}`,
+        `安全输出证据：${safeOutputDraftEvidence}`,
         `剧情增强提示：${pendingPlotAugmentation}`,
         `应用计划：${applyPlans}`,
         `应用执行：${applyExecutions}`,

--- a/src/utils/noNameApplyLifecycle.test.ts
+++ b/src/utils/noNameApplyLifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   summarizeNoNameApplyExecutions,
   summarizeNoNameApplyLifecycle,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameSafeOutputDraftEvidence,
   summarizeNoNameSafeOutputDrafts,
 } from './noNameApplyLifecycle';
 
@@ -405,6 +406,8 @@ describe('buildNoNameApplyLifecycle', () => {
       secondGuardrailDecision: 'notEntered',
       manualApplyRecorded: false,
       finalPlotStateWriteAllowed: false,
+      missingEvidence: ['humanReviewApproval'],
+      warnings: [],
     }));
     expect(draft?.evidence.reasons).toContain('draft probe never allows final plot state writes');
   });
@@ -420,6 +423,7 @@ describe('buildNoNameApplyLifecycle', () => {
     }));
     expect(allowed?.lifecycleState).toBe('guardrailAllowed');
     expect(allowed?.evidence.secondGuardrailDecision).toBe('allow');
+    expect(allowed?.evidence.missingEvidence).toEqual(['manualApplyCommand']);
     expect(allowed?.evidence.finalPlotStateWriteAllowed).toBe(false);
 
     const [applied] = buildNoNameSafeOutputDrafts(buildReviewedDraftTrace({
@@ -429,6 +433,8 @@ describe('buildNoNameApplyLifecycle', () => {
     }));
     expect(applied?.lifecycleState).toBe('manuallyApplied');
     expect(applied?.evidence.manualApplyRecorded).toBe(true);
+    expect(applied?.evidence.missingEvidence).toEqual([]);
+    expect(applied?.evidence.warnings).toEqual([]);
     expect(applied?.evidence.finalPlotStateWriteAllowed).toBe(false);
   });
 
@@ -471,6 +477,34 @@ describe('buildNoNameApplyLifecycle', () => {
     })).toBe('none');
     expect(summarizeNoNameSafeOutputDrafts({
       ...trace,
+      controlledOutputReviews: [],
+    }, {}, '无')).toBe('无');
+  });
+
+  it('summarizes safe output draft evidence gaps without promoting invalid manual apply', () => {
+    const [invalidManualApply] = buildNoNameSafeOutputDrafts(buildReviewedDraftTrace({
+      manualApply: true,
+    }));
+    expect(invalidManualApply?.lifecycleState).toBe('drafted');
+    expect(invalidManualApply?.evidence.manualApplyRecorded).toBe(true);
+    expect(invalidManualApply?.evidence.missingEvidence).toEqual(['humanReviewApproval']);
+    expect(invalidManualApply?.evidence.warnings).toEqual([
+      'manual apply recorded before human review approval',
+      'manual apply recorded without second guardrail allow',
+    ]);
+
+    expect(summarizeNoNameSafeOutputDraftEvidence(buildReviewedDraftTrace())).toBe(
+      'drafted:plotAugmentationHint[missing=humanReviewApproval][warnings=none]',
+    );
+    expect(summarizeNoNameSafeOutputDraftEvidence(buildReviewedDraftTrace({
+      humanReviewDecision: 'approvedForHigherApply',
+      secondGuardrail: 'allow',
+      manualApply: true,
+    }))).toBe(
+      'manuallyApplied:plotAugmentationHint[missing=none][warnings=none]',
+    );
+    expect(summarizeNoNameSafeOutputDraftEvidence({
+      ...buildReviewedDraftTrace(),
       controlledOutputReviews: [],
     }, {}, '无')).toBe('无');
   });

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -49,6 +49,8 @@ export interface NoNameSafeOutputDraftEvidence {
   secondGuardrailDecision: 'allow' | 'reject' | 'fallback' | 'notEntered';
   manualApplyRecorded: boolean;
   finalPlotStateWriteAllowed: false;
+  missingEvidence: string[];
+  warnings: string[];
   reasons: string[];
 }
 
@@ -616,6 +618,26 @@ export function buildNoNameSafeOutputDrafts(
         `safe apply scope=${safeApplyScope}`,
         'draft probe never allows final plot state writes',
       ];
+      const missingEvidence: string[] = [];
+      const warnings: string[] = [];
+      const humanReviewSatisfied = humanReviewDecision === 'approvedForHigherApply'
+        || humanReviewDecision === 'notRequired';
+
+      if (review.requiresHumanReview && humanReviewDecision === 'pending') {
+        missingEvidence.push('humanReviewApproval');
+      }
+      if (humanReviewSatisfied && secondGuardrailDecision === 'notEntered') {
+        missingEvidence.push('secondGuardrailDecision');
+      }
+      if (secondGuardrailDecision === 'allow' && !manualApplyRecorded) {
+        missingEvidence.push('manualApplyCommand');
+      }
+      if (manualApplyRecorded && !humanReviewSatisfied) {
+        warnings.push('manual apply recorded before human review approval');
+      }
+      if (manualApplyRecorded && secondGuardrailDecision !== 'allow') {
+        warnings.push('manual apply recorded without second guardrail allow');
+      }
 
       let lifecycleState: NoNameSafeOutputDraftState = 'drafted';
       if (humanReviewDecision === 'rejectedForHigherApply' || secondGuardrailDecision === 'reject') {
@@ -624,7 +646,7 @@ export function buildNoNameSafeOutputDrafts(
       } else if (secondGuardrailDecision === 'fallback') {
         lifecycleState = 'fallback';
         reasons.push('second guardrail requested fallback instead of manual apply');
-      } else if (manualApplyRecorded) {
+      } else if (manualApplyRecorded && humanReviewSatisfied && secondGuardrailDecision === 'allow') {
         lifecycleState = 'manuallyApplied';
         reasons.push('explicit manual apply evidence is recorded');
       } else if (secondGuardrailDecision === 'allow') {
@@ -653,6 +675,8 @@ export function buildNoNameSafeOutputDrafts(
           secondGuardrailDecision,
           manualApplyRecorded,
           finalPlotStateWriteAllowed: false,
+          missingEvidence,
+          warnings,
           reasons,
         },
       };
@@ -673,6 +697,28 @@ export function summarizeNoNameSafeOutputDrafts(
       `${draft.lifecycleState}:${draft.safeApplyScope}:${draft.outputKind}`
       + `[final=${draft.evidence.finalPlotStateWriteAllowed ? 'true' : 'false'}]`
     ))
+    .join(', ');
+}
+
+export function summarizeNoNameSafeOutputDraftEvidence(
+  trace: NoNameTrace,
+  reviewDecisions: Record<string, NoNameHumanReviewDecision> = {},
+  emptyLabel = 'none',
+) {
+  const drafts = buildNoNameSafeOutputDrafts(trace, reviewDecisions);
+  if (drafts.length === 0) {
+    return emptyLabel;
+  }
+  return drafts
+    .map((draft) => {
+      const missing = draft.evidence.missingEvidence.length > 0
+        ? draft.evidence.missingEvidence.join('/')
+        : 'none';
+      const warnings = draft.evidence.warnings.length > 0
+        ? draft.evidence.warnings.join('/')
+        : 'none';
+      return `${draft.lifecycleState}:${draft.safeApplyScope}[missing=${missing}][warnings=${warnings}]`;
+    })
     .join(', ');
 }
 


### PR DESCRIPTION
## Summary
- add read-only evidence diagnostics for NoName safe output drafts
- surface missing human review / second guardrail / manual apply evidence in store and debug console reports
- keep safe output drafts non-final and avoid new buttons, commands, or apply scopes

## Tests
- npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts
- git diff --check origin/codex/c7-safe-output-draft-display..HEAD