### PR TITLE
feat(noname): expose role context note evidence

### DIFF
--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -66,7 +66,7 @@
 
 ### 3.7 多 Agent 仍处于“本地协作可观测”阶段
 
-当前多角色 fan-out、协议事件和角色上下文包已经具备，但距离最终多 Agent 仍差 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环。协议可观测性与调度策略显式化都已完成第一轮：trace / 调试面板能解释协作健康度，graph 层也有 `NoNameRoleDispatchPlan` 表达 `Director` orchestrator 与 fan-out callees。后续仍应先完善调度证据和知识接入，再考虑更复杂的权限。
+当前多角色 fan-out、协议事件和角色上下文包已经具备，但距离最终多 Agent 仍差 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环。协议可观测性、调度策略显式化和记忆/知识检索深接入都已完成第一轮：trace / 调试面板能解释协作健康度，graph 层有 `NoNameRoleDispatchPlan` 表达 `Director` orchestrator 与 fan-out callees，role context packet 也能通过 `noteEvidenceStats` 说明 structured notes 证据构成。后续仍应先完善调度证据和知识接入，再考虑更复杂的权限。
 
 ## 4. 当前最合理的发展策略
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -158,6 +158,7 @@
 - 多角色本地 fan-out、协议事件和角色上下文包已经具备
 - 协议摘要第一轮已完成：store 诊断、debug console 复制摘要和 `AgentTracePanel` 可只读展示 roles / tasks / events / statuses / errors
 - 调度策略显式化第一轮已完成：后端 graph 层新增 `NoNameRoleDispatchPlan`，明确 `Director` orchestrator 与 fan-out callees，runtime 不再直接遍历硬编码顺序
+- 记忆/知识检索深接入第一轮已完成：role context packet 新增 `noteEvidenceStats`，让多角色上下文能显式说明 structured notes 证据构成
 - 距离最终多 Agent 目标还剩 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环
 
 ## 3. 不建议现在就做的事

--- a/src-tauri/src/noname_context_builder.rs
+++ b/src-tauri/src/noname_context_builder.rs
@@ -2,7 +2,7 @@ use crate::entity_store::{EntityQuery, EntityStore};
 use crate::entity_types::EntityType;
 use crate::noname_context_types::{
     NoNameContextBuildInput, NoNameContextPacket, NoNameContextSourceStat, NoNameRoleContextPacket,
-    NoNameRoleContextSliceStat,
+    NoNameRoleContextSliceStat, NoNameRoleNoteEvidenceStat,
 };
 use crate::noname_memory_manager::NoNameMemoryManager;
 use crate::noname_memory_retrieval::NoNameMemoryQuery;
@@ -255,6 +255,7 @@ pub fn build_role_context_packet(
     let ranked_notes = role_ranked_active_notes(memory_manager.active_notes(), role);
     let mut role_packet = specialize_context_packet(&packet);
     role_packet.note_type_hits = build_role_note_hits(&ranked_notes, input.per_section_limit);
+    role_packet.note_evidence_stats = build_role_note_evidence_stats(&ranked_notes);
     role_packet
 }
 
@@ -320,6 +321,7 @@ fn director_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
             &packet.hard_facts,
         ]),
         note_type_hits: Vec::new(),
+        note_evidence_stats: Vec::new(),
         world_facts: world_facts.clone(),
         character_relationships: character_relationships.clone(),
         narrative_priorities: narrative_priorities.clone(),
@@ -378,6 +380,7 @@ fn world_curator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacke
             &packet.recent_context,
         ]),
         note_type_hits: Vec::new(),
+        note_evidence_stats: Vec::new(),
         world_facts: world_facts.clone(),
         character_relationships: character_relationships.clone(),
         narrative_priorities: narrative_priorities.clone(),
@@ -441,6 +444,7 @@ fn npc_intent_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
             &packet.recent_context,
         ]),
         note_type_hits: Vec::new(),
+        note_evidence_stats: Vec::new(),
         world_facts: world_facts.clone(),
         character_relationships: character_relationships.clone(),
         narrative_priorities: narrative_priorities.clone(),
@@ -500,6 +504,7 @@ fn combat_narrator_context(packet: &NoNameContextPacket) -> NoNameRoleContextPac
             &packet.narrative_notes,
         ]),
         note_type_hits: Vec::new(),
+        note_evidence_stats: Vec::new(),
         world_facts: world_facts.clone(),
         character_relationships: character_relationships.clone(),
         narrative_priorities: narrative_priorities.clone(),
@@ -550,6 +555,7 @@ fn system_context(packet: &NoNameContextPacket) -> NoNameRoleContextPacket {
         role_goal: "Provide diagnostics without narrative authority.".to_string(),
         scene_focus: first_of(&[&packet.recent_context, &packet.working_memory]),
         note_type_hits: Vec::new(),
+        note_evidence_stats: Vec::new(),
         world_facts: Vec::new(),
         character_relationships: Vec::new(),
         narrative_priorities: Vec::new(),
@@ -576,6 +582,30 @@ fn build_slice_stat(
         source_count,
         visible_count,
     }
+}
+
+fn build_role_note_evidence_stats(
+    ranked_notes: &[NoNameNarrativeMemoryItem],
+) -> Vec<NoNameRoleNoteEvidenceStat> {
+    let mut stats: Vec<NoNameRoleNoteEvidenceStat> = Vec::new();
+    for note in ranked_notes {
+        let note_type = note_type_label(note.note_type).to_string();
+        if let Some(existing) = stats.iter_mut().find(|item| item.note_type == note_type) {
+            existing.count += 1;
+        } else {
+            stats.push(NoNameRoleNoteEvidenceStat {
+                note_type,
+                count: 1,
+            });
+        }
+    }
+    stats.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.note_type.cmp(&right.note_type))
+    });
+    stats
 }
 
 fn role_source_stats(
@@ -1049,6 +1079,18 @@ mod tests {
         assert_eq!(director.note_type_hits[0], "conflict: Gate Assault");
         assert_eq!(npc.note_type_hits[0], "characterArc: Elder Qinghe Doubt");
         assert_eq!(world.note_type_hits[0], "goal: Hold Gate");
+        assert!(director
+            .note_evidence_stats
+            .iter()
+            .any(|item| item.note_type == "conflict" && item.count == 1));
+        assert!(npc
+            .note_evidence_stats
+            .iter()
+            .any(|item| item.note_type == "characterArc" && item.count == 1));
+        assert!(world
+            .note_evidence_stats
+            .iter()
+            .any(|item| item.note_type == "goal" && item.count == 1));
     }
 
     #[test]

--- a/src-tauri/src/noname_context_types.rs
+++ b/src-tauri/src/noname_context_types.rs
@@ -18,6 +18,13 @@ pub struct NoNameRoleContextSliceStat {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct NoNameRoleNoteEvidenceStat {
+    pub note_type: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NoNameContextPacket {
     pub role: NoNameRole,
     pub hard_facts: Vec<String>,
@@ -40,6 +47,8 @@ pub struct NoNameRoleContextPacket {
     pub scene_focus: String,
     #[serde(default)]
     pub note_type_hits: Vec<String>,
+    #[serde(default)]
+    pub note_evidence_stats: Vec<NoNameRoleNoteEvidenceStat>,
     pub world_facts: Vec<String>,
     pub character_relationships: Vec<String>,
     pub narrative_priorities: Vec<String>,

--- a/src-tauri/src/noname_output_interface.rs
+++ b/src-tauri/src/noname_output_interface.rs
@@ -454,6 +454,7 @@ mod tests {
             role_goal: "Track conflict rhythm".to_string(),
             scene_focus: "山门冲突".to_string(),
             note_type_hits: vec![],
+            note_evidence_stats: vec![],
             world_facts: vec![],
             character_relationships: vec![],
             narrative_priorities: vec![],


### PR DESCRIPTION
## Summary
- add noteEvidenceStats to NoName role context packets
- derive role-specific structured note evidence counts from active notes
- document the first pass of memory/knowledge deep integration for multi-agent work

## Tests
- cargo fmt --manifest-path E:/Nobody/_c12_role_context_note_evidence/src-tauri/Cargo.toml
- cargo test --manifest-path E:/Nobody/_c12_role_context_note_evidence/src-tauri/Cargo.toml noname_context -- --nocapture
- git diff --check origin/codex/c11-explicit-agent-dispatch-plan..HEAD