### PR TITLE
feat(noname): show safe output evidence panel

### DIFF
--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -144,6 +144,7 @@
 - 安全输出草稿层第一轮探针已完成：`NoNameSafeOutputDraft` 只读推导 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`，并固定 `finalPlotStateWriteAllowed=false`
 - 安全输出草稿层只读展示第一轮已完成：store 诊断文本与 debug console 复制摘要可展示 `Safe Output Drafts`，但没有新增写入按钮、后端命令或 apply scope
 - 安全输出草稿层证据诊断已补齐第一轮：只读摘要可标出缺失的 `humanReviewApproval / secondGuardrailDecision / manualApplyCommand` 证据，以及 manual apply 早于复核或缺少二次护栏允许的异常记录
+- 安全输出证据面板第一轮已完成：`AgentTracePanel` 以只读卡片展示草稿状态、`final=false`、缺失证据和异常提醒，不新增写入按钮、后端命令或 apply scope
 - 评估文档见 [下一层安全输出接口试点评估](./05-下一层安全输出接口试点评估.md)
 
 ### 任务 8：评估多角色协作与更强知识检索

--- a/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
+++ b/docs/项目文档/03-规划/05-下一层安全输出接口试点评估.md
@@ -82,10 +82,11 @@
 - 测试已覆盖 review reject、second guardrail reject 与 fallback 不会误进入 manual apply
 - 只读展示第一轮已完成：store 诊断文本与 debug console 复制摘要会展示 `Safe Output Drafts`，用于审查草稿层状态与 `final=false` 安全边界
 - 证据诊断第一轮已完成：store 诊断文本与 debug console 复制摘要会展示 `Safe Output Evidence`，用于核对缺失证据和异常 manual apply 记录
+- 面板证据区第一轮已完成：`AgentTracePanel` 会以只读卡片展示草稿状态、`final=false`、缺失证据与异常提醒
 - 本轮展示不新增按钮、不新增命令、不新增 apply scope，也不写任何 runtime 状态
 
 下一步更合理的动作是：
 
 - 先观察该探针与只读展示在 review / 调试交接中是否足够表达安全输出草稿层
-- 若继续扩展 UI，也应保持只读展示，优先改善证据可读性，不新增 apply scope
+- 若继续扩展 UI，也应保持只读展示，优先改善证据分组与筛选，不新增 apply scope
 - 等 trace、mock、后端语义都能说明该草稿层不会自动写终态后，再评估是否进入正式实现

--- a/docs/项目文档/03-规划/06-近期开发任务卡片.md
+++ b/docs/项目文档/03-规划/06-近期开发任务卡片.md
@@ -220,12 +220,14 @@
 - 第二轮只读展示已完成：`gameStore` 诊断文本与 `NoNameDebugConsole` 复制摘要会输出 `Safe Output Drafts`，便于 review 时核对草稿层状态和 `final=false`
 - 第三轮证据诊断已完成：`NoNameSafeOutputDraft` evidence 增加 `missingEvidence / warnings`，store 诊断文本与 debug console 复制摘要会输出 `Safe Output Evidence`
 - 当前手动 apply 只有同时具备人工复核通过与 second guardrail allow 证据时，才会被只读探针提升为 `manuallyApplied`
+- 第四轮面板展示已完成：`AgentTracePanel` 新增只读“安全输出证据”卡片，展示草稿状态、`final=false`、缺失证据与异常提醒
 - 本轮未新增 UI 写入按钮、未新增后端命令、未扩大 apply scope
 
 已验证：
 
 - `npm run test -- --run src/utils/noNameApplyLifecycle.test.ts`
 - `npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/stores/__tests__/gameStore.test.ts src/components/__tests__/NoNameDebugConsole.test.ts`
+- `npm run test -- --run src/components/__tests__/AgentTracePanel.test.ts`
 
 ## 3. 文档管理动作
 

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -131,6 +131,47 @@
 
       <section class="agent-trace-card">
         <p class="agent-trace-card-title">
+          安全输出证据
+        </p>
+        <p
+          v-if="safeOutputDrafts.length === 0"
+          class="agent-trace-muted"
+        >
+          暂无安全输出草稿证据
+        </p>
+        <ul
+          v-else
+          class="agent-trace-rows"
+        >
+          <li
+            v-for="draft in safeOutputDrafts"
+            :key="draft.draftId"
+            class="agent-trace-row agent-trace-evidence-row"
+            :class="safeOutputEvidenceTone(draft)"
+          >
+            <div class="agent-trace-lifecycle-head">
+              <span class="agent-trace-main-line">
+                {{ draft.safeApplyScope }} · {{ draft.outputKind }}
+              </span>
+              <span class="agent-trace-lifecycle-state">
+                {{ draft.lifecycleState }}
+              </span>
+            </div>
+            <p class="agent-trace-muted">
+              source={{ draft.sourceProposalId }} · final={{ draft.evidence.finalPlotStateWriteAllowed ? 'true' : 'false' }}
+            </p>
+            <p class="agent-trace-muted">
+              缺失证据：{{ formatSafeOutputEvidenceList(draft.evidence.missingEvidence) }}
+            </p>
+            <p class="agent-trace-muted">
+              异常提醒：{{ formatSafeOutputEvidenceList(draft.evidence.warnings) }}
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section class="agent-trace-card">
+        <p class="agent-trace-card-title">
           状态迁移
         </p>
         <p
@@ -516,10 +557,12 @@ import type {
   NoNameTrace,
 } from '../types/game';
 import {
+  buildNoNameSafeOutputDrafts,
   buildNoNameApplyLifecycle,
   formatNoNameApplyExecutionRecord,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  type NoNameSafeOutputDraft,
 } from '../utils/noNameApplyLifecycle';
 
 const props = withDefaults(defineProps<{
@@ -571,9 +614,26 @@ const applyLifecycleCheckpointSummary = computed(() => (
 const pendingPlotAugmentationSummary = computed(() => (
   props.trace ? summarizeNoNamePendingPlotAugmentation(props.trace) : '无'
 ));
+const safeOutputDrafts = computed(() => (
+  props.trace ? buildNoNameSafeOutputDrafts(props.trace, props.reviewDecisions) : []
+));
 
 function applyExecutionDisplay(execution: NoNameApplyExecutionRecord) {
   return formatNoNameApplyExecutionRecord(execution);
+}
+
+function formatSafeOutputEvidenceList(items: string[]) {
+  return items.length > 0 ? items.join(' / ') : '无';
+}
+
+function safeOutputEvidenceTone(draft: NoNameSafeOutputDraft) {
+  if (draft.evidence.warnings.length > 0) {
+    return 'is-warn';
+  }
+  if (draft.evidence.missingEvidence.length === 0) {
+    return 'is-safe';
+  }
+  return 'is-pending';
 }
 
 function formatSourceStats(sourceStats: NoNameContextSourceStat[] | undefined) {
@@ -1200,6 +1260,18 @@ function applyManualReviewedOutput(review: NoNameControlledOutputReviewRecord) {
   border: 1px solid color-mix(in srgb, var(--ink-border-soft) 72%, transparent);
   background: color-mix(in srgb, var(--ink-card-bg) 90%, transparent);
   padding: 10px 12px;
+}
+
+.agent-trace-evidence-row.is-safe {
+  border-color: color-mix(in srgb, #2f6b4b 44%, var(--ink-border-soft));
+}
+
+.agent-trace-evidence-row.is-pending {
+  border-color: color-mix(in srgb, var(--ink-accent-main) 54%, var(--ink-border-soft));
+}
+
+.agent-trace-evidence-row.is-warn {
+  border-color: color-mix(in srgb, #9b4d2e 54%, var(--ink-border-soft));
 }
 
 .agent-trace-review-state {

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -129,6 +129,12 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('Lifecycle Checkpoints: 1.Human Review=pending');
     expect(wrapper.text()).toContain('提案阶段');
     expect(wrapper.text()).toContain('低风险输出');
+    expect(wrapper.text()).toContain('安全输出证据');
+    expect(wrapper.text()).toContain('plotTextHint · sceneAugmentation');
+    expect(wrapper.text()).toContain('drafted');
+    expect(wrapper.text()).toContain('final=false');
+    expect(wrapper.text()).toContain('缺失证据：humanReviewApproval');
+    expect(wrapper.text()).toContain('异常提醒：无');
     expect(wrapper.text()).toContain('协作观察');
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('角色上下文');
@@ -205,6 +211,7 @@ describe('AgentTracePanel', () => {
       },
     });
     expect(wrapper.text()).toContain('人工结论：可进入下一阶段 apply 设计');
+    expect(wrapper.text()).toContain('缺失证据：secondGuardrailDecision');
     expect(wrapper.text()).toContain('重置待复核');
     expect(wrapper.text()).toContain('二次护栏允许');
 
@@ -241,6 +248,7 @@ describe('AgentTracePanel', () => {
       },
     });
     expect(wrapper.text()).toContain('显式人工写入正文提示');
+    expect(wrapper.text()).toContain('缺失证据：manualApplyCommand');
     expect(wrapper.text()).toContain('人工写入');
     expect(wrapper.text()).toContain('等待显式命令');
     expect(wrapper.text()).toContain('人工写入预览');


### PR DESCRIPTION
## Summary
- add a read-only Safe Output Evidence card to AgentTracePanel
- show draft lifecycle state, final=false, missing evidence, and warning signals
- keep the UI display-only with no new buttons, backend commands, or apply scopes

## Tests
- npm run test -- --run src/components/__tests__/AgentTracePanel.test.ts src/utils/noNameApplyLifecycle.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts
- git diff --check origin/codex/c8-safe-output-draft-lifecycle..HEAD