### PR TITLE
feat(noname): summarize multi-agent protocol health

### DIFF
--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -19,6 +19,7 @@
 - 调试台信息结构已完成第一轮优化，trace 面板提供前置快读条，复制摘要提供 `Trace Breakdown`
 - reviewed apply 生命周期展示已完成第一轮收口，前端可核对 `Human Review -> Second Guardrail -> Manual Apply`
 - 下一层安全输出接口已完成第一轮试点评估，并已有只读 `NoNameSafeOutputDraft` 探针，当前结论仍是只适合先探索非最终状态的 pending / draft / diagnostics-like 输出层
+- 多 Agent 协议可观测性已完成第一轮摘要化，前端诊断可读出 roles / tasks / events / statuses / errors
 
 ## 3. 当前主要风险
 
@@ -62,6 +63,10 @@
 ### 3.6 下一层安全输出仍不能扩大权限边界
 
 下一层输出接口目前只完成试点评估与只读探针，不代表可以直接写最终剧情状态。当前 `NoNameSafeOutputDraft` 只从 trace 证据推导 `drafted / reviewed / guardrailAllowed / manuallyApplied / blocked / fallback`，并固定 `finalPlotStateWriteAllowed=false`。草稿证据诊断已能标出缺失的人工复核、二次护栏或 manual apply 证据，以及 manual apply 早于复核链路的异常 trace。后续若实现 `draft / pending hint` 类输出，仍必须保留人工复核、二次护栏、显式写入和 stale snapshot 校验。
+
+### 3.7 多 Agent 仍处于“本地协作可观测”阶段
+
+当前多角色 fan-out、协议事件和角色上下文包已经具备，但距离最终多 Agent 仍差 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环。当前最安全的推进方式是先让 trace 和调试面板能稳定解释协作健康度，再考虑更复杂的调度或权限。
 
 ## 4. 当前最合理的发展策略
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -153,6 +153,12 @@
   - 当前 `Director + WorldCurator + NpcIntent` 路径稳定
   - 记忆与 protocol 层已具备明确接入点
 
+当前状态：
+
+- 多角色本地 fan-out、协议事件和角色上下文包已经具备
+- 协议摘要第一轮已完成：store 诊断、debug console 复制摘要和 `AgentTracePanel` 可只读展示 roles / tasks / events / statuses / errors
+- 距离最终多 Agent 目标还剩 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环
+
 ## 3. 不建议现在就做的事
 
 - 直接让 `NoName` 改写最终剧情状态

--- a/src/components/AgentTracePanel.vue
+++ b/src/components/AgentTracePanel.vue
@@ -263,6 +263,9 @@
         <p class="agent-trace-card-title">
           协议事件
         </p>
+        <p class="agent-trace-muted">
+          协议摘要：{{ protocolSummary }}
+        </p>
         <p
           v-if="protocolEvents.length === 0"
           class="agent-trace-muted"
@@ -562,6 +565,7 @@ import {
   formatNoNameApplyExecutionRecord,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameProtocolSummary,
   type NoNameSafeOutputDraft,
 } from '../utils/noNameApplyLifecycle';
 
@@ -613,6 +617,9 @@ const applyLifecycleCheckpointSummary = computed(() => (
 ));
 const pendingPlotAugmentationSummary = computed(() => (
   props.trace ? summarizeNoNamePendingPlotAugmentation(props.trace) : '无'
+));
+const protocolSummary = computed(() => (
+  props.trace ? summarizeNoNameProtocolSummary(props.trace, '无') : '无'
 ));
 const safeOutputDrafts = computed(() => (
   props.trace ? buildNoNameSafeOutputDrafts(props.trace, props.reviewDecisions) : []

--- a/src/components/NoNameDebugConsole.vue
+++ b/src/components/NoNameDebugConsole.vue
@@ -153,6 +153,7 @@ import {
   summarizeNoNameApplyLifecycle,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameProtocolSummary,
   summarizeNoNameSafeOutputDraftEvidence,
   summarizeNoNameSafeOutputDrafts,
 } from '../utils/noNameApplyLifecycle';
@@ -356,6 +357,7 @@ function buildTraceReport(
     : '无';
   const lifecycle = summarizeNoNameApplyLifecycle(trace, reviewDecisions);
   const lifecycleCheckpoints = summarizeNoNameApplyLifecycleCheckpoints(trace, reviewDecisions);
+  const protocolSummary = summarizeNoNameProtocolSummary(trace);
   const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(trace);
   const safeOutputDrafts = summarizeNoNameSafeOutputDrafts(trace, reviewDecisions);
   const safeOutputDraftEvidence = summarizeNoNameSafeOutputDraftEvidence(trace, reviewDecisions);
@@ -375,6 +377,7 @@ function buildTraceReport(
     `Related Observations: ${relatedObservations.length}`,
     `Role Contexts: ${roleContextSummary}`,
     `Protocol Events: ${protocolEvents.length}`,
+    `Protocol Summary: ${protocolSummary}`,
     `Controlled Reviews: ${controlledReviews.length} (${humanReviewCount} needs human review)`,
     `Human Review Decisions: ${reviewDecisionCounts.approvedForHigherApply} approved / ${reviewDecisionCounts.rejectedForHigherApply} rejected / ${reviewDecisionCounts.pending} pending`,
     `Guardrail: ${guardrail}`,

--- a/src/components/__tests__/AgentTracePanel.test.ts
+++ b/src/components/__tests__/AgentTracePanel.test.ts
@@ -149,6 +149,7 @@ describe('AgentTracePanel', () => {
     expect(wrapper.text()).toContain('裁剪差异');
     expect(wrapper.text()).toContain('worldFacts:4->3');
     expect(wrapper.text()).toContain('协议事件');
+    expect(wrapper.text()).toContain('协议摘要：roles=2(director/world_curator), tasks=1, events=1, statuses=running:1, errors=no');
     expect(wrapper.text()).toContain('agent · delegation · running');
     expect(wrapper.text()).toContain('受控输出复核');
     expect(wrapper.text()).toContain('sceneAugmentation · plotTextHint · needsReview');

--- a/src/components/__tests__/NoNameDebugConsole.test.ts
+++ b/src/components/__tests__/NoNameDebugConsole.test.ts
@@ -142,6 +142,7 @@ describe('NoNameDebugConsole', () => {
     expect(wrapper.text()).toContain('WorldCurator提案：山门法阵');
     expect(wrapper.text()).toContain('当前模式：assisted');
     expect(wrapper.text()).toContain('Protocol Events: 1');
+    expect(wrapper.text()).toContain('Protocol Summary: roles=1(worldCurator), tasks=1, events=1, statuses=queued:1, errors=no');
     expect(wrapper.text()).toContain('Role Contexts: worldCurator:Maintain world facts, scene constraints, and canon anchors.:山门法阵');
     expect(wrapper.text()).toContain('[notes=goal: Hold Gate]');
     expect(wrapper.text()).toContain('[sources=hard_facts:2]');
@@ -234,6 +235,7 @@ describe('NoNameDebugConsole', () => {
 
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace: trace-2'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Protocol Events: 1'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Protocol Summary: roles=1(worldCurator), tasks=1, events=1, statuses=queued:1, errors=no'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Controlled Reviews: 1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Trace Breakdown: proposals=1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Apply Lifecycle:'));

--- a/src/stores/__tests__/gameStore.test.ts
+++ b/src/stores/__tests__/gameStore.test.ts
@@ -441,6 +441,7 @@ describe('gameStore', () => {
     expect(text).toContain('作用域：diagnostics, chapterSummaryHint');
     expect(text).toContain('剧情增强提示：已消费');
     expect(text).toContain('agent:delegation:running');
+    expect(text).toContain('协议摘要：roles=2(director/world_curator), tasks=1, events=1, statuses=running:1, errors=no');
     expect(text).toContain('[来源=hard_facts:2]');
     expect(text).toContain('[token=42]');
     expect(text).toContain('[裁剪=worldFacts:4->3]');

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -5,6 +5,7 @@ import {
   summarizeNoNameApplyLifecycle,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameProtocolSummary,
   summarizeNoNameSafeOutputDraftEvidence,
   summarizeNoNameSafeOutputDrafts,
 } from '../utils/noNameApplyLifecycle';
@@ -481,6 +482,7 @@ export const useGameStore = defineStore('game', {
       const pendingPlotAugmentation = summarizeNoNamePendingPlotAugmentation(latest);
       const safeOutputDrafts = summarizeNoNameSafeOutputDrafts(latest, {}, '无');
       const safeOutputDraftEvidence = summarizeNoNameSafeOutputDraftEvidence(latest, {}, '无');
+      const protocolSummary = summarizeNoNameProtocolSummary(latest, '无');
       return [
         `最近 Trace：${latest.traceId}`,
         `模式：${latest.mode}`,
@@ -489,6 +491,7 @@ export const useGameStore = defineStore('game', {
         `提案：${proposal ? `${proposal.title} / ${proposal.focus} / ${proposalStatus}` : '无'}`,
         `协作观察：${relatedObservations}`,
         `协议事件：${protocolEvents}`,
+        `协议摘要：${protocolSummary}`,
         `受控输出复核：${controlledOutputReviews}`,
         `目标段：${proposal?.targetSegment || '无'}`,
         `预期效果：${proposal?.intendedEffect || '无'}`,

--- a/src/utils/noNameApplyLifecycle.test.ts
+++ b/src/utils/noNameApplyLifecycle.test.ts
@@ -3,12 +3,14 @@ import type { NoNameTrace } from '../types/game';
 import {
   buildNoNameApplyLifecycleCheckpoints,
   buildNoNameApplyLifecycle,
+  buildNoNameProtocolSummary,
   buildNoNameSafeOutputDrafts,
   formatNoNameApplyExecutionRecord,
   summarizeNoNameApplyLifecycleCheckpoints,
   summarizeNoNameApplyExecutions,
   summarizeNoNameApplyLifecycle,
   summarizeNoNamePendingPlotAugmentation,
+  summarizeNoNameProtocolSummary,
   summarizeNoNameSafeOutputDraftEvidence,
   summarizeNoNameSafeOutputDrafts,
 } from './noNameApplyLifecycle';
@@ -507,5 +509,46 @@ describe('buildNoNameApplyLifecycle', () => {
       ...buildReviewedDraftTrace(),
       controlledOutputReviews: [],
     }, {}, '无')).toBe('无');
+  });
+
+  it('summarizes multi-agent protocol fan-out health', () => {
+    const trace = buildReviewedDraftTrace();
+    trace.protocolEvents = [{
+      channel: 'agent',
+      from: 'director',
+      to: 'world_curator',
+      kind: 'taskRequest',
+      taskId: 'turn-1-world_curator-observe',
+      status: 'queued',
+    }, {
+      channel: 'agent',
+      from: 'world_curator',
+      to: 'director',
+      kind: 'result',
+      taskId: 'turn-1-world_curator-observe',
+      status: 'completed',
+    }, {
+      channel: 'agent',
+      from: 'npc_intent',
+      to: 'director',
+      kind: 'error',
+      taskId: 'turn-1-npc_intent-observe',
+      status: 'failed',
+    }];
+
+    expect(buildNoNameProtocolSummary(trace)).toEqual(expect.objectContaining({
+      eventCount: 3,
+      taskCount: 2,
+      roleCount: 3,
+      roles: ['director', 'npc_intent', 'world_curator'],
+      hasErrors: true,
+    }));
+    expect(summarizeNoNameProtocolSummary(trace)).toBe(
+      'roles=3(director/npc_intent/world_curator), tasks=2, events=3, statuses=completed:1/failed:1/queued:1, errors=yes',
+    );
+    expect(summarizeNoNameProtocolSummary({
+      ...trace,
+      protocolEvents: [],
+    }, '无')).toBe('无');
   });
 });

--- a/src/utils/noNameApplyLifecycle.ts
+++ b/src/utils/noNameApplyLifecycle.ts
@@ -3,6 +3,7 @@ import type {
   NoNameApplyScope,
   NoNameControlledOutputKind,
   NoNameHumanReviewDecision,
+  NoNameProtocolEvent,
   NoNameTrace,
 } from '../types/game';
 
@@ -63,6 +64,15 @@ export interface NoNameSafeOutputDraft {
   rationale: string;
   lifecycleState: NoNameSafeOutputDraftState;
   evidence: NoNameSafeOutputDraftEvidence;
+}
+
+export interface NoNameProtocolSummary {
+  eventCount: number;
+  taskCount: number;
+  roleCount: number;
+  roles: string[];
+  statusCounts: Record<string, number>;
+  hasErrors: boolean;
 }
 
 interface NoNameSecondGuardrailStats {
@@ -177,6 +187,51 @@ function countExecutionOutcomes(trace: NoNameTrace, outcome: string) {
 
 function countExecutionMatches(trace: NoNameTrace, predicate: (item: NoNameApplyExecutionRecord) => boolean) {
   return trace.applyExecutionLog?.filter(predicate).length ?? 0;
+}
+
+function protocolRoleIds(event: NoNameProtocolEvent) {
+  return [event.from, event.to]
+    .filter((item): item is string => Boolean(item && item !== 'runtime'));
+}
+
+export function buildNoNameProtocolSummary(trace: NoNameTrace): NoNameProtocolSummary {
+  const events = trace.protocolEvents ?? [];
+  const roles = new Set<string>();
+  const tasks = new Set<string>();
+  const statusCounts: Record<string, number> = {};
+
+  events.forEach((event) => {
+    protocolRoleIds(event).forEach((role) => roles.add(role));
+    if (event.taskId) {
+      tasks.add(event.taskId);
+    }
+    statusCounts[event.status] = (statusCounts[event.status] ?? 0) + 1;
+  });
+
+  return {
+    eventCount: events.length,
+    taskCount: tasks.size,
+    roleCount: roles.size,
+    roles: [...roles].sort(),
+    statusCounts,
+    hasErrors: events.some((event) => event.status === 'failed' || event.kind === 'error'),
+  };
+}
+
+export function summarizeNoNameProtocolSummary(trace: NoNameTrace, emptyLabel = 'none') {
+  const summary = buildNoNameProtocolSummary(trace);
+  if (summary.eventCount === 0) {
+    return emptyLabel;
+  }
+  const statuses = Object.entries(summary.statusCounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([status, count]) => `${status}:${count}`)
+    .join('/');
+  return (
+    `roles=${summary.roleCount}(${summary.roles.join('/') || 'none'}), `
+    + `tasks=${summary.taskCount}, events=${summary.eventCount}, `
+    + `statuses=${statuses || 'none'}, errors=${summary.hasErrors ? 'yes' : 'no'}`
+  );
 }
 
 function countOutcomeEvidence(


### PR DESCRIPTION
## Summary
- add a read-only protocol health summary for NoName multi-agent fan-out
- surface roles, tasks, events, statuses, and error presence in store diagnostics, debug console reports, and AgentTracePanel
- document the remaining four steps toward the final multi-agent target

## Tests
- npm run test -- --run src/utils/noNameApplyLifecycle.test.ts src/components/__tests__/AgentTracePanel.test.ts src/components/__tests__/NoNameDebugConsole.test.ts src/stores/__tests__/gameStore.test.ts
- git diff --check origin/codex/c9-safe-output-evidence-panel..HEAD