### PR TITLE
feat(noname): define backend safe output draft contract

### DIFF
--- a/docs/项目文档/03-规划/01-现状评估.md
+++ b/docs/项目文档/03-规划/01-现状评估.md
@@ -66,7 +66,7 @@
 
 ### 3.7 多 Agent 仍处于“本地协作可观测”阶段
 
-当前多角色 fan-out、协议事件和角色上下文包已经具备，但距离最终多 Agent 仍差 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环。协议可观测性、调度策略显式化和记忆/知识检索深接入都已完成第一轮：trace / 调试面板能解释协作健康度，graph 层有 `NoNameRoleDispatchPlan` 表达 `Director` orchestrator 与 fan-out callees，role context packet 也能通过 `noteEvidenceStats` 说明 structured notes 证据构成。后续仍应先完善调度证据和知识接入，再考虑更复杂的权限。
+当前多角色 fan-out、协议事件和角色上下文包已经具备。最终多 Agent 的 4 个收口台阶已经完成第一轮：trace / 调试面板能解释协作健康度，graph 层有 `NoNameRoleDispatchPlan` 表达 `Director` orchestrator 与 fan-out callees，role context packet 能通过 `noteEvidenceStats` 说明 structured notes 证据构成，后端也有 `NoNameSafeOutputDraftContract` 固定 `finalPlotStateWriteAllowed=false`。后续重点应转向 PR 队列合并后的端到端验收与语义打磨，而不是继续扩大权限。
 
 ## 4. 当前最合理的发展策略
 

--- a/docs/项目文档/03-规划/02-后续路线图.md
+++ b/docs/项目文档/03-规划/02-后续路线图.md
@@ -159,7 +159,8 @@
 - 协议摘要第一轮已完成：store 诊断、debug console 复制摘要和 `AgentTracePanel` 可只读展示 roles / tasks / events / statuses / errors
 - 调度策略显式化第一轮已完成：后端 graph 层新增 `NoNameRoleDispatchPlan`，明确 `Director` orchestrator 与 fan-out callees，runtime 不再直接遍历硬编码顺序
 - 记忆/知识检索深接入第一轮已完成：role context packet 新增 `noteEvidenceStats`，让多角色上下文能显式说明 structured notes 证据构成
-- 距离最终多 Agent 目标还剩 4 个收口台阶：协议可观测性稳定化、调度策略显式化、记忆/知识检索深接入、更高层受控输出闭环
+- 更高层受控输出闭环第一轮已完成：后端 `NoNameSafeOutputDraftContract` 固定 `finalPlotStateWriteAllowed=false`，把安全草稿、review 结果和 safe apply scope 绑定成显式合同
+- 最终多 Agent 目标的 4 个收口台阶均已完成第一轮；后续需要在 PR 队列合并后做端到端验收与必要的语义打磨
 
 ## 3. 不建议现在就做的事
 

--- a/src-tauri/src/noname_output_interface.rs
+++ b/src-tauri/src/noname_output_interface.rs
@@ -122,6 +122,28 @@ pub struct NoNameControlledOutputReview {
     pub requires_human_review: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NoNameSafeOutputDraftLifecycleState {
+    Drafted,
+    Reviewed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoNameSafeOutputDraftContract {
+    pub draft_id: String,
+    pub request_id: String,
+    pub source_proposal_id: Option<String>,
+    pub output_kind: NoNameControlledOutputKind,
+    pub safe_apply_scope: NoNameApplyScope,
+    pub lifecycle_state: NoNameSafeOutputDraftLifecycleState,
+    pub requires_human_review: bool,
+    pub final_plot_state_write_allowed: bool,
+    pub evidence: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct NoNameControlledOutputInterface {
     policy: NoNameControlledOutputPolicy,
@@ -229,6 +251,39 @@ impl NoNameControlledOutputInterface {
                 kind_key.to_string(),
             ],
         }
+    }
+
+    pub fn safe_output_draft_contract(
+        &self,
+        request: &NoNameControlledOutputRequest,
+        review: &NoNameControlledOutputReview,
+    ) -> Option<NoNameSafeOutputDraftContract> {
+        let safe_apply_scope = review.safe_apply_scope?;
+        let lifecycle_state = match review.decision {
+            NoNameControlledOutputDecision::Allow => NoNameSafeOutputDraftLifecycleState::Reviewed,
+            NoNameControlledOutputDecision::NeedsReview => {
+                NoNameSafeOutputDraftLifecycleState::Drafted
+            }
+            NoNameControlledOutputDecision::Reject => NoNameSafeOutputDraftLifecycleState::Blocked,
+        };
+        Some(NoNameSafeOutputDraftContract {
+            draft_id: format!("safe-output-draft-{}", request.request_id),
+            request_id: request.request_id.clone(),
+            source_proposal_id: request
+                .proposal_ref
+                .as_ref()
+                .map(|proposal| proposal.proposal_id.clone()),
+            output_kind: review.normalized_kind.unwrap_or(request.kind),
+            safe_apply_scope,
+            lifecycle_state,
+            requires_human_review: review.requires_human_review,
+            final_plot_state_write_allowed: false,
+            evidence: vec![
+                format!("controlled output decision={:?}", review.decision),
+                format!("safe apply scope={}", safe_apply_scope.as_str()),
+                "backend draft contract never allows final plot state writes".to_string(),
+            ],
+        })
     }
 
     fn reject(
@@ -445,6 +500,57 @@ mod tests {
             Some(NoNameApplyScope::PlotAugmentationHint)
         );
         assert!(review.requires_human_review);
+    }
+
+    #[test]
+    fn safe_output_draft_contract_keeps_backend_boundary_non_final() {
+        let interface = NoNameControlledOutputInterface::default();
+        let request = interface.draft_stub(
+            NoNameControlledOutputKind::NonFinalPlotAugmentation,
+            NoNameRole::Director,
+            "Staged scene beat",
+            "Stage a reversible clue for the next turn without rewriting final plot state.",
+        );
+        let review = interface.review(&request);
+
+        let contract = interface
+            .safe_output_draft_contract(&request, &review)
+            .expect("safe apply scope should produce a draft contract");
+
+        assert_eq!(
+            contract.lifecycle_state,
+            NoNameSafeOutputDraftLifecycleState::Drafted
+        );
+        assert_eq!(
+            contract.safe_apply_scope,
+            NoNameApplyScope::PlotAugmentationHint
+        );
+        assert!(contract.requires_human_review);
+        assert!(!contract.final_plot_state_write_allowed);
+        assert!(contract
+            .evidence
+            .iter()
+            .any(|item| item.contains("never allows final plot state writes")));
+    }
+
+    #[test]
+    fn rejected_controlled_output_has_no_safe_draft_contract() {
+        let interface = NoNameControlledOutputInterface::default();
+        let mut request = interface.draft_stub(
+            NoNameControlledOutputKind::NarrativeNote,
+            NoNameRole::WorldCurator,
+            "Canon change",
+            "The sect law is permanently rewritten.",
+        );
+        request
+            .touched_forbidden_scopes
+            .push(NoNameForbiddenOutputScope::CanonWorldFact);
+        let review = interface.review(&request);
+
+        assert_eq!(
+            interface.safe_output_draft_contract(&request, &review),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a backend NoNameSafeOutputDraftContract for controlled output drafts
- bind review results, safe apply scope, and finalPlotStateWriteAllowed=false in one explicit contract
- document that the first pass of the final multi-agent convergence steps is complete pending end-to-end queue validation

## Tests
- cargo fmt --manifest-path E:/Nobody/_c13_backend_safe_output_draft_contract/src-tauri/Cargo.toml
- cargo test --manifest-path E:/Nobody/_c13_backend_safe_output_draft_contract/src-tauri/Cargo.toml noname_output_interface -- --nocapture
- git diff --check origin/codex/c12-role-context-note-evidence..HEAD